### PR TITLE
feat: Phase 3 Content Services — narrative-architect + speaker-notes-writer

### DIFF
--- a/.bsa/models/jack-tar-deckhand.json
+++ b/.bsa/models/jack-tar-deckhand.json
@@ -490,6 +490,16 @@
           "serviceId": "presentation-engineering",
           "relationship": "consumes",
           "description": "Receives the finished .pptx and review feedback"
+        },
+        {
+          "serviceId": "content-outline-generation",
+          "relationship": "reviews",
+          "description": "Selects narrative arc from options proposed by narrative-architect"
+        },
+        {
+          "serviceId": "content-speaker-notes",
+          "relationship": "consults",
+          "description": "Provides voice and style preferences to speaker-notes-writer"
         }
       ]
     },
@@ -866,6 +876,22 @@
       "type": "consultation",
       "description": "Conductor presents design options to Speaker during Design phase for direction selection",
       "dataFlows": ["Design options", "BrandProfile summary", "Compliance mode"]
+    },
+    {
+      "id": "int-speaker-to-narrative-architect",
+      "sourceId": "actor-speaker",
+      "targetId": "content-outline-generation",
+      "type": "review/approval",
+      "description": "Speaker selects narrative arc from 2-3 options proposed by narrative-architect",
+      "dataFlows": ["Arc options presented", "Arc selection"]
+    },
+    {
+      "id": "int-speaker-to-speaker-notes-writer",
+      "sourceId": "actor-speaker",
+      "targetId": "content-speaker-notes",
+      "type": "consultation",
+      "description": "Speaker provides voice and style preferences: note format, interaction style, experience level",
+      "dataFlows": ["Voice preferences", "Interaction style", "Experience level"]
     }
   ],
 

--- a/.claude/skills/narrative-architect/SKILL.md
+++ b/.claude/skills/narrative-architect/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: narrative-architect
+description: Transform a TalkBrief into a structured SlideOutline through collaborative arc selection and autonomous outline generation.
+argument-hint: [--deck-dir PATH]
+allowed-tools: Bash(python *), Read, Glob, Write
+---
+
+# /narrative-architect
+
+Transform a TalkBrief into a structured SlideOutline. Works in two stages: collaborative arc selection with the Speaker, then autonomous outline generation.
+
+## Prerequisites
+
+- `./tmp/deck/talk-brief.json` must exist
+- `./tmp/deck/style-guide.json` must exist (produced by slide-stylist)
+
+## Usage
+
+Invoked by the Deck Conductor after slide-stylist. Can also be invoked directly:
+
+```
+/narrative-architect
+/narrative-architect --deck-dir ./tmp/deck
+```
+
+## What It Does
+
+### Stage 1: Arc Proposal (Collaborative)
+
+Read `./tmp/deck/talk-brief.json` for topic, audience, duration, tone, key takeaways, and data sources.
+
+Based on these signals, select 2-3 narrative arc options that genuinely fit this specific talk. Do NOT present all 16 arcs from the catalogue -- curate down to the best matches.
+
+For each proposed arc, present:
+
+> "For a **{duration}-minute {tone}** talk on **{topic}**, here are the narrative structures I'd recommend:
+>
+> 1. **{Arc Name}** -- {one-line emotional description}
+>    - Best for: {when this works}
+>    - Your talk would flow: {beat1} -> {beat2} -> {beat3} -> ... -> {final beat}
+>    - Slide count: ~{count} slides at {pacing} pacing
+>
+> 2. **{Arc Name}** -- {one-line emotional description}
+>    - Best for: {when this works}
+>    - Your talk would flow: {beat1} -> {beat2} -> ...
+>    - Slide count: ~{count} slides
+>
+> 3. **{Arc Name}** -- {one-line emotional description}
+>    - Best for: {when this works}
+>    - Your talk would flow: {beat1} -> {beat2} -> ...
+>    - Slide count: ~{count} slides
+>
+> **My recommendation:** {Arc Name} because {one-sentence rationale connecting to this specific talk}.
+>
+> Which structure speaks to you? (Or describe what you're looking for)"
+
+Wait for the Speaker to select or describe their preference. If they describe something custom, map it to the closest arc or propose a hybrid.
+
+### Arc Catalogue Reference
+
+These are the established structures to draw from (Research #08):
+
+| Arc | Best For | Pacing |
+|-----|----------|--------|
+| Situation-Complication-Resolution | Executive briefings, problem-solving | Standard |
+| Monroe's Motivated Sequence | Persuasion, calls to action | Standard |
+| Hero's Journey | Transformation stories, keynotes | Visual-heavy |
+| Problem-Solution-Impact | Product talks, case studies | Standard |
+| Problem-Demo-Impact | Technical demos, tool showcases | Content-heavy |
+| What-So What-Now What | Data presentations, research findings | Content-heavy |
+| Hook-Thesis-Body-Callback-CTA | Persuasion talks, thought leadership | Standard |
+| Story-Point-Application | Rule of Three, teaching talks | Standard |
+| Pecha Kucha | 6:40 fixed format, 20 slides x 20 seconds | Rapid-fire |
+| Ignite | 5 min fixed, 20 slides x 15 seconds | Rapid-fire |
+| Lightning Talk | 5-10 min, minimal slides | Standard |
+| Lessig Method | Rapid visual reinforcement, advocacy | Rapid-fire |
+| Takahashi Method | Japanese big-text style, storytelling | Rapid-fire |
+| 10/20/30 Rule | Startup pitches, 10 slides | Content-heavy |
+| Duarte Sparkline | Long keynotes, What Is vs What Could Be | Visual-heavy |
+| Modular Deck | Flexible/reusable, workshop-style | Standard |
+
+### Stage 2: Outline Execution (Autonomous)
+
+Once the Speaker selects an arc, produce the full SlideOutline. This is expert craft -- do NOT seek per-slide approval.
+
+**What you decide autonomously:**
+- Exact slide count (calibrated to duration and pacing style)
+- Slide type assignment per slide (from the 12 types)
+- Headlines -- punchy conference headlines, not academic paper titles
+- Body points (max 5 per slide)
+- Narrative beat labels
+- Visual direction prose per slide (specific enough for prompt engineering, incorporating StyleGuide image_style_tokens)
+- Layout template references from StyleGuide
+- Transition notes between slides
+- Section divider placement (before every major beat transition)
+- Attention reset beats (every ~10 minutes of duration)
+- Data source mapping from TalkBrief to data_chart slides
+
+**Pacing guidelines:**
+- Content-heavy (data, technical deep-dive): 0.5-1.0 slides/min
+- Standard (most conference talks): 1.0-1.5 slides/min
+- Visual-heavy (keynotes, storytelling): 1.5-2.5 slides/min
+- Rapid-fire (Pecha Kucha, Ignite, Lessig): 3.0-4.0 slides/min
+
+**Structural overhead added to base count:**
+- +1 title slide (always)
+- +1 closing slide (always)
+- +1 section divider per major beat transition
+- +1 attention reset per 10 minutes of duration
+
+If `preferences.slide_count_hint` is provided, use it as a soft target (within 20%) but override if the arc demands it.
+
+**Read the StyleGuide** at `./tmp/deck/style-guide.json` for:
+- Layout template names (ensure every slide's `layout_template` exists in `layout.templates`)
+- Image style tokens (weave `mood`, `color_direction`, and `style_modifiers` into `visual_direction` prose)
+
+### Step 3: Validate and Write
+
+Validate the outline before writing:
+
+```bash
+source .venv/bin/activate && python3 -c "
+import json
+from src.content_validation import validate_outline_schema, check_outline_layout_references
+outline = json.load(open('./tmp/deck/outline.json'))
+style_guide = json.load(open('./tmp/deck/style-guide.json'))
+schema_errors = validate_outline_schema(outline)
+ref_issues = check_outline_layout_references(outline, style_guide)
+for e in schema_errors: print(f'SCHEMA: {e}')
+for e in ref_issues: print(f'REF: {e}')
+if not schema_errors and not ref_issues:
+    print('SlideOutline validates successfully')
+"
+```
+
+Write the validated SlideOutline to `./tmp/deck/outline.json`.
+
+## Output
+
+`./tmp/deck/outline.json` (SlideOutline contract)
+
+## Design Rules
+
+- Headlines should be punchy conference headlines, not generic titles ("The 3-Second Rule for Slide Readability" not "Text Best Practices")
+- Max 5 body points per slide
+- Visual direction must be specific enough to generate images but not prescriptive about implementation
+- Section dividers before every major narrative beat transition
+- Title slide always first, closing slide always last
+- Do NOT ask the Speaker about individual slide choices -- the arc approval is the collaboration point

--- a/.claude/skills/speaker-notes-writer/SKILL.md
+++ b/.claude/skills/speaker-notes-writer/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: speaker-notes-writer
+description: Generate timed, transition-cued speaker notes calibrated to talk duration and audience profile, with lightweight preference gathering.
+argument-hint: [--deck-dir PATH]
+allowed-tools: Bash(python *), Read, Glob, Write
+---
+
+# /speaker-notes-writer
+
+Generate per-slide speaker notes with timing markers, cumulative time marks, and interaction cues.
+
+## Prerequisites
+
+- `./tmp/deck/talk-brief.json` must exist
+- `./tmp/deck/outline.json` must exist (produced by narrative-architect)
+
+## Usage
+
+Invoked by the Deck Conductor after narrative-architect. Can also be invoked directly:
+
+```
+/speaker-notes-writer
+/speaker-notes-writer --deck-dir ./tmp/deck
+```
+
+## What It Does
+
+### Step 1: Gather Preferences (Lightweight Collaboration)
+
+Before generating notes, ask the Speaker three quick questions (if the answers aren't obvious from the TalkBrief):
+
+> "Before I write your speaker notes, three quick questions:
+>
+> 1. **Note format:** Do you prefer bullet points/keywords or fuller sentences?
+> 2. **Audience interaction:** Any preference? (show of hands, rhetorical questions, polls, none)
+> 3. **Your experience level:** First-time presenter, comfortable, or seasoned?
+>
+> (Or just say 'defaults' and I'll use: bullet points, match-to-tone interaction, moderate detail)"
+
+**Defaults if Speaker says 'defaults' or skips:**
+- Format: Bullet points with key phrases
+- Interaction: Match to tone (conversational = show of hands, professional = rhetorical, technical = none)
+- Detail: Moderate (comfortable presenter)
+
+### Step 2: Generate Notes (Autonomous)
+
+Read `./tmp/deck/talk-brief.json` and `./tmp/deck/outline.json`.
+
+For each slide in the outline, produce a note with:
+
+**text** -- The speaking content for this slide:
+- Bullet format: key phrases and memory joggers
+- Sentence format: near-script with natural spoken language
+- Detail scaled to experience level (first-time = more explicit cues, seasoned = less)
+
+**estimated_seconds** -- Time allocation for this slide:
+- Calculate from `target_pace_wpm` (default 130) and word count
+- Heavier slides (data, key arguments) get more time
+- Structural slides (title, dividers, closing) get less
+- Total must sum to approximately `duration_minutes` from TalkBrief
+
+**timing_marker** -- Cumulative time mark (e.g., "~5:30", "~12:00"):
+- Helps the speaker track progress during delivery
+- Calculate from cumulative estimated_seconds
+
+**cues** -- Interaction cues appropriate to the slide:
+- `transition`: How to bridge from the previous slide ("Building on that insight...")
+- `pause`: Deliberate silence for impact ("[pause 2 seconds for the number to land]")
+- `audience_interaction`: Engage the audience, matching the Speaker's preference
+- `emphasis`: Key point to stress ("This is the number your CFO cares about")
+- `demo`: Live demonstration beat ("Switch to terminal, run the command")
+- `build_animation`: Timed reveal ("Click to reveal the second column")
+
+**What you decide autonomously:**
+- Word count per slide (calibrated to pace and duration)
+- Timing allocation per slide
+- Cumulative timing markers
+- Transition cue placement and content
+- Pause placement (after key data, before major shifts)
+- Audience interaction beat placement (every ~10 minutes)
+- Emphasis markers on key phrases
+- Demo cues (when outline includes demo beats)
+- Build animation triggers (when outline has progressive disclosure)
+
+### Step 3: Validate and Write
+
+Validate the notes before writing:
+
+```bash
+source .venv/bin/activate && python3 -c "
+import json
+from src.content_validation import validate_notes_schema, check_timing_total, check_notes_slide_references
+notes = json.load(open('./tmp/deck/speaker-notes.json'))
+outline = json.load(open('./tmp/deck/outline.json'))
+brief = json.load(open('./tmp/deck/talk-brief.json'))
+schema_errors = validate_notes_schema(notes)
+timing_issues = check_timing_total(notes, brief['duration_minutes'])
+ref_issues = check_notes_slide_references(notes, outline)
+for e in schema_errors: print(f'SCHEMA: {e}')
+for e in timing_issues: print(f'TIMING: {e}')
+for e in ref_issues: print(f'REF: {e}')
+if not schema_errors and not timing_issues and not ref_issues:
+    print('SpeakerNotes validates successfully')
+"
+```
+
+Write the validated SpeakerNotes to `./tmp/deck/speaker-notes.json`.
+
+## Output
+
+`./tmp/deck/speaker-notes.json` (SpeakerNotes contract)
+
+## Design Rules
+
+- Notes must be specific and actionable -- "Explain that Raft uses heartbeats for failure detection" not "Talk about this slide"
+- Total timing must match talk duration within 20%
+- Every content slide should have a transition cue (how to get there from the previous slide)
+- Audience interaction beats every ~10 minutes of duration
+- Do NOT ask the Speaker to review individual slide notes -- deliver the complete set
+- The target_pace_wpm default is 130 (natural conversational pace)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,8 @@ Claude Code skills and agents for conference-quality PowerPoint presentations. T
   - Phase 4C: Routing & Advisory — COMPLETE (35 tests, 260 total)
   - Phase 5: Assembly & QA — COMPLETE (67 tests, 327 total)
   - Phase 2: Design Services — COMPLETE (27 tests, 354 total)
-  - Phase 3: Content Services — planned, NEXT
-  - Phase 6: Orchestration (deck-conductor) — planned
+  - Phase 3: Content Services — COMPLETE (12 tests, 366 total)
+  - Phase 6: Orchestration (deck-conductor) — planned, NEXT
 
 - **Existing ollama-* skills are upstream — do NOT fork or modify them.** The imagegen-bridge handles all DeckContext integration.
 
@@ -52,6 +52,7 @@ Claude Code skills and agents for conference-quality PowerPoint presentations. T
 | Brand profile utils | `src/brand_profile.py` | 12 | Done |
 | Style validation | `src/style_validation.py` | 10 | Done |
 | Schema tests (P2) | `tests/test_schemas.py` | 5 | Done |
+| Content validation | `src/content_validation.py` | 12 | Done |
 
 ### Architecture Summary
 

--- a/docs/architecture/content-services.md
+++ b/docs/architecture/content-services.md
@@ -63,6 +63,10 @@ The narrative-architect selects from established arc patterns based on talk dura
 - **compare-contrast** -- evaluation and decision-making talks
 - **deep-dive** -- technical single-topic explorations
 
+### Collaborative Workflow
+
+The narrative-architect operates in two stages with a Speaker approval gate between them. Stage 1 proposes 2-3 narrative arc options curated from research. Stage 2 produces the full SlideOutline autonomously once the arc is agreed. Individual slide decisions are professional craft -- the architect does not seek per-slide approval.
+
 ### Constraints
 
 - Maximum 5 body points per slide (projection readability)
@@ -96,6 +100,10 @@ Generate per-slide speaker notes with timing markers, cumulative time marks, and
 | `demo` | Live demonstration beat | "Switch to terminal, run the command" |
 | `build_animation` | Timed reveal | "Click to reveal the second column" |
 
+### Collaborative Workflow
+
+The speaker-notes-writer gathers three lightweight preferences before autonomous execution: note format (bullets vs sentences), audience interaction style, and speaker experience level. It then produces the full SpeakerNotes without per-slide review.
+
 ---
 
 ## Data Contracts
@@ -123,6 +131,8 @@ Generate per-slide speaker notes with timing markers, cumulative time marks, and
 | Source | Type | Data |
 |---|---|---|
 | Deck Conductor | invocation | TalkBrief, StyleGuide |
+| Speaker | review/approval | Narrative arc selection, outline approval |
+| Speaker | consultation | Voice preferences, interaction style, experience level |
 
 ### Outbound
 
@@ -138,11 +148,25 @@ Deck Conductor
   |
   | TalkBrief + StyleGuide
   v
-narrative-architect
+narrative-architect (Stage 1: Arc Proposal)
+  |
+  | 2-3 arc options with descriptions
+  v
+Speaker selects arc
+  |
+  v
+narrative-architect (Stage 2: Outline Execution)
   |
   | SlideOutline (outline.json)
   v
-speaker-notes-writer
+speaker-notes-writer (Voice Preferences)
+  |
+  | 3 quick questions
+  v
+Speaker answers preferences
+  |
+  v
+speaker-notes-writer (Notes Execution)
   |
   | SpeakerNotes (speaker-notes.json)
   v
@@ -159,10 +183,11 @@ The narrative-architect runs first because the speaker-notes-writer needs the Sl
 |---|---|---|---|---|
 | Outline Generation | `narrative-architect` | `.claude/skills/narrative-architect/SKILL.md` | -- | Planned (Phase 3) |
 | Speaker Notes | `speaker-notes-writer` | `.claude/skills/speaker-notes-writer/SKILL.md` | -- | Planned (Phase 3) |
+| Content Validation | -- | `src/content_validation.py` | -- | Planned (Phase 3) |
 | SlideOutline schema | -- | `src/schemas/slide_outline.schema.json` | 27 (shared) | Done (Phase 1) |
 | SpeakerNotes schema | -- | `src/schemas/speaker_notes.schema.json` | 27 (shared) | Done (Phase 1) |
 
-The JSON schemas for SlideOutline and SpeakerNotes were defined in Phase 1 as part of the 8 contract schemas. The skills themselves (SKILL.md files) are planned for Phase 3.
+The JSON schemas for SlideOutline and SpeakerNotes were defined in Phase 1 as part of the 8 contract schemas. The skills themselves are SKILL.md files planned for Phase 3. The `content_validation.py` module handles timing arithmetic and reference integrity only.
 
 ---
 

--- a/docs/superpowers/plans/2026-03-29-phase-3-content-services-v2.md
+++ b/docs/superpowers/plans/2026-03-29-phase-3-content-services-v2.md
@@ -1,0 +1,838 @@
+# Phase 3: Content Services — narrative-architect + speaker-notes-writer
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build two Claude Code skills that transform a TalkBrief into structured presentation content — a narrative-architect (collaborative arc selection then autonomous outline generation) and a speaker-notes-writer (lightweight preference gathering then autonomous note generation), plus a thin Python validation module for timing arithmetic and reference integrity.
+
+**Architecture:** Two SKILL.md files define how Claude collaborates with the Speaker on narrative arc selection and note preferences, then produces SlideOutline and SpeakerNotes autonomously. A thin Python module `src/content_validation.py` handles only machine-checkable validation: timing arithmetic (do note durations sum to talk duration?) and reference integrity (do layout templates exist in StyleGuide? do note slide numbers exist in outline?). All narrative reasoning — arc selection, slide sequencing, headline quality, visual direction prose — is Claude's contextual reasoning, not codified rules.
+
+**Tech Stack:** Claude Code skills (SKILL.md), Python 3.8+ (content_validation.py, jsonschema, pytest), src/deckcontext.py (Phase 1)
+
+**Dependencies:**
+- Phase 1 (complete): `src/deckcontext.py`, `src/schemas/slide_outline.schema.json`, `src/schemas/speaker_notes.schema.json`
+- Phase 2 (complete): StyleGuide contract (consumed by narrative-architect for layout template references)
+
+**Supersedes:** `docs/superpowers/plans/2026-03-29-phase-3-content-services.md` (written for old non-collaborative architecture with Python arc selection logic)
+
+---
+
+## File Structure
+
+```
+research/
+  synthesis-narrative-architect.md        # Research synthesis
+  synthesis-speaker-notes-writer.md       # Research synthesis
+src/
+  content_validation.py                   # Timing arithmetic + reference integrity only
+.claude/
+  skills/
+    narrative-architect/
+      SKILL.md                            # Two-stage collaborative skill
+    speaker-notes-writer/
+      SKILL.md                            # Preference-gathering then autonomous skill
+tests/
+  test_content_validation.py              # Validation utility tests
+  fixtures/
+    talk_brief_technical_30min.json        # Extended fixture: technical talk
+    talk_brief_lightning_5min.json         # Extended fixture: lightning talk
+```
+
+---
+
+## Task 1: Research Synthesis Documents
+
+**Files:**
+- Create: `research/synthesis-narrative-architect.md`
+- Create: `research/synthesis-speaker-notes-writer.md`
+
+- [ ] **Step 1: Read primary research**
+
+Read and synthesise:
+- `research/08-narrative-arc-patterns.md` (16 arc structures, slide density research, invisible slides)
+- `research/06-speaker-notes-design.md` (timing calibration, cue types, pacing)
+- `docs/architecture/content-services.md` (L1 service document with collaborative workflow)
+
+- [ ] **Step 2: Write narrative-architect synthesis**
+
+Create `research/synthesis-narrative-architect.md` covering:
+1. **Two-stage collaborative model:** Stage 1 (arc proposal with Speaker approval) and Stage 2 (autonomous outline execution)
+2. **Arc catalogue summary:** The 16 structures from Research #08 with when each works best — grouped by talk duration and tone
+3. **Arc-to-slide-count derivation:** Pacing styles (content-heavy 0.5-1.0/min, standard 1.0-1.5/min, visual-heavy 1.5-2.5/min, rapid-fire 3.0-4.0/min) plus structural overhead (title, closing, section dividers, attention resets)
+4. **Slide type assignment patterns:** How narrative beats map to the 12 slide types
+5. **Visual direction prose guidance:** How to write specific enough for prompt engineering without prescribing implementation
+6. **What the architect decides autonomously:** Section dividers, sequencing, opening/closing sequences, body point allocation, layout template selection
+
+- [ ] **Step 3: Write speaker-notes-writer synthesis**
+
+Create `research/synthesis-speaker-notes-writer.md` covering:
+1. **Lightweight preference gathering:** The 3 questions (format, interaction style, experience level) and defaults
+2. **Timing calibration:** WPM-based calculation, cumulative timing markers, duration matching
+3. **Cue type usage:** When to use each of the 6 cue types (transition, pause, audience_interaction, emphasis, demo, build_animation)
+4. **Autonomous execution scope:** What the writer decides without seeking approval
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add research/synthesis-narrative-architect.md research/synthesis-speaker-notes-writer.md
+git commit -m "docs: add research synthesis for narrative-architect and speaker-notes-writer"
+```
+
+---
+
+## Task 2: Test Fixtures
+
+**Files:**
+- Create: `tests/fixtures/talk_brief_technical_30min.json`
+- Create: `tests/fixtures/talk_brief_lightning_5min.json`
+
+- [ ] **Step 1: Create technical 30-minute talk fixture**
+
+Create `tests/fixtures/talk_brief_technical_30min.json`:
+
+```json
+{
+  "topic": "Building Fault-Tolerant Distributed Systems with Raft Consensus",
+  "audience": "Backend engineers familiar with distributed systems but new to consensus algorithms",
+  "duration_minutes": 30,
+  "tone": "technical",
+  "key_takeaways": [
+    "Raft is simpler than Paxos without sacrificing correctness",
+    "Leader election is the hardest part to get right",
+    "Log replication handles network partitions gracefully"
+  ],
+  "branding": {
+    "company_name": "Nexus Technologies",
+    "brand_id": "nexus-tech",
+    "compliance_mode": "guided"
+  },
+  "preferences": {
+    "style": "diagram-heavy",
+    "slide_count_hint": 25,
+    "image_backend": "ollama",
+    "resolution": "1080p",
+    "include_speaker_notes": true,
+    "include_charts": false
+  },
+  "data_sources": []
+}
+```
+
+- [ ] **Step 2: Create lightning 5-minute talk fixture**
+
+Create `tests/fixtures/talk_brief_lightning_5min.json`:
+
+```json
+{
+  "topic": "One Weird Trick That Cut Our Deploy Time by 80%",
+  "audience": "DevOps engineers and SREs at a meetup",
+  "duration_minutes": 5,
+  "tone": "conversational",
+  "key_takeaways": [
+    "Parallel test execution was the bottleneck, not build time"
+  ],
+  "preferences": {
+    "style": "minimalist",
+    "slide_count_hint": 8,
+    "image_backend": "ollama",
+    "resolution": "1080p",
+    "include_speaker_notes": true,
+    "include_charts": true
+  },
+  "data_sources": [
+    {
+      "label": "Deploy time before/after",
+      "type": "inline_json",
+      "content": "{\"before_minutes\": 45, \"after_minutes\": 9}"
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Validate fixtures against schema**
+
+Run:
+```bash
+source .venv/bin/activate && python3 -c "
+import json
+from jsonschema import validate
+schema = json.load(open('src/schemas/talk_brief.schema.json'))
+for f in ['talk_brief_technical_30min', 'talk_brief_lightning_5min']:
+    brief = json.load(open(f'tests/fixtures/{f}.json'))
+    validate(instance=brief, schema=schema)
+    print(f'{f}.json validates')
+"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/fixtures/talk_brief_technical_30min.json tests/fixtures/talk_brief_lightning_5min.json
+git commit -m "test: add extended TalkBrief fixtures for content services"
+```
+
+---
+
+## Task 3: Content Validation Utilities
+
+**Files:**
+- Create: `src/content_validation.py`
+- Create: `tests/test_content_validation.py`
+
+- [ ] **Step 1: Write tests**
+
+Create `tests/test_content_validation.py`:
+
+```python
+"""Tests for content validation utilities — timing arithmetic and reference integrity."""
+
+import json
+import os
+import pytest
+
+from src.content_validation import (
+    validate_outline_schema,
+    validate_notes_schema,
+    check_timing_total,
+    check_notes_slide_references,
+    check_outline_layout_references,
+)
+
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+
+def _load_fixture(name):
+    with open(os.path.join(FIXTURE_DIR, name)) as f:
+        return json.load(f)
+
+
+class TestValidateOutlineSchema:
+    def test_valid_outline_passes(self):
+        outline = _load_fixture('valid_slide_outline.json')
+        errors = validate_outline_schema(outline)
+        assert len(errors) == 0
+
+    def test_missing_slides_fails(self):
+        outline = {"narrative_arc": "test", "estimated_duration_minutes": 10}
+        errors = validate_outline_schema(outline)
+        assert len(errors) > 0
+
+
+class TestValidateNotesSchema:
+    def test_valid_notes_passes(self):
+        notes = _load_fixture('valid_speaker_notes.json')
+        errors = validate_notes_schema(notes)
+        assert len(errors) == 0
+
+    def test_missing_notes_array_fails(self):
+        notes = {"target_pace_wpm": 130}
+        errors = validate_notes_schema(notes)
+        assert len(errors) > 0
+
+
+class TestTimingTotal:
+    def test_timing_within_tolerance(self):
+        notes = {
+            "total_estimated_minutes": 10,
+            "notes": [
+                {"slide_number": 1, "text": "Hello", "estimated_seconds": 300},
+                {"slide_number": 2, "text": "World", "estimated_seconds": 300},
+            ]
+        }
+        issues = check_timing_total(notes, duration_minutes=10)
+        assert len(issues) == 0
+
+    def test_timing_too_long(self):
+        notes = {
+            "total_estimated_minutes": 30,
+            "notes": [
+                {"slide_number": 1, "text": "Hello", "estimated_seconds": 600},
+                {"slide_number": 2, "text": "World", "estimated_seconds": 600},
+                {"slide_number": 3, "text": "Extra", "estimated_seconds": 600},
+            ]
+        }
+        issues = check_timing_total(notes, duration_minutes=10)
+        assert len(issues) > 0
+        assert any('exceeds' in i.lower() or 'over' in i.lower() for i in issues)
+
+    def test_timing_without_seconds_skips(self):
+        notes = {
+            "notes": [
+                {"slide_number": 1, "text": "Hello"},
+            ]
+        }
+        issues = check_timing_total(notes, duration_minutes=10)
+        assert len(issues) == 0
+
+
+class TestNotesSlideReferences:
+    def test_valid_references(self):
+        outline = {
+            "slides": [
+                {"slide_number": 1, "slide_type": "title", "headline": "Hi"},
+                {"slide_number": 2, "slide_type": "content", "headline": "Body"},
+            ]
+        }
+        notes = {
+            "notes": [
+                {"slide_number": 1, "text": "Hello"},
+                {"slide_number": 2, "text": "World"},
+            ]
+        }
+        issues = check_notes_slide_references(notes, outline)
+        assert len(issues) == 0
+
+    def test_orphan_note_detected(self):
+        outline = {
+            "slides": [
+                {"slide_number": 1, "slide_type": "title", "headline": "Hi"},
+            ]
+        }
+        notes = {
+            "notes": [
+                {"slide_number": 1, "text": "Hello"},
+                {"slide_number": 99, "text": "Orphan"},
+            ]
+        }
+        issues = check_notes_slide_references(notes, outline)
+        assert len(issues) > 0
+        assert any('99' in i for i in issues)
+
+
+class TestOutlineLayoutReferences:
+    def test_valid_layout_references(self):
+        outline = {
+            "slides": [
+                {"slide_number": 1, "slide_type": "title", "headline": "Hi", "layout_template": "title"},
+                {"slide_number": 2, "slide_type": "content", "headline": "Body", "layout_template": "content"},
+            ]
+        }
+        style_guide = {
+            "layout": {
+                "templates": {"title": {}, "content": {}}
+            }
+        }
+        issues = check_outline_layout_references(outline, style_guide)
+        assert len(issues) == 0
+
+    def test_missing_template_detected(self):
+        outline = {
+            "slides": [
+                {"slide_number": 1, "slide_type": "title", "headline": "Hi", "layout_template": "nonexistent"},
+            ]
+        }
+        style_guide = {
+            "layout": {
+                "templates": {"title": {}, "content": {}}
+            }
+        }
+        issues = check_outline_layout_references(outline, style_guide)
+        assert len(issues) > 0
+
+    def test_no_layout_template_skips(self):
+        outline = {
+            "slides": [
+                {"slide_number": 1, "slide_type": "title", "headline": "Hi"},
+            ]
+        }
+        style_guide = {"layout": {"templates": {}}}
+        issues = check_outline_layout_references(outline, style_guide)
+        assert len(issues) == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python3 -m pytest tests/test_content_validation.py -v`
+
+Expected: FAIL — `src.content_validation` not found.
+
+- [ ] **Step 3: Implement content validation utilities**
+
+Create `src/content_validation.py`:
+
+```python
+"""Content validation utilities — timing arithmetic and reference integrity.
+
+This module handles ONLY machine-checkable validation:
+- Schema conformance (SlideOutline, SpeakerNotes)
+- Timing arithmetic (do note durations sum to talk duration?)
+- Reference integrity (layout templates, slide numbers)
+
+All narrative reasoning — arc selection, slide sequencing, headline quality,
+visual direction prose — is Claude's contextual reasoning in the SKILL.md,
+NOT codified rules here.
+"""
+
+import json
+import os
+
+import jsonschema
+
+SCHEMA_DIR = os.path.join(os.path.dirname(__file__), 'schemas')
+
+TIMING_TOLERANCE_PCT = 20  # Allow 20% deviation from target duration
+
+
+def validate_outline_schema(outline):
+    """Validate a SlideOutline dict against the JSON schema. Returns list of error messages."""
+    schema_path = os.path.join(SCHEMA_DIR, 'slide_outline.schema.json')
+    with open(schema_path) as f:
+        schema = json.load(f)
+    validator = jsonschema.Draft202012Validator(schema)
+    return [e.message for e in validator.iter_errors(outline)]
+
+
+def validate_notes_schema(notes):
+    """Validate a SpeakerNotes dict against the JSON schema. Returns list of error messages."""
+    schema_path = os.path.join(SCHEMA_DIR, 'speaker_notes.schema.json')
+    with open(schema_path) as f:
+        schema = json.load(f)
+    validator = jsonschema.Draft202012Validator(schema)
+    return [e.message for e in validator.iter_errors(notes)]
+
+
+def check_timing_total(notes, duration_minutes):
+    """Check that note durations sum to approximately the talk duration.
+
+    Returns list of issue strings. Tolerates TIMING_TOLERANCE_PCT deviation.
+    """
+    issues = []
+    total_seconds = 0
+    has_timing = False
+    for note in notes.get('notes', []):
+        est = note.get('estimated_seconds')
+        if est is not None:
+            total_seconds += est
+            has_timing = True
+
+    if not has_timing:
+        return []
+
+    target_seconds = duration_minutes * 60
+    deviation_pct = abs(total_seconds - target_seconds) / target_seconds * 100
+
+    if total_seconds > target_seconds * (1 + TIMING_TOLERANCE_PCT / 100):
+        issues.append(
+            f'Notes total {total_seconds}s ({total_seconds/60:.1f}min) exceeds '
+            f'talk duration {duration_minutes}min by {deviation_pct:.0f}%'
+        )
+    elif total_seconds < target_seconds * (1 - TIMING_TOLERANCE_PCT / 100):
+        issues.append(
+            f'Notes total {total_seconds}s ({total_seconds/60:.1f}min) under '
+            f'talk duration {duration_minutes}min by {deviation_pct:.0f}%'
+        )
+
+    return issues
+
+
+def check_notes_slide_references(notes, outline):
+    """Check that every note references a slide that exists in the outline."""
+    issues = []
+    outline_slides = {s['slide_number'] for s in outline.get('slides', [])}
+    for note in notes.get('notes', []):
+        sn = note.get('slide_number')
+        if sn is not None and sn not in outline_slides:
+            issues.append(f'Note references slide {sn} which does not exist in outline')
+    return issues
+
+
+def check_outline_layout_references(outline, style_guide):
+    """Check that every layout_template in the outline exists in the StyleGuide."""
+    issues = []
+    templates = style_guide.get('layout', {}).get('templates', {})
+    for slide in outline.get('slides', []):
+        lt = slide.get('layout_template')
+        if lt and lt not in templates:
+            issues.append(
+                f'Slide {slide["slide_number"]} references layout template '
+                f'"{lt}" which does not exist in StyleGuide'
+            )
+    return issues
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python3 -m pytest tests/test_content_validation.py -v`
+
+Expected: All tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/content_validation.py tests/test_content_validation.py
+git commit -m "feat: add content validation utilities (timing arithmetic, reference integrity)"
+```
+
+---
+
+## Task 4: narrative-architect Skill Definition
+
+**Files:**
+- Create: `.claude/skills/narrative-architect/SKILL.md`
+
+- [ ] **Step 1: Read research synthesis and architecture doc**
+
+Read:
+- `research/synthesis-narrative-architect.md`
+- `research/08-narrative-arc-patterns.md` (sections 1.1-1.16 for arc catalogue)
+- `docs/architecture/content-services.md`
+- `src/schemas/slide_outline.schema.json`
+
+- [ ] **Step 2: Write the narrative-architect skill**
+
+Create `.claude/skills/narrative-architect/SKILL.md`:
+
+```markdown
+---
+name: narrative-architect
+description: Transform a TalkBrief into a structured SlideOutline through collaborative arc selection and autonomous outline generation.
+argument-hint: [--deck-dir PATH]
+allowed-tools: Bash(python *), Read, Glob, Write
+---
+
+# /narrative-architect
+
+Transform a TalkBrief into a structured SlideOutline. Works in two stages: collaborative arc selection with the Speaker, then autonomous outline generation.
+
+## Prerequisites
+
+- `./tmp/deck/talk-brief.json` must exist
+- `./tmp/deck/style-guide.json` must exist (produced by slide-stylist)
+
+## Usage
+
+Invoked by the Deck Conductor after slide-stylist. Can also be invoked directly:
+
+```
+/narrative-architect
+/narrative-architect --deck-dir ./tmp/deck
+```
+
+## What It Does
+
+### Stage 1: Arc Proposal (Collaborative)
+
+Read `./tmp/deck/talk-brief.json` for topic, audience, duration, tone, key takeaways, and data sources.
+
+Based on these signals, select 2-3 narrative arc options that genuinely fit this specific talk. Do NOT present all 16 arcs from the catalogue -- curate down to the best matches.
+
+For each proposed arc, present:
+
+> "For a **{duration}-minute {tone}** talk on **{topic}**, here are the narrative structures I'd recommend:
+>
+> 1. **{Arc Name}** -- {one-line emotional description}
+>    - Best for: {when this works}
+>    - Your talk would flow: {beat1} -> {beat2} -> {beat3} -> ... -> {final beat}
+>    - Slide count: ~{count} slides at {pacing} pacing
+>
+> 2. **{Arc Name}** -- {one-line emotional description}
+>    - Best for: {when this works}
+>    - Your talk would flow: {beat1} -> {beat2} -> ...
+>    - Slide count: ~{count} slides
+>
+> 3. **{Arc Name}** -- {one-line emotional description}
+>    - Best for: {when this works}
+>    - Your talk would flow: {beat1} -> {beat2} -> ...
+>    - Slide count: ~{count} slides
+>
+> **My recommendation:** {Arc Name} because {one-sentence rationale connecting to this specific talk}.
+>
+> Which structure speaks to you? (Or describe what you're looking for)"
+
+Wait for the Speaker to select or describe their preference. If they describe something custom, map it to the closest arc or propose a hybrid.
+
+### Arc Catalogue Reference
+
+These are the established structures to draw from (Research #08):
+
+| Arc | Best For | Pacing |
+|-----|----------|--------|
+| Situation-Complication-Resolution | Executive briefings, problem-solving | Standard |
+| Monroe's Motivated Sequence | Persuasion, calls to action | Standard |
+| Hero's Journey | Transformation stories, keynotes | Visual-heavy |
+| Problem-Solution-Impact | Product talks, case studies | Standard |
+| Problem-Demo-Impact | Technical demos, tool showcases | Content-heavy |
+| What-So What-Now What | Data presentations, research findings | Content-heavy |
+| Hook-Thesis-Body-Callback-CTA | Persuasion talks, thought leadership | Standard |
+| Story-Point-Application | Rule of Three, teaching talks | Standard |
+| Pecha Kucha | 6:40 fixed format, 20 slides x 20 seconds | Rapid-fire |
+| Ignite | 5 min fixed, 20 slides x 15 seconds | Rapid-fire |
+| Lightning Talk | 5-10 min, minimal slides | Standard |
+| Lessig Method | Rapid visual reinforcement, advocacy | Rapid-fire |
+| Takahashi Method | Japanese big-text style, storytelling | Rapid-fire |
+| 10/20/30 Rule | Startup pitches, 10 slides | Content-heavy |
+| Duarte Sparkline | Long keynotes, What Is vs What Could Be | Visual-heavy |
+| Modular Deck | Flexible/reusable, workshop-style | Standard |
+
+### Stage 2: Outline Execution (Autonomous)
+
+Once the Speaker selects an arc, produce the full SlideOutline. This is expert craft -- do NOT seek per-slide approval.
+
+**What you decide autonomously:**
+- Exact slide count (calibrated to duration and pacing style)
+- Slide type assignment per slide (from the 12 types)
+- Headlines -- punchy conference headlines, not academic paper titles
+- Body points (max 5 per slide)
+- Narrative beat labels
+- Visual direction prose per slide (specific enough for prompt engineering, incorporating StyleGuide image_style_tokens)
+- Layout template references from StyleGuide
+- Transition notes between slides
+- Section divider placement (before every major beat transition)
+- Attention reset beats (every ~10 minutes of duration)
+- Data source mapping from TalkBrief to data_chart slides
+
+**Pacing guidelines:**
+- Content-heavy (data, technical deep-dive): 0.5-1.0 slides/min
+- Standard (most conference talks): 1.0-1.5 slides/min
+- Visual-heavy (keynotes, storytelling): 1.5-2.5 slides/min
+- Rapid-fire (Pecha Kucha, Ignite, Lessig): 3.0-4.0 slides/min
+
+**Structural overhead added to base count:**
+- +1 title slide (always)
+- +1 closing slide (always)
+- +1 section divider per major beat transition
+- +1 attention reset per 10 minutes of duration
+
+If `preferences.slide_count_hint` is provided, use it as a soft target (within 20%) but override if the arc demands it.
+
+**Read the StyleGuide** at `./tmp/deck/style-guide.json` for:
+- Layout template names (ensure every slide's `layout_template` exists in `layout.templates`)
+- Image style tokens (weave `mood`, `color_direction`, and `style_modifiers` into `visual_direction` prose)
+
+### Step 3: Validate and Write
+
+Validate the outline before writing:
+
+```bash
+source .venv/bin/activate && python3 -c "
+import json
+from src.content_validation import validate_outline_schema, check_outline_layout_references
+outline = json.load(open('./tmp/deck/outline.json'))
+style_guide = json.load(open('./tmp/deck/style-guide.json'))
+schema_errors = validate_outline_schema(outline)
+ref_issues = check_outline_layout_references(outline, style_guide)
+for e in schema_errors: print(f'SCHEMA: {e}')
+for e in ref_issues: print(f'REF: {e}')
+if not schema_errors and not ref_issues:
+    print('SlideOutline validates successfully')
+"
+```
+
+Write the validated SlideOutline to `./tmp/deck/outline.json`.
+
+## Output
+
+`./tmp/deck/outline.json` (SlideOutline contract)
+
+## Design Rules
+
+- Headlines should be punchy conference headlines, not generic titles ("The 3-Second Rule for Slide Readability" not "Text Best Practices")
+- Max 5 body points per slide
+- Visual direction must be specific enough to generate images but not prescriptive about implementation
+- Never place two data_chart slides consecutively without a breathing slide between them
+- Section dividers before every major narrative beat transition
+- Title slide always first, closing slide always last
+- Do NOT ask the Speaker about individual slide choices -- the arc approval is the collaboration point
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/narrative-architect/
+git commit -m "feat: add narrative-architect skill with two-stage collaborative workflow"
+```
+
+---
+
+## Task 5: speaker-notes-writer Skill Definition
+
+**Files:**
+- Create: `.claude/skills/speaker-notes-writer/SKILL.md`
+
+- [ ] **Step 1: Read research synthesis and architecture doc**
+
+Read:
+- `research/synthesis-speaker-notes-writer.md`
+- `research/06-speaker-notes-design.md`
+- `docs/architecture/content-services.md`
+- `src/schemas/speaker_notes.schema.json`
+
+- [ ] **Step 2: Write the speaker-notes-writer skill**
+
+Create `.claude/skills/speaker-notes-writer/SKILL.md`:
+
+```markdown
+---
+name: speaker-notes-writer
+description: Generate timed, transition-cued speaker notes calibrated to talk duration and audience profile, with lightweight preference gathering.
+argument-hint: [--deck-dir PATH]
+allowed-tools: Bash(python *), Read, Glob, Write
+---
+
+# /speaker-notes-writer
+
+Generate per-slide speaker notes with timing markers, cumulative time marks, and interaction cues.
+
+## Prerequisites
+
+- `./tmp/deck/talk-brief.json` must exist
+- `./tmp/deck/outline.json` must exist (produced by narrative-architect)
+
+## Usage
+
+Invoked by the Deck Conductor after narrative-architect. Can also be invoked directly:
+
+```
+/speaker-notes-writer
+/speaker-notes-writer --deck-dir ./tmp/deck
+```
+
+## What It Does
+
+### Step 1: Gather Preferences (Lightweight Collaboration)
+
+Before generating notes, ask the Speaker three quick questions (if the answers aren't obvious from the TalkBrief):
+
+> "Before I write your speaker notes, three quick questions:
+>
+> 1. **Note format:** Do you prefer bullet points/keywords or fuller sentences?
+> 2. **Audience interaction:** Any preference? (show of hands, rhetorical questions, polls, none)
+> 3. **Your experience level:** First-time presenter, comfortable, or seasoned?
+>
+> (Or just say 'defaults' and I'll use: bullet points, match-to-tone interaction, moderate detail)"
+
+**Defaults if Speaker says 'defaults' or skips:**
+- Format: Bullet points with key phrases
+- Interaction: Match to tone (conversational = show of hands, professional = rhetorical, technical = none)
+- Detail: Moderate (comfortable presenter)
+
+### Step 2: Generate Notes (Autonomous)
+
+Read `./tmp/deck/talk-brief.json` and `./tmp/deck/outline.json`.
+
+For each slide in the outline, produce a note with:
+
+**text** — The speaking content for this slide:
+- Bullet format: key phrases and memory joggers
+- Sentence format: near-script with natural spoken language
+- Detail scaled to experience level (first-time = more explicit cues, seasoned = less)
+
+**estimated_seconds** — Time allocation for this slide:
+- Calculate from `target_pace_wpm` (default 130) and word count
+- Heavier slides (data, key arguments) get more time
+- Structural slides (title, dividers, closing) get less
+- Total must sum to approximately `duration_minutes` from TalkBrief
+
+**timing_marker** — Cumulative time mark (e.g., "~5:30", "~12:00"):
+- Helps the speaker track progress during delivery
+- Calculate from cumulative estimated_seconds
+
+**cues** — Interaction cues appropriate to the slide:
+- `transition`: How to bridge from the previous slide ("Building on that insight...")
+- `pause`: Deliberate silence for impact ("[pause 2 seconds for the number to land]")
+- `audience_interaction`: Engage the audience, matching the Speaker's preference
+- `emphasis`: Key point to stress ("This is the number your CFO cares about")
+- `demo`: Live demonstration beat ("Switch to terminal, run the command")
+- `build_animation`: Timed reveal ("Click to reveal the second column")
+
+**What you decide autonomously:**
+- Word count per slide (calibrated to pace and duration)
+- Timing allocation per slide
+- Cumulative timing markers
+- Transition cue placement and content
+- Pause placement (after key data, before major shifts)
+- Audience interaction beat placement (every ~10 minutes)
+- Emphasis markers on key phrases
+- Demo cues (when outline includes demo beats)
+- Build animation triggers (when outline has progressive disclosure)
+
+### Step 3: Validate and Write
+
+Validate the notes before writing:
+
+```bash
+source .venv/bin/activate && python3 -c "
+import json
+from src.content_validation import validate_notes_schema, check_timing_total, check_notes_slide_references
+notes = json.load(open('./tmp/deck/speaker-notes.json'))
+outline = json.load(open('./tmp/deck/outline.json'))
+brief = json.load(open('./tmp/deck/talk-brief.json'))
+schema_errors = validate_notes_schema(notes)
+timing_issues = check_timing_total(notes, brief['duration_minutes'])
+ref_issues = check_notes_slide_references(notes, outline)
+for e in schema_errors: print(f'SCHEMA: {e}')
+for e in timing_issues: print(f'TIMING: {e}')
+for e in ref_issues: print(f'REF: {e}')
+if not schema_errors and not timing_issues and not ref_issues:
+    print('SpeakerNotes validates successfully')
+"
+```
+
+Write the validated SpeakerNotes to `./tmp/deck/speaker-notes.json`.
+
+## Output
+
+`./tmp/deck/speaker-notes.json` (SpeakerNotes contract)
+
+## Design Rules
+
+- Notes must be specific and actionable -- "Explain that Raft uses heartbeats for failure detection" not "Talk about this slide"
+- Total timing must match talk duration within 20%
+- Every content slide should have a transition cue (how to get there from the previous slide)
+- Audience interaction beats every ~10 minutes of duration
+- Do NOT ask the Speaker to review individual slide notes -- deliver the complete set
+- The target_pace_wpm default is 130 (natural conversational pace)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/speaker-notes-writer/
+git commit -m "feat: add speaker-notes-writer skill with preference gathering"
+```
+
+---
+
+## Task 6: Mark Old Plan Superseded, Update CLAUDE.md
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-03-29-phase-3-content-services.md`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `source .venv/bin/activate && python3 -m pytest tests/ -v`
+
+Expected: All tests PASS (354 existing + new Phase 3 tests).
+
+- [ ] **Step 2: Mark old plan superseded**
+
+Add at the top of `docs/superpowers/plans/2026-03-29-phase-3-content-services.md`:
+
+```markdown
+> **SUPERSEDED** by `docs/superpowers/plans/2026-03-29-phase-3-content-services-v2.md`. Redesigned with collaborative arc selection workflow and thin validation module (no Python arc logic). This plan is retained for historical reference.
+```
+
+- [ ] **Step 3: Update CLAUDE.md**
+
+Add to the implementation table:
+```
+| Content validation | `src/content_validation.py` | N | Done |
+```
+
+Update Phase 3 status from "planned, NEXT" to "COMPLETE".
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md docs/superpowers/plans/2026-03-29-phase-3-content-services.md
+git commit -m "docs: update CLAUDE.md with Phase 3 completion, mark old plan superseded"
+```
+
+---
+
+### Critical Files for Implementation
+
+- `/Users/stevejones/Documents/Development/jack-tar-deckhand/.claude/skills/narrative-architect/SKILL.md` — two-stage collaborative skill (arc proposal + autonomous outline)
+- `/Users/stevejones/Documents/Development/jack-tar-deckhand/.claude/skills/speaker-notes-writer/SKILL.md` — preference gathering then autonomous notes
+- `/Users/stevejones/Documents/Development/jack-tar-deckhand/src/content_validation.py` — timing arithmetic and reference integrity only (~60 lines)
+- `/Users/stevejones/Documents/Development/jack-tar-deckhand/docs/architecture/content-services.md` — L1 service document (authoritative design reference)

--- a/docs/superpowers/plans/2026-03-29-phase-3-content-services.md
+++ b/docs/superpowers/plans/2026-03-29-phase-3-content-services.md
@@ -1,4 +1,6 @@
-# Phase 3: Content Services — narrative-architect & speaker-notes-writer
+> **SUPERSEDED** by `docs/superpowers/plans/2026-03-29-phase-3-content-services-v2.md`. Redesigned with collaborative arc selection workflow and thin validation module (no Python arc logic). This plan is retained for historical reference.
+
+# Phase 3: Content Services — narrative-architect & speaker-notes-writer (SUPERSEDED)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 

--- a/research/synthesis-narrative-architect.md
+++ b/research/synthesis-narrative-architect.md
@@ -1,0 +1,274 @@
+# Synthesis: narrative-architect
+
+> Distilled from: research/08-narrative-arc-patterns.md, docs/architecture/content-services.md, src/schemas/slide_outline.schema.json
+
+## 1. Two-Stage Collaborative Model
+
+The narrative-architect operates in two stages with a Speaker approval gate between them.
+
+### Stage 1: Arc Proposal (Interactive)
+
+1. Read the TalkBrief (topic, audience, duration, tone, key takeaways, data sources)
+2. Read the StyleGuide (layout templates, slide types available)
+3. Select 2-3 narrative arc options from the catalogue (Section 2 below), curated by duration, tone, and content type
+4. For each option, present:
+   - Arc name and origin
+   - Why it suits this talk (audience + goal alignment)
+   - Beat structure with approximate time allocations
+   - Estimated slide count range
+   - Example slide-type sequence (abbreviated)
+5. Wait for Speaker to select one arc
+
+### Stage 2: Outline Execution (Autonomous)
+
+Once the arc is agreed, the narrative-architect produces the full SlideOutline (`./tmp/deck/outline.json`) without per-slide approval. Individual slide decisions are professional craft. The architect decides autonomously:
+
+- Exact slide count within the arc's range
+- Per-slide type assignment from the 12 available types
+- Headlines (punchy, conference-style -- not academic paper titles)
+- Body points (max 5 per slide, projection-readable)
+- Narrative beat labels
+- Visual direction prose per slide
+- Visual type assignment (hero_image, diagram, chart, icon_set, pattern_background, none)
+- Data source mapping from TalkBrief to data_chart slides
+- Layout template references from the StyleGuide
+- Transition notes between slides
+- Placement of invisible slides (section dividers, breathing room, interaction beats)
+
+---
+
+## 2. Arc Catalogue
+
+### 2.1 Grouped by Duration and Tone
+
+**Short-form (5-10 minutes)**
+
+| Arc | Beats | Fixed Slides | Best For |
+|-----|-------|-------------|----------|
+| Pecha Kucha | 20 images, 20s each | 20 (fixed) | Design showcases, creative portfolios, meetups |
+| Ignite | 20 slides, 15s each | 20 (fixed) | Tech meetups, rapid-fire idea sharing |
+| Lightning Talk | Flexible | 10-15 | Developer conferences, unconferences |
+
+**Medium-form (15-30 minutes)**
+
+| Arc | Beats | Typical Slides | Best For |
+|-----|-------|---------------|----------|
+| Problem-Solution-Impact | 3 | 7-15 | Sales pitches, client proposals, startup pitches |
+| Problem-Demo-Impact | 3 | 10-15 + demo | Product launches, developer conferences |
+| 10/20/30 (Kawasaki) | 10 prescribed | 10 (fixed) | Investor pitches, high-stakes proposals |
+| What-So What-Now What | 3 per data point | 12-20 | Quarterly reviews, data presentations |
+| Hook-Thesis-Body-Callback-CTA | 5 | 15-25 | Conference talks, thought leadership |
+
+**Long-form (30-60 minutes)**
+
+| Arc | Beats | Typical Slides | Best For |
+|-----|-------|---------------|----------|
+| SCR (Minto Pyramid) | 3 (or 4 with SCQA) | 10-20 | Executive briefings, strategy, consulting |
+| Monroe's Motivated Sequence | 5 | 15-25 | Persuasion, advocacy, fundraising |
+| Hero's Journey | 6 | 20-35 | Keynotes, transformation stories, case studies |
+| Story-Point-Application | 3x3 = 9 | 18-30 | Motivational, leadership, workshops |
+| Duarte Sparkline | Alternating contrast | 20-40 | Keynotes, vision talks, all-hands |
+
+**Special formats (any duration)**
+
+| Arc | Constraint | Best For |
+|-----|-----------|----------|
+| Lessig Method | 1 word/phrase/image per slide, 15s each | Advocacy, legal arguments, TED-style |
+| Takahashi Method | Giant text only, many slides | Technical talks without design resources |
+| Modular Deck | Reorderable core sections | Client meetings, unpredictable conversations |
+
+### 2.2 Quick Selection Guide
+
+| If the talk is... | Use |
+|-------------------|-----|
+| Persuading executives to approve a strategy | SCR (Minto Pyramid) |
+| Advocating for change with a clear ask | Monroe's Motivated Sequence |
+| Telling a transformation story at a keynote | Hero's Journey or Duarte Sparkline |
+| Pitching a product or startup | Problem-Solution-Impact or 10/20/30 |
+| Demoing a product to developers | Problem-Demo-Impact |
+| Presenting quarterly data to leadership | What-So What-Now What |
+| Giving a conference talk to inspire action | Hook-Thesis-Body-Callback-CTA |
+| Teaching through stories at a workshop | Story-Point-Application (Rule of Three) |
+| Presenting at a design meetup | Pecha Kucha |
+| Sharing a quick idea at a tech meetup | Lightning Talk or Ignite |
+| Making a legal or advocacy argument | Lessig Method |
+| Presenting without design resources | Takahashi Method |
+| Running an unpredictable client meeting | Modular Deck |
+| Giving a vision/all-hands talk | Duarte Sparkline |
+
+---
+
+## 3. Arc-to-Slide-Count Derivation
+
+### 3.1 Pacing Styles
+
+| Pace | Slides/Minute | When to Use |
+|------|---------------|-------------|
+| Standard | 0.5-1.0 | Content-heavy: data presentations, technical deep dives, board meetings |
+| Fast | 1.0-2.0 | Visual-heavy: storytelling keynotes, image-driven narratives |
+| Rapid-fire | 2.0-4.0 | Fixed-format: Pecha Kucha, Ignite, Lessig, Takahashi |
+
+### 3.2 Content Slide Duration
+
+Each content slide is calibrated to approximately 1.5-2 minutes of speaking time at standard pace. This means:
+
+- 5-minute talk: 3-5 content slides
+- 20-minute talk: 10-13 content slides
+- 30-minute talk: 15-20 content slides
+- 45-minute talk: 22-30 content slides
+
+### 3.3 Structural Overhead
+
+Content slide counts above do NOT include structural "invisible" slides. Add:
+
+| Structural Element | Count Rule | Purpose |
+|-------------------|------------|---------|
+| Title slide | 1 (always) | Opens the deck |
+| Section dividers | 1 per major beat transition | Mental breathing room, topic shift signal |
+| Closing slide | 1 (always) | CTA + contact/resources |
+| Recap/checkpoint slides | 1 per 15 minutes of talk | Resets audience comprehension |
+| Interaction beat slides | 1 per 10 minutes of talk | Resets attention (the 10-minute rule) |
+
+**Example for a 30-minute talk using Hook-Thesis-Body-Callback-CTA:**
+- Content slides: ~16
+- Title: 1
+- Section dividers: 3-4 (between body points + before callback)
+- Closing: 1
+- Checkpoint: 1 (at ~15 min)
+- Total: ~22-23 slides
+
+### 3.4 Fixed-Format Overrides
+
+Some arcs have non-negotiable slide counts that override the derivation:
+
+| Arc | Slide Count | Duration |
+|-----|-------------|----------|
+| Pecha Kucha | 20 (exactly) | 6:40 |
+| Ignite | 20 (exactly) | 5:00 |
+| 10/20/30 (Kawasaki) | 10 (exactly) | 20 min max |
+
+---
+
+## 4. Slide Type Assignment Patterns
+
+### 4.1 The 12 Slide Types
+
+From the SlideOutline schema: `title`, `section_divider`, `content`, `two_column`, `image_feature`, `data_chart`, `stat_callout`, `quote`, `icon_grid`, `diagram`, `closing`, `blank_visual`.
+
+### 4.2 Beat-to-Type Mapping
+
+| Narrative Function | Primary Type | Secondary Type |
+|-------------------|-------------|----------------|
+| Open / hook | `image_feature` or `stat_callout` | `blank_visual` (striking image) |
+| Context / current state | `content` or `two_column` | `data_chart` |
+| Problem / tension | `data_chart` or `stat_callout` | `content` |
+| Solution / concept | `content` or `diagram` | `icon_grid` |
+| Evidence / proof | `data_chart` | `quote` (testimonial) |
+| Demo segment | `blank_visual` (screenshot) | `diagram` (architecture) |
+| Vision / future | `image_feature` | `two_column` (before/after) |
+| Story / anecdote | `image_feature` or `blank_visual` | `quote` |
+| Recap / checkpoint | `content` (bullet summary) | `icon_grid` |
+| Call to action | `closing` | `stat_callout` |
+| Transition | `section_divider` | -- |
+
+### 4.3 Sequencing Rules
+
+1. **Never two data-heavy slides in a row.** Follow any `data_chart` with an insight (`content`), story (`image_feature`), or `section_divider`.
+2. **Section dividers before every major topic shift.** One `section_divider` at each beat boundary.
+3. **Progressive disclosure for complex ideas.** Concept (`content`) then data (`data_chart`) then conclusion (`stat_callout` or `content`).
+4. **One idea per slide.** If a slide needs more than 2 minutes during practice, split it.
+5. **Maximum 6 elements per slide.** Text blocks + images + chart elements combined.
+6. **Vary slide types rhythmically.** Alternate between text-heavy, image-heavy, and data types. Insert a change-of-pace element every 8-10 minutes.
+7. **Maximum 5 body points per slide.** Enforced by schema constraint.
+
+### 4.4 Opening Conventions
+
+**Talks > 15 minutes:**
+1. `title` -- on screen as audience settles
+2. `image_feature` or `stat_callout` -- the hook
+3. `content` (optional) -- thesis/agenda for longer talks
+4. First content slide
+
+**Talks < 15 minutes:**
+1. `title` -- brief
+2. Hook -- go directly into content. No agenda slide.
+
+### 4.5 Closing Conventions
+
+1. `content` -- recap/summary (key takeaways)
+2. Callback slide (reference the opening hook) -- type varies by hook type
+3. `closing` -- call to action + resources/contact
+
+---
+
+## 5. Visual Direction Prose Guidance
+
+The `visual_direction` field on each slide provides prose guidance for Image Services. It must be specific enough for prompt engineering but not prescriptive about implementation.
+
+### 5.1 What Visual Direction Includes
+
+- **Subject matter:** What the image should depict ("server room with glowing network connections", "diverse team collaborating around a whiteboard")
+- **Mood/atmosphere:** Emotional tone ("warm and inviting", "dramatic and high-contrast", "clean and clinical")
+- **Composition hints:** Where the subject sits in frame ("subject left with open space right for text overlay", "centered with radial symmetry")
+- **Colour alignment:** References to StyleGuide palette ("use brand primary blue as dominant tone", "warm palette consistent with section mood")
+- **Negative space requirement:** Whether text will overlay the image ("needs clear area in lower-third for headline", "full-bleed with no text overlay")
+
+### 5.2 What Visual Direction Does NOT Include
+
+- Specific model or provider names (that is the imagegen-bridge's decision)
+- Prompt syntax or tokens (visual_direction is human-readable prose, not a prompt)
+- Exact hex colours (reference the palette semantically)
+- Technical generation parameters (dimensions, steps, seed)
+
+### 5.3 Visual Direction by Slide Type
+
+| Slide Type | Visual Direction Focus |
+|------------|----------------------|
+| `title` | Full-bleed hero image with negative space for title text |
+| `section_divider` | No image needed (solid dark background) or subtle texture |
+| `content` | Supporting illustration in right zone, 3:4 aspect ratio |
+| `image_feature` | Hero image in upper zone, subject-centric, high impact |
+| `data_chart` | No image (chart is the visual); may note chart colour guidance |
+| `stat_callout` | No image; visual emphasis is typographic |
+| `quote` | No image or subtle background texture |
+| `blank_visual` | Full-bleed storytelling image, cinematic composition |
+| `icon_grid` | Icon style description (flat, outlined, filled) + subject per icon |
+
+### 5.4 Visual Type Assignment
+
+Each slide gets a `visual_type` from: `hero_image`, `diagram`, `chart`, `icon_set`, `pattern_background`, `none`.
+
+| Slide Type | Default visual_type | Override When |
+|------------|-------------------|---------------|
+| `title` | `hero_image` | No image needed: `pattern_background` |
+| `section_divider` | `none` | Decorative: `pattern_background` |
+| `content` | `hero_image` | Text-only: `none` |
+| `image_feature` | `hero_image` | -- |
+| `data_chart` | `chart` | -- |
+| `stat_callout` | `none` | -- |
+| `quote` | `none` | Background texture: `pattern_background` |
+| `icon_grid` | `icon_set` | -- |
+| `diagram` | `diagram` | -- |
+| `closing` | `none` | Brand image: `hero_image` |
+| `blank_visual` | `hero_image` | -- |
+| `two_column` | `hero_image` | Comparison: `none` |
+
+---
+
+## 6. Anti-Patterns
+
+- **Proposing more than 3 arc options.** Choice paralysis. Propose 2-3, curated for the specific talk.
+- **Seeking per-slide approval.** Stage 2 is autonomous. The arc was approved; individual slides are craft decisions.
+- **Using academic paper titles as headlines.** Headlines should be punchy and conference-ready: "Revenue Doubled -- Here's How" not "Analysis of Revenue Growth Factors."
+- **Ignoring structural overhead.** Raw content slide count without section dividers, title, and closing produces too few slides.
+- **Consecutive data slides.** Follow every data_chart with interpretation. Never stack two data-heavy slides without a breathing slide between them.
+- **Empty visual_direction.** Every slide that needs imagery must have specific prose guidance. "Add an image" is not direction.
+- **Exceeding 5 body points per slide.** Schema-enforced maximum for projection readability.
+
+---
+
+## Sources
+
+- Research #08 (Narrative Arc & Conference Storytelling Patterns): Sections 1-6 (16 arc structures, slide density, invisible slides, conference analysis, sequencing rules, speaker notes intelligence)
+- Content Services L1 architecture document: narrative-architect workflow, responsibilities, constraints
+- Schema: `src/schemas/slide_outline.schema.json` (output contract)

--- a/research/synthesis-speaker-notes-writer.md
+++ b/research/synthesis-speaker-notes-writer.md
@@ -1,0 +1,207 @@
+# Synthesis: speaker-notes-writer
+
+> Distilled from: research/08-narrative-arc-patterns.md (Section 6: Speaker Notes Intelligence), docs/architecture/content-services.md, src/schemas/speaker_notes.schema.json
+
+## 1. Lightweight Preference Gathering
+
+The speaker-notes-writer gathers three preferences before autonomous execution. These are quick, single-answer questions -- not an extended interview.
+
+### 1.1 The Three Questions
+
+| # | Question | Options | Default |
+|---|----------|---------|---------|
+| 1 | **Note format** | Bullets (keywords/phrases) or Sentences (flowing prose) | Bullets |
+| 2 | **Audience interaction style** | Minimal (few or no audience prompts), Moderate (show-of-hands, rhetorical questions), High (polls, discussions, scale ratings) | Moderate |
+| 3 | **Speaker experience level** | Novice (detailed stage directions, explicit transitions), Experienced (key points and timing only), Expert (minimal -- timing markers and cues only) | Experienced |
+
+### 1.2 How Preferences Shape Output
+
+**Note format:**
+- **Bullets:** Keywords and phrases. The speaker glances at notes for reminders, not scripts. Avoids reading. Recommended for most speakers.
+- **Sentences:** Flowing talk track. Better for speakers who want a safety net or for talks being delivered by someone other than the author. Risk: reading verbatim kills audience connection.
+
+**Interaction style:**
+- **Minimal:** Interaction cues limited to transitions and emphasis. No audience_interaction cues inserted.
+- **Moderate:** One interaction beat per 10 minutes (the attention-reset rule). Show-of-hands within first 2 minutes. Rhetorical questions at topic transitions.
+- **High:** Interaction beats every 8 minutes. Polls, discussion prompts, scale ratings, reflection pauses. Only suitable for workshop-style or small-room talks.
+
+**Experience level:**
+- **Novice:** Full stage directions (`[PAUSE]`, `[SLOW DOWN]`, `[LOOK AT AUDIENCE]`), explicit transition phrases ("Now that we've covered X, let's move on to Y"), vocal emphasis markers, timing warnings.
+- **Experienced:** Main points, transition cues, timing markers, key emphasis. No basic stage directions.
+- **Expert:** Timing markers and interaction cues only. Trusts the speaker to handle delivery.
+
+---
+
+## 2. Timing Calibration
+
+### 2.1 WPM-Based Calculation
+
+| Speaking Pace | Words/Minute | When to Use |
+|---------------|-------------|----------|
+| Slow | 100-120 | Complex technical content, non-native audience |
+| Standard | 130-150 | General conference talks (default: 130 WPM) |
+| Fast | 160-170 | Motivational speeches, lively narratives |
+
+The default target pace is 130 WPM. This is set in the SpeakerNotes output as `target_pace_wpm`.
+
+### 2.2 Per-Slide Word Budget
+
+Calculate the word budget for each slide's notes based on allocated time:
+
+| Slide Duration | Words at 130 WPM | Typical Slide Type |
+|----------------|------------------|--------------------|
+| 30 seconds | ~65 words | Visual accent, blank_visual, section_divider |
+| 1 minute | ~130 words | Simple content, stat_callout, quote |
+| 1.5 minutes | ~195 words | Standard content slide |
+| 2 minutes | ~260 words | Data-heavy, complex content, demo introduction |
+
+### 2.3 Cumulative Timing Markers
+
+Every slide in the SpeakerNotes includes a `timing_marker` showing the cumulative time at the START of that slide. Format: `~MM:SS`.
+
+```
+Slide 1:  timing_marker: "~0:00"
+Slide 2:  timing_marker: "~0:30"
+Slide 5:  timing_marker: "~5:30"
+Slide 10: timing_marker: "~12:00"
+Slide 15: timing_marker: "~20:00"
+```
+
+These markers let the speaker track progress against the clock. They are approximate (`~`) because actual delivery pace varies.
+
+### 2.4 Duration Matching
+
+The total of all `estimated_seconds` across all slides MUST equal (within 5%) the talk duration from the TalkBrief. If the sum exceeds the target duration, the writer must trim notes content. If it falls short, notes are too thin and need expansion.
+
+**Validation formula:**
+
+```
+total_estimated_seconds = sum(note.estimated_seconds for note in notes)
+target_seconds = talk_brief.duration_minutes * 60
+drift = abs(total_estimated_seconds - target_seconds) / target_seconds
+assert drift <= 0.05  # 5% tolerance
+```
+
+### 2.5 Duration Allocation by Slide Type
+
+Not all slides get equal time. Structural slides are fast; content slides are slower:
+
+| Slide Type | Typical Duration | Rationale |
+|------------|-----------------|-----------|
+| `title` | 15-30s | On screen as audience settles; brief welcome |
+| `section_divider` | 10-20s | Pause for breath; transition phrase only |
+| `content` | 90-120s | Main speaking slide |
+| `two_column` | 90-120s | Compare/contrast needs explanation |
+| `image_feature` | 60-90s | Image does work; less spoken |
+| `data_chart` | 90-120s | Needs What + So What + Now What treatment |
+| `stat_callout` | 30-60s | Let the number land, then interpret |
+| `quote` | 30-45s | Read quote, add brief context |
+| `icon_grid` | 60-90s | Walk through icons briefly |
+| `diagram` | 90-120s | Walk through flow/architecture |
+| `closing` | 45-60s | CTA and sign-off |
+| `blank_visual` | 30-60s | Narrate over image; speaker's moment |
+
+---
+
+## 3. Cue Type Usage
+
+The SpeakerNotes schema defines 6 cue types. Each slide's `cues` array contains zero or more cues.
+
+### 3.1 When to Use Each Cue Type
+
+| Cue Type | Purpose | When to Insert | Example Text |
+|----------|---------|----------------|-------------|
+| `transition` | Connect the previous slide to this one | Start of every slide EXCEPT the first | "Building on that data point..." / "Now that we've seen the problem, let me show you how we solved it." |
+| `pause` | Deliberate silence for effect | After a striking statistic, after a quote, after revealing a key number on a stat_callout | "[pause 2 seconds for the number to land]" |
+| `audience_interaction` | Engage the audience directly | Within first 2 minutes (establish connection), every 8-10 minutes (attention reset), before introducing a solution (make the problem personal). Never during climax or conclusion. | "Show of hands -- who has experienced this?" / "Take 10 seconds to think about a time this happened to you." |
+| `emphasis` | Key point the speaker must stress | One per slide maximum. The single most important sentence or phrase. | "This is the number your CFO cares about." / "[SLOW DOWN] This is the most important point in the talk." |
+| `demo` | Live demonstration or screen switch | At the start of any demo segment. Paired with a corresponding "return to slides" cue on the next slide. | "Switch to terminal, run the command." / "Open the browser tab with the live dashboard." |
+| `build_animation` | Timed reveal of slide elements | When the slide uses progressive disclosure (e.g., revealing bullet points one at a time, or showing a second column after discussing the first) | "Click to reveal the second column." / "[CLICK] Advance to show the chart." |
+
+### 3.2 Cue Density Guidelines
+
+| Speaker Experience | Cues per Slide (typical) |
+|-------------------|-------------------------|
+| Novice | 2-4 (transition + emphasis + stage direction cues) |
+| Experienced | 1-2 (transition + one other when needed) |
+| Expert | 0-1 (only non-obvious cues: demo, build_animation) |
+
+### 3.3 Cue Placement Rules
+
+- **transition:** Always the FIRST cue for a slide (if present). It tells the speaker how to arrive at this slide.
+- **pause:** Placed AFTER the content that needs to sink in. Never at the start of a slide.
+- **audience_interaction:** Placed at the natural conversation break. Include the expected response handling ("Wait 5 seconds for show of hands. Acknowledge the response.").
+- **emphasis:** Placed inline with the text it modifies. Mark the specific word or phrase.
+- **demo:** Placed at the exact moment the speaker should switch context. Include what to open and where.
+- **build_animation:** Placed before the speaker begins talking about the element that will be revealed.
+
+---
+
+## 4. Autonomous Execution Scope
+
+After gathering the three preferences, the speaker-notes-writer produces the full SpeakerNotes (`./tmp/deck/speaker-notes.json`) without per-slide review.
+
+### 4.1 What the Writer Decides Autonomously
+
+- Per-slide note text (specific, actionable -- "Explain the three cost reduction strategies" not "Talk about this slide")
+- Per-slide timing allocation (estimated_seconds)
+- Cumulative timing markers
+- Cue selection and placement
+- Transition phrasing between slides
+- Emphasis markers on key phrases
+- Audience interaction placement (governed by the chosen interaction style)
+- Stage direction depth (governed by the chosen experience level)
+
+### 4.2 What the Writer Does NOT Decide
+
+- Slide order or content (comes from SlideOutline -- the writer follows it exactly)
+- Slide types or headlines (immutable from the outline)
+- Target speaking pace (default 130 WPM; could be overridden by TalkBrief preferences)
+- Talk duration (from TalkBrief -- the writer calibrates to it, not the reverse)
+
+### 4.3 Input Dependencies
+
+The speaker-notes-writer REQUIRES the SlideOutline to exist before it runs. The outline provides:
+- Slide order and count
+- Per-slide type, headline, body points
+- Narrative beat (governs emotional tone of notes)
+- Transition notes (the architect's structural transitions, which the writer converts to spoken phrases)
+
+### 4.4 Notes Structure Per Slide
+
+Each entry in the SpeakerNotes array follows this structure (from the schema):
+
+```json
+{
+  "slide_number": 5,
+  "text": "The key insight from our Q3 data is...",
+  "estimated_seconds": 90,
+  "timing_marker": "~8:00",
+  "cues": [
+    {"type": "transition", "text": "Building on the trends we just saw..."},
+    {"type": "emphasis", "text": "This is the number that changed our strategy."},
+    {"type": "pause", "text": "[pause 2 seconds after revealing the 73% figure]"}
+  ]
+}
+```
+
+---
+
+## 5. Notes Anti-Patterns
+
+- **Writing full scripts.** Notes are glance-able reminders, not teleprompter scripts. Full sentences encourage reading, which kills audience connection. Exception: sentence format chosen by speaker preference.
+- **Generic filler.** "Talk about this slide" or "Explain the chart" is useless. Notes must be specific: "Walk through the three cost drivers: licensing at 40%, compute at 35%, and support at 25%."
+- **Missing timing markers.** Every slide needs a cumulative timing marker. Without them, the speaker has no clock discipline.
+- **Missing transition cues.** Stumbling between slides is the most common delivery failure. Every slide (except the first) needs a transition cue.
+- **Forgetting core-moment rule.** Opening, closing, and key stories should be memorized. Notes for these slides should be minimal keywords, not detailed text. The speaker must have eye contact at critical moments.
+- **Overloading novice speakers with cues.** More than 4 cues per slide creates cognitive overload. Prioritize transition and emphasis; add others selectively.
+- **Duration drift.** If total estimated time exceeds the TalkBrief duration by more than 5%, content must be trimmed. Do not silently produce notes that run over.
+
+---
+
+## Sources
+
+- Research #08 (Narrative Arc & Conference Storytelling Patterns): Section 6 (Speaker Notes Intelligence -- WPM calibration, timing markers, transition cues, audience prompts, emphasis markers, notes structure template, anti-patterns)
+- Research #08: Section 3 (Invisible Slides -- audience interaction beats, section dividers, pause slides, the 10-minute attention reset rule)
+- Content Services L1 architecture document: speaker-notes-writer workflow, cue type table, collaborative preferences, data contracts
+- Schema: `src/schemas/speaker_notes.schema.json` (output contract)

--- a/src/content_validation.py
+++ b/src/content_validation.py
@@ -1,0 +1,97 @@
+"""Content validation utilities — timing arithmetic and reference integrity.
+
+This module handles ONLY machine-checkable validation:
+- Schema conformance (SlideOutline, SpeakerNotes)
+- Timing arithmetic (do note durations sum to talk duration?)
+- Reference integrity (layout templates, slide numbers)
+
+All narrative reasoning — arc selection, slide sequencing, headline quality,
+visual direction prose — is Claude's contextual reasoning in the SKILL.md,
+NOT codified rules here.
+"""
+
+import json
+import os
+
+import jsonschema
+
+SCHEMA_DIR = os.path.join(os.path.dirname(__file__), 'schemas')
+
+TIMING_TOLERANCE_PCT = 20  # Allow 20% deviation from target duration
+
+
+def validate_outline_schema(outline):
+    """Validate a SlideOutline dict against the JSON schema. Returns list of error messages."""
+    schema_path = os.path.join(SCHEMA_DIR, 'slide_outline.schema.json')
+    with open(schema_path) as f:
+        schema = json.load(f)
+    validator = jsonschema.Draft202012Validator(schema)
+    return [e.message for e in validator.iter_errors(outline)]
+
+
+def validate_notes_schema(notes):
+    """Validate a SpeakerNotes dict against the JSON schema. Returns list of error messages."""
+    schema_path = os.path.join(SCHEMA_DIR, 'speaker_notes.schema.json')
+    with open(schema_path) as f:
+        schema = json.load(f)
+    validator = jsonschema.Draft202012Validator(schema)
+    return [e.message for e in validator.iter_errors(notes)]
+
+
+def check_timing_total(notes, duration_minutes):
+    """Check that note durations sum to approximately the talk duration.
+
+    Returns list of issue strings. Tolerates TIMING_TOLERANCE_PCT deviation.
+    """
+    issues = []
+    total_seconds = 0
+    has_timing = False
+    for note in notes.get('notes', []):
+        est = note.get('estimated_seconds')
+        if est is not None:
+            total_seconds += est
+            has_timing = True
+
+    if not has_timing:
+        return []
+
+    target_seconds = duration_minutes * 60
+    deviation_pct = abs(total_seconds - target_seconds) / target_seconds * 100
+
+    if total_seconds > target_seconds * (1 + TIMING_TOLERANCE_PCT / 100):
+        issues.append(
+            f'Notes total {total_seconds}s ({total_seconds/60:.1f}min) exceeds '
+            f'talk duration {duration_minutes}min by {deviation_pct:.0f}%'
+        )
+    elif total_seconds < target_seconds * (1 - TIMING_TOLERANCE_PCT / 100):
+        issues.append(
+            f'Notes total {total_seconds}s ({total_seconds/60:.1f}min) under '
+            f'talk duration {duration_minutes}min by {deviation_pct:.0f}%'
+        )
+
+    return issues
+
+
+def check_notes_slide_references(notes, outline):
+    """Check that every note references a slide that exists in the outline."""
+    issues = []
+    outline_slides = {s['slide_number'] for s in outline.get('slides', [])}
+    for note in notes.get('notes', []):
+        sn = note.get('slide_number')
+        if sn is not None and sn not in outline_slides:
+            issues.append(f'Note references slide {sn} which does not exist in outline')
+    return issues
+
+
+def check_outline_layout_references(outline, style_guide):
+    """Check that every layout_template in the outline exists in the StyleGuide."""
+    issues = []
+    templates = style_guide.get('layout', {}).get('templates', {})
+    for slide in outline.get('slides', []):
+        lt = slide.get('layout_template')
+        if lt and lt not in templates:
+            issues.append(
+                f'Slide {slide["slide_number"]} references layout template '
+                f'"{lt}" which does not exist in StyleGuide'
+            )
+    return issues

--- a/tests/fixtures/talk_brief_lightning_5min.json
+++ b/tests/fixtures/talk_brief_lightning_5min.json
@@ -1,0 +1,24 @@
+{
+  "topic": "One Weird Trick That Cut Our Deploy Time by 80%",
+  "audience": "DevOps engineers and SREs at a meetup",
+  "duration_minutes": 5,
+  "tone": "conversational",
+  "key_takeaways": [
+    "Parallel test execution was the bottleneck, not build time"
+  ],
+  "preferences": {
+    "style": "minimalist",
+    "slide_count_hint": 8,
+    "image_backend": "ollama",
+    "resolution": "1080p",
+    "include_speaker_notes": true,
+    "include_charts": true
+  },
+  "data_sources": [
+    {
+      "label": "Deploy time before/after",
+      "type": "inline_json",
+      "content": "{\"before_minutes\": 45, \"after_minutes\": 9}"
+    }
+  ]
+}

--- a/tests/fixtures/talk_brief_technical_30min.json
+++ b/tests/fixtures/talk_brief_technical_30min.json
@@ -1,0 +1,25 @@
+{
+  "topic": "Building Fault-Tolerant Distributed Systems with Raft Consensus",
+  "audience": "Backend engineers familiar with distributed systems but new to consensus algorithms",
+  "duration_minutes": 30,
+  "tone": "technical",
+  "key_takeaways": [
+    "Raft is simpler than Paxos without sacrificing correctness",
+    "Leader election is the hardest part to get right",
+    "Log replication handles network partitions gracefully"
+  ],
+  "branding": {
+    "company_name": "Nexus Technologies",
+    "brand_id": "nexus-tech",
+    "compliance_mode": "guided"
+  },
+  "preferences": {
+    "style": "diagram-heavy",
+    "slide_count_hint": 25,
+    "image_backend": "ollama",
+    "resolution": "1080p",
+    "include_speaker_notes": true,
+    "include_charts": false
+  },
+  "data_sources": []
+}

--- a/tests/test_content_validation.py
+++ b/tests/test_content_validation.py
@@ -1,0 +1,154 @@
+"""Tests for content validation utilities — timing arithmetic and reference integrity."""
+
+import json
+import os
+import pytest
+
+from src.content_validation import (
+    validate_outline_schema,
+    validate_notes_schema,
+    check_timing_total,
+    check_notes_slide_references,
+    check_outline_layout_references,
+)
+
+FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
+
+
+def _load_fixture(name):
+    with open(os.path.join(FIXTURE_DIR, name)) as f:
+        return json.load(f)
+
+
+class TestValidateOutlineSchema:
+    def test_valid_outline_passes(self):
+        outline = _load_fixture('valid_slide_outline.json')
+        errors = validate_outline_schema(outline)
+        assert len(errors) == 0
+
+    def test_missing_slides_fails(self):
+        outline = {"narrative_arc": "test", "estimated_duration_minutes": 10}
+        errors = validate_outline_schema(outline)
+        assert len(errors) > 0
+
+
+class TestValidateNotesSchema:
+    def test_valid_notes_passes(self):
+        notes = _load_fixture('valid_speaker_notes.json')
+        errors = validate_notes_schema(notes)
+        assert len(errors) == 0
+
+    def test_missing_notes_array_fails(self):
+        notes = {"target_pace_wpm": 130}
+        errors = validate_notes_schema(notes)
+        assert len(errors) > 0
+
+
+class TestTimingTotal:
+    def test_timing_within_tolerance(self):
+        notes = {
+            "total_estimated_minutes": 10,
+            "notes": [
+                {"slide_number": 1, "text": "Hello", "estimated_seconds": 300},
+                {"slide_number": 2, "text": "World", "estimated_seconds": 300},
+            ]
+        }
+        issues = check_timing_total(notes, duration_minutes=10)
+        assert len(issues) == 0
+
+    def test_timing_too_long(self):
+        notes = {
+            "total_estimated_minutes": 30,
+            "notes": [
+                {"slide_number": 1, "text": "Hello", "estimated_seconds": 600},
+                {"slide_number": 2, "text": "World", "estimated_seconds": 600},
+                {"slide_number": 3, "text": "Extra", "estimated_seconds": 600},
+            ]
+        }
+        issues = check_timing_total(notes, duration_minutes=10)
+        assert len(issues) > 0
+        assert any('exceeds' in i.lower() or 'over' in i.lower() for i in issues)
+
+    def test_timing_without_seconds_skips(self):
+        notes = {
+            "notes": [
+                {"slide_number": 1, "text": "Hello"},
+            ]
+        }
+        issues = check_timing_total(notes, duration_minutes=10)
+        assert len(issues) == 0
+
+
+class TestNotesSlideReferences:
+    def test_valid_references(self):
+        outline = {
+            "slides": [
+                {"slide_number": 1, "slide_type": "title", "headline": "Hi"},
+                {"slide_number": 2, "slide_type": "content", "headline": "Body"},
+            ]
+        }
+        notes = {
+            "notes": [
+                {"slide_number": 1, "text": "Hello"},
+                {"slide_number": 2, "text": "World"},
+            ]
+        }
+        issues = check_notes_slide_references(notes, outline)
+        assert len(issues) == 0
+
+    def test_orphan_note_detected(self):
+        outline = {
+            "slides": [
+                {"slide_number": 1, "slide_type": "title", "headline": "Hi"},
+            ]
+        }
+        notes = {
+            "notes": [
+                {"slide_number": 1, "text": "Hello"},
+                {"slide_number": 99, "text": "Orphan"},
+            ]
+        }
+        issues = check_notes_slide_references(notes, outline)
+        assert len(issues) > 0
+        assert any('99' in i for i in issues)
+
+
+class TestOutlineLayoutReferences:
+    def test_valid_layout_references(self):
+        outline = {
+            "slides": [
+                {"slide_number": 1, "slide_type": "title", "headline": "Hi", "layout_template": "title"},
+                {"slide_number": 2, "slide_type": "content", "headline": "Body", "layout_template": "content"},
+            ]
+        }
+        style_guide = {
+            "layout": {
+                "templates": {"title": {}, "content": {}}
+            }
+        }
+        issues = check_outline_layout_references(outline, style_guide)
+        assert len(issues) == 0
+
+    def test_missing_template_detected(self):
+        outline = {
+            "slides": [
+                {"slide_number": 1, "slide_type": "title", "headline": "Hi", "layout_template": "nonexistent"},
+            ]
+        }
+        style_guide = {
+            "layout": {
+                "templates": {"title": {}, "content": {}}
+            }
+        }
+        issues = check_outline_layout_references(outline, style_guide)
+        assert len(issues) > 0
+
+    def test_no_layout_template_skips(self):
+        outline = {
+            "slides": [
+                {"slide_number": 1, "slide_type": "title", "headline": "Hi"},
+            ]
+        }
+        style_guide = {"layout": {"templates": {}}}
+        issues = check_outline_layout_references(outline, style_guide)
+        assert len(issues) == 0


### PR DESCRIPTION
## Summary

- **narrative-architect** skill: Two-stage collaborative workflow — proposes 2-3 narrative arc options from 16 researched structures, Speaker selects, then autonomous outline generation with punchy headlines, visual direction, and layout template references.
- **speaker-notes-writer** skill: Lightweight preference gathering (format, interaction style, experience level) then autonomous note generation with timing markers, transition cues, and audience interaction beats.
- **Content validation** (`src/content_validation.py`): Thin validation module — timing arithmetic (do durations sum to talk length?) and reference integrity (layout templates exist, slide numbers match). No codified arc selection or sequencing rules — that's Claude's contextual reasoning.
- 2 research synthesis documents, 2 extended TalkBrief fixtures, 12 new tests (366 total).

## Test plan

- [x] All 366 tests pass (354 existing + 12 new)
- [x] Timing total validation (within tolerance, too long, missing seconds)
- [x] Note-to-outline slide reference integrity
- [x] Outline-to-StyleGuide layout template references
- [x] Schema validation for SlideOutline and SpeakerNotes
- [ ] Review PR diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)