### PR TITLE
feat: image pipeline gaps — manifest utils, SVG rasterisation, upgrade planner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Claude Code skills and agents for conference-quality PowerPoint presentations. T
   - Start with `research/RESEARCH-INDEX.md` for fast lookup
   - Create `research/synthesis-[skill-name].md` before implementing any skill
 
-- **All Phases COMPLETE — 385 tests passing**
+- **All Phases COMPLETE — 401 tests passing**
   - Phase 1: Foundation — 38 tests
   - Phase 2: Design Services (brand-manager, slide-stylist) — 27 tests
   - Phase 3: Content Services (narrative-architect, speaker-notes-writer) — 12 tests
@@ -56,6 +56,9 @@ Claude Code skills and agents for conference-quality PowerPoint presentations. T
 | Schema tests (P2) | `tests/test_schemas.py` | 5 | Done |
 | Content validation | `src/content_validation.py` | 12 | Done |
 | Conductor utils | `src/conductor.py` | 19 | Done |
+| Manifest utilities | `src/manifest_utils.py` | 7 | Done |
+| SVG rasterisation | `src/process_image.py` | 23 | Done |
+| Production upgrade | `src/image_router.py` | 40 | Done |
 
 ### Architecture Summary
 

--- a/src/image_router.py
+++ b/src/image_router.py
@@ -29,6 +29,18 @@ RoutingDecision = namedtuple('RoutingDecision', [
     'is_fallback',     # whether this was a fallback choice
 ])
 
+UpgradeDecision = namedtuple('UpgradeDecision', [
+    'slide_number',
+    'image_id',
+    'action',           # 'upgrade' or 'keep'
+    'reason',
+    'draft_prompt',     # carried from draft manifest (None if absent)
+    'target_provider',  # provider for upgrade (None if keep)
+    'target_model',     # model for upgrade (None if keep)
+    'target_size',      # size string e.g. '1536x1024' (None if keep)
+    'estimated_cost_usd',
+])
+
 
 # --- Routing Matrix ---
 # Maps (visual_type, mode) -> list of RoutingTargets in priority order.
@@ -125,6 +137,12 @@ SLIDE_TYPE_TO_VISUAL_TYPE = {
 }
 
 VALID_VISUAL_TYPES = {'hero_image', 'icon_set', 'pattern_background', 'diagram', 'chart', 'none'}
+
+# Models/tools that already produce high-quality output
+_PRODUCTION_QUALITY_SOURCES = {'svg-convert', 'matplotlib', 'render_chart'}
+
+# Visual types that benefit from cloud upgrade
+_UPGRADEABLE_VISUAL_TYPES = {'hero_image', 'pattern_background', 'icon_set'}
 
 
 def classify_visual_type(slide):
@@ -316,3 +334,98 @@ def generate_placeholder_color(palette, visual_type):
     }
     key = colour_map.get(visual_type, 'primary')
     return palette.get(key, palette.get('primary', '333333'))
+
+
+def plan_production_upgrade(draft_manifest, outline, available_providers, budget_state):
+    """Plan which images to upgrade from draft to production quality.
+
+    Args:
+        draft_manifest: dict from image-manifest.json.
+        outline: dict from outline.json with 'slides' array.
+        available_providers: dict from provider_discovery.
+        budget_state: dict with 'budget_state' and 'remaining_usd'.
+
+    Returns:
+        list[UpgradeDecision]: One decision per manifest entry.
+    """
+    remaining = budget_state.get('remaining_usd', 0.0)
+    slide_types = {
+        s['slide_number']: classify_visual_type(s)
+        for s in outline.get('slides', [])
+    }
+
+    decisions = []
+    for entry in draft_manifest.get('images', []):
+        slide_num = entry.get('slide_number', 0)
+        image_id = entry.get('image_id', '')
+        model_used = entry.get('model_used', '')
+        visual_type = slide_types.get(slide_num, 'none')
+        draft_prompt = entry.get('source_prompt')
+
+        # Already production quality?
+        if model_used in _PRODUCTION_QUALITY_SOURCES:
+            decisions.append(UpgradeDecision(
+                slide_number=slide_num,
+                image_id=image_id,
+                action='keep',
+                reason=f'Already production quality ({model_used})',
+                draft_prompt=draft_prompt,
+                target_provider=None,
+                target_model=None,
+                target_size=None,
+                estimated_cost_usd=0.0,
+            ))
+            continue
+
+        # Not a type that benefits from upgrade?
+        if visual_type not in _UPGRADEABLE_VISUAL_TYPES:
+            decisions.append(UpgradeDecision(
+                slide_number=slide_num,
+                image_id=image_id,
+                action='keep',
+                reason=f'Visual type {visual_type} does not benefit from cloud upgrade',
+                draft_prompt=draft_prompt,
+                target_provider=None,
+                target_model=None,
+                target_size=None,
+                estimated_cost_usd=0.0,
+            ))
+            continue
+
+        # Find the best production route
+        route = route_slide(
+            {'slide_number': slide_num, 'visual_type': visual_type},
+            'production',
+            available_providers,
+            budget_state.get('budget_state', 'allow'),
+        )
+
+        # Budget check
+        if route.cost_per_image > remaining:
+            decisions.append(UpgradeDecision(
+                slide_number=slide_num,
+                image_id=image_id,
+                action='keep',
+                reason=f'Upgrade cost ${route.cost_per_image:.3f} exceeds remaining ${remaining:.2f}',
+                draft_prompt=draft_prompt,
+                target_provider=None,
+                target_model=None,
+                target_size=None,
+                estimated_cost_usd=0.0,
+            ))
+            continue
+
+        remaining -= route.cost_per_image
+        decisions.append(UpgradeDecision(
+            slide_number=slide_num,
+            image_id=image_id,
+            action='upgrade',
+            reason=f'{visual_type} benefits from cloud quality',
+            draft_prompt=draft_prompt,
+            target_provider=route.provider,
+            target_model=route.model,
+            target_size='1536x1024',
+            estimated_cost_usd=route.cost_per_image,
+        ))
+
+    return decisions

--- a/src/manifest_utils.py
+++ b/src/manifest_utils.py
@@ -1,0 +1,43 @@
+"""Manifest utilities for surgical image-manifest.json updates.
+
+Provides functions to load, update individual entries, and save
+the image manifest without requiring a full pipeline re-run.
+Uses process_image.py primitives for dimension/hash computation.
+"""
+
+import json
+import os
+
+
+def load_manifest(deck_dir):
+    """Load image-manifest.json from a deck directory.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+
+    Returns:
+        dict: The parsed manifest.
+
+    Raises:
+        FileNotFoundError: If manifest does not exist.
+    """
+    path = os.path.join(deck_dir, 'image-manifest.json')
+    if not os.path.exists(path):
+        raise FileNotFoundError(f'No image-manifest.json in {deck_dir}')
+    with open(path) as f:
+        return json.load(f)
+
+
+def save_manifest(deck_dir, manifest):
+    """Write image-manifest.json atomically.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+        manifest: The manifest dict to write.
+    """
+    path = os.path.join(deck_dir, 'image-manifest.json')
+    tmp_path = path + '.tmp'
+    with open(tmp_path, 'w') as f:
+        json.dump(manifest, f, indent=2)
+        f.write('\n')
+    os.replace(tmp_path, path)

--- a/src/manifest_utils.py
+++ b/src/manifest_utils.py
@@ -8,6 +8,8 @@ Uses process_image.py primitives for dimension/hash computation.
 import json
 import os
 
+from src.process_image import get_dimensions, compute_content_hash
+
 
 def load_manifest(deck_dir):
     """Load image-manifest.json from a deck directory.
@@ -41,3 +43,81 @@ def save_manifest(deck_dir, manifest):
         json.dump(manifest, f, indent=2)
         f.write('\n')
     os.replace(tmp_path, path)
+
+
+def _find_entry(manifest, *, image_id=None, slide_number=None):
+    """Find an entry in the manifest by image_id or slide_number."""
+    for entry in manifest.get('images', []):
+        if image_id and entry.get('image_id') == image_id:
+            return entry
+        if slide_number is not None and entry.get('slide_number') == slide_number:
+            return entry
+    key = image_id if image_id else f'slide {slide_number}'
+    raise KeyError(f'No manifest entry for {key}')
+
+
+def update_manifest_entry(deck_dir, image_id, model_used=None, alt_text=None):
+    """Update a single entry in the manifest by image_id.
+
+    Recomputes dimensions and content_hash from the file on disk.
+    Only updates model_used and alt_text if provided.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+        image_id: The image_id to update.
+        model_used: Optional new model attribution.
+        alt_text: Optional new alt text.
+
+    Returns:
+        dict: The updated entry.
+
+    Raises:
+        KeyError: If image_id not found.
+    """
+    manifest = load_manifest(deck_dir)
+    entry = _find_entry(manifest, image_id=image_id)
+
+    file_path = entry['file_path']
+    w, h = get_dimensions(file_path)
+    entry['dimensions'] = {'width': w, 'height': h}
+    entry['content_hash'] = compute_content_hash(file_path)
+
+    if model_used is not None:
+        entry['model_used'] = model_used
+    if alt_text is not None:
+        entry['alt_text'] = alt_text
+
+    save_manifest(deck_dir, manifest)
+    return entry
+
+
+def replace_image_in_manifest(deck_dir, slide_number, new_file_path, model_used, alt_text=None):
+    """Replace an image entry by slide_number with a new file.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+        slide_number: Slide number to update.
+        new_file_path: Path to the replacement image.
+        model_used: Model/tool attribution string.
+        alt_text: Optional new alt text.
+
+    Returns:
+        dict: The updated entry.
+
+    Raises:
+        KeyError: If slide_number not found.
+    """
+    manifest = load_manifest(deck_dir)
+    entry = _find_entry(manifest, slide_number=slide_number)
+
+    entry['file_path'] = new_file_path
+    w, h = get_dimensions(new_file_path)
+    entry['dimensions'] = {'width': w, 'height': h}
+    entry['content_hash'] = compute_content_hash(new_file_path)
+    entry['model_used'] = model_used
+
+    if alt_text is not None:
+        entry['alt_text'] = alt_text
+
+    save_manifest(deck_dir, manifest)
+    return entry

--- a/src/manifest_utils.py
+++ b/src/manifest_utils.py
@@ -121,3 +121,25 @@ def replace_image_in_manifest(deck_dir, slide_number, new_file_path, model_used,
 
     save_manifest(deck_dir, manifest)
     return entry
+
+
+def rebuild_manifest_hashes(deck_dir):
+    """Recompute dimensions and content_hash for every image in the manifest.
+
+    Useful after bulk image replacement (e.g., production re-render).
+
+    Args:
+        deck_dir: Path to the deck working directory.
+
+    Returns:
+        dict: The full updated manifest.
+    """
+    manifest = load_manifest(deck_dir)
+    for entry in manifest.get('images', []):
+        file_path = entry.get('file_path', '')
+        if os.path.exists(file_path):
+            w, h = get_dimensions(file_path)
+            entry['dimensions'] = {'width': w, 'height': h}
+            entry['content_hash'] = compute_content_hash(file_path)
+    save_manifest(deck_dir, manifest)
+    return manifest

--- a/src/process_image.py
+++ b/src/process_image.py
@@ -8,8 +8,14 @@ Does NOT use Real-ESRGAN (too slow on CPU — use Lanczos instead).
 
 import hashlib
 import os
+import shutil
+import subprocess
 
 from PIL import Image
+
+
+# Detect rsvg-convert at module load
+_RSVG_CONVERT_PATH = shutil.which('rsvg-convert')
 
 
 # ---------------------------------------------------------------------------
@@ -214,4 +220,51 @@ def optimize_png(image_path, output_path=None, quality=80):
         'original_size': original_size,
         'optimized_size': optimized_size,
         'savings_pct': savings_pct,
+    }
+
+
+def rasterize_svg(svg_path, output_path, width=2048, height=None, keep_aspect=True):
+    """Convert an SVG file to a PNG using rsvg-convert.
+
+    Args:
+        svg_path: Path to the source SVG file.
+        output_path: Where to save the PNG.
+        width: Target width in pixels.
+        height: Target height in pixels. If None and keep_aspect is True,
+                height is computed from the SVG's native aspect ratio.
+        keep_aspect: If True (default), maintain the SVG's aspect ratio.
+
+    Returns:
+        dict: {path, width, height, content_hash}
+
+    Raises:
+        FileNotFoundError: If svg_path does not exist.
+        RuntimeError: If rsvg-convert is not installed.
+    """
+    if not os.path.exists(svg_path):
+        raise FileNotFoundError(f'SVG not found: {svg_path}')
+    if _RSVG_CONVERT_PATH is None:
+        raise RuntimeError(
+            'rsvg-convert is not installed. '
+            'Install via: brew install librsvg (macOS) or apt install librsvg2-bin (Linux)'
+        )
+
+    cmd = [_RSVG_CONVERT_PATH, '-w', str(width)]
+    if height is not None:
+        cmd.extend(['-h', str(height)])
+    if keep_aspect:
+        cmd.append('--keep-aspect-ratio')
+    cmd.extend([svg_path, '-o', output_path])
+
+    os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
+    subprocess.run(cmd, check=True, capture_output=True)
+
+    w, h = get_dimensions(output_path)
+    content_hash = compute_content_hash(output_path)
+
+    return {
+        'path': output_path,
+        'width': w,
+        'height': h,
+        'content_hash': content_hash,
     }

--- a/tests/test_image_router.py
+++ b/tests/test_image_router.py
@@ -3,6 +3,7 @@
 import json
 import os
 import pytest
+from src.image_router import plan_production_upgrade, UpgradeDecision
 
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
 
@@ -283,3 +284,99 @@ class TestPlaceholderColor:
         palette = {'primary': '1A365D', 'secondary': '2B6CB0', 'background_alt': '1A202C'}
         colour = generate_placeholder_color(palette, 'icon_set')
         assert colour in ('1A365D', '2B6CB0')
+
+
+@pytest.fixture
+def draft_manifest():
+    return {
+        'images': [
+            {
+                'image_id': 'slide-01-hero_image',
+                'slide_number': 1,
+                'file_path': '/tmp/deck/images/slide-01-hero.png',
+                'status': 'generated',
+                'model_used': 'x/z-image-turbo',
+                'source_prompt': 'Dramatic teal composition',
+                'dimensions': {'width': 1024, 'height': 576},
+            },
+            {
+                'image_id': 'slide-04-diagram',
+                'slide_number': 4,
+                'file_path': '/tmp/deck/images/slide-04-diagram.png',
+                'status': 'generated',
+                'model_used': 'svg-convert',
+                'dimensions': {'width': 1705, 'height': 1536},
+            },
+            {
+                'image_id': 'slide-05-hero_image',
+                'slide_number': 5,
+                'file_path': '/tmp/deck/images/slide-05-hero.png',
+                'status': 'generated',
+                'model_used': 'x/z-image-turbo',
+                'source_prompt': 'Abstract collaboration',
+                'dimensions': {'width': 1024, 'height': 576},
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def upgrade_outline():
+    return {
+        'slides': [
+            {'slide_number': 1, 'visual_type': 'hero_image'},
+            {'slide_number': 4, 'visual_type': 'diagram'},
+            {'slide_number': 5, 'visual_type': 'hero_image'},
+        ],
+    }
+
+
+@pytest.fixture
+def all_providers():
+    return {
+        'ollama': {'available': True, 'models': ['x/z-image-turbo']},
+        'openai': {'available': True, 'model': 'gpt-image-1.5'},
+        'google': {'available': True, 'model': 'imagen-4'},
+        'fal': {'available': True, 'models': ['flux-2-pro']},
+    }
+
+
+@pytest.fixture
+def budget_allow():
+    return {'budget_state': 'allow', 'remaining_usd': 5.0}
+
+
+def test_plan_upgrade_upgrades_hero_images(draft_manifest, upgrade_outline, all_providers, budget_allow):
+    decisions = plan_production_upgrade(draft_manifest, upgrade_outline, all_providers, budget_allow)
+    heroes = [d for d in decisions if d.action == 'upgrade']
+    assert len(heroes) == 2
+    assert heroes[0].slide_number == 1
+    assert heroes[1].slide_number == 5
+
+
+def test_plan_upgrade_keeps_svg_diagrams(draft_manifest, upgrade_outline, all_providers, budget_allow):
+    decisions = plan_production_upgrade(draft_manifest, upgrade_outline, all_providers, budget_allow)
+    kept = [d for d in decisions if d.action == 'keep']
+    assert len(kept) == 1
+    assert kept[0].slide_number == 4
+    assert 'already' in kept[0].reason.lower()
+
+
+def test_plan_upgrade_respects_budget(draft_manifest, upgrade_outline, all_providers):
+    tight_budget = {'budget_state': 'allow', 'remaining_usd': 0.02}
+    decisions = plan_production_upgrade(draft_manifest, upgrade_outline, all_providers, tight_budget)
+    upgrades = [d for d in decisions if d.action == 'upgrade']
+    total_cost = sum(d.estimated_cost_usd for d in upgrades)
+    assert total_cost <= 0.02
+
+
+def test_plan_upgrade_carries_source_prompt(draft_manifest, upgrade_outline, all_providers, budget_allow):
+    decisions = plan_production_upgrade(draft_manifest, upgrade_outline, all_providers, budget_allow)
+    slide_1 = [d for d in decisions if d.slide_number == 1][0]
+    assert slide_1.draft_prompt == 'Dramatic teal composition'
+
+
+def test_plan_upgrade_returns_upgrade_decisions(draft_manifest, upgrade_outline, all_providers, budget_allow):
+    decisions = plan_production_upgrade(draft_manifest, upgrade_outline, all_providers, budget_allow)
+    assert all(isinstance(d, UpgradeDecision) for d in decisions)
+    assert len(decisions) == 3

--- a/tests/test_manifest_utils.py
+++ b/tests/test_manifest_utils.py
@@ -1,0 +1,70 @@
+"""Tests for manifest utilities."""
+
+import json
+import os
+import shutil
+import tempfile
+
+import pytest
+from PIL import Image
+
+
+@pytest.fixture
+def deck_dir():
+    d = tempfile.mkdtemp()
+    os.makedirs(os.path.join(d, 'images'), exist_ok=True)
+    yield d
+    shutil.rmtree(d)
+
+
+@pytest.fixture
+def sample_image(deck_dir):
+    """Create a 200x100 red PNG in the deck images dir."""
+    path = os.path.join(deck_dir, 'images', 'slide-01-hero.png')
+    img = Image.new('RGB', (200, 100), color=(255, 0, 0))
+    img.save(path)
+    return path
+
+
+@pytest.fixture
+def sample_manifest(deck_dir, sample_image):
+    """Write a minimal valid image-manifest.json."""
+    manifest = {
+        'images': [
+            {
+                'image_id': 'slide-01-hero_image',
+                'slide_number': 1,
+                'file_path': sample_image,
+                'status': 'generated',
+                'dimensions': {'width': 200, 'height': 100},
+                'model_used': 'x/z-image-turbo',
+                'alt_text': 'Test image',
+                'content_hash': 'abc123',
+            }
+        ],
+        'summary': {
+            'total_images': 1,
+            'generated_count': 1,
+            'cached_count': 0,
+            'placeholder_count': 0,
+            'failed_count': 0,
+            'total_generation_seconds': 0.0,
+        },
+    }
+    manifest_path = os.path.join(deck_dir, 'image-manifest.json')
+    with open(manifest_path, 'w') as f:
+        json.dump(manifest, f)
+    return manifest_path
+
+
+def test_load_manifest(deck_dir, sample_manifest):
+    from src.manifest_utils import load_manifest
+    manifest = load_manifest(deck_dir)
+    assert len(manifest['images']) == 1
+    assert manifest['images'][0]['image_id'] == 'slide-01-hero_image'
+
+
+def test_load_manifest_missing_file(deck_dir):
+    from src.manifest_utils import load_manifest
+    with pytest.raises(FileNotFoundError):
+        load_manifest(deck_dir)

--- a/tests/test_manifest_utils.py
+++ b/tests/test_manifest_utils.py
@@ -68,3 +68,54 @@ def test_load_manifest_missing_file(deck_dir):
     from src.manifest_utils import load_manifest
     with pytest.raises(FileNotFoundError):
         load_manifest(deck_dir)
+
+
+def test_update_manifest_entry(deck_dir, sample_manifest, sample_image):
+    from src.manifest_utils import load_manifest, update_manifest_entry
+    entry = update_manifest_entry(
+        deck_dir,
+        image_id='slide-01-hero_image',
+        model_used='openai/gpt-image-1.5',
+        alt_text='Updated alt text',
+    )
+    assert entry['model_used'] == 'openai/gpt-image-1.5'
+    assert entry['alt_text'] == 'Updated alt text'
+    assert entry['dimensions'] == {'width': 200, 'height': 100}
+    assert len(entry['content_hash']) == 64  # SHA-256 hex
+
+    # Verify persisted
+    manifest = load_manifest(deck_dir)
+    assert manifest['images'][0]['model_used'] == 'openai/gpt-image-1.5'
+
+
+def test_update_manifest_entry_unknown_id(deck_dir, sample_manifest):
+    from src.manifest_utils import update_manifest_entry
+    with pytest.raises(KeyError, match='no-such-id'):
+        update_manifest_entry(deck_dir, image_id='no-such-id')
+
+
+def test_replace_image_in_manifest(deck_dir, sample_manifest, sample_image):
+    from src.manifest_utils import load_manifest, replace_image_in_manifest
+    # Create a new replacement image
+    new_path = os.path.join(deck_dir, 'images', 'slide-01-hero-v2.png')
+    img = Image.new('RGB', (400, 300), color=(0, 255, 0))
+    img.save(new_path)
+
+    entry = replace_image_in_manifest(
+        deck_dir,
+        slide_number=1,
+        new_file_path=new_path,
+        model_used='svg-convert',
+    )
+    assert entry['file_path'] == new_path
+    assert entry['dimensions'] == {'width': 400, 'height': 300}
+    assert entry['model_used'] == 'svg-convert'
+
+    manifest = load_manifest(deck_dir)
+    assert manifest['images'][0]['file_path'] == new_path
+
+
+def test_replace_image_unknown_slide(deck_dir, sample_manifest):
+    from src.manifest_utils import replace_image_in_manifest
+    with pytest.raises(KeyError, match='slide 99'):
+        replace_image_in_manifest(deck_dir, slide_number=99, new_file_path='/x', model_used='test')

--- a/tests/test_manifest_utils.py
+++ b/tests/test_manifest_utils.py
@@ -119,3 +119,19 @@ def test_replace_image_unknown_slide(deck_dir, sample_manifest):
     from src.manifest_utils import replace_image_in_manifest
     with pytest.raises(KeyError, match='slide 99'):
         replace_image_in_manifest(deck_dir, slide_number=99, new_file_path='/x', model_used='test')
+
+
+def test_rebuild_manifest_hashes(deck_dir, sample_manifest, sample_image):
+    from src.manifest_utils import load_manifest, rebuild_manifest_hashes
+    from src.process_image import compute_content_hash
+
+    result = rebuild_manifest_hashes(deck_dir)
+    assert len(result['images']) == 1
+
+    expected_hash = compute_content_hash(sample_image)
+    assert result['images'][0]['content_hash'] == expected_hash
+    assert result['images'][0]['dimensions'] == {'width': 200, 'height': 100}
+
+    # Verify persisted
+    manifest = load_manifest(deck_dir)
+    assert manifest['images'][0]['content_hash'] == expected_hash

--- a/tests/test_process_image.py
+++ b/tests/test_process_image.py
@@ -194,3 +194,49 @@ class TestOptimizePng:
         img = Image.open(result['path'])
         assert img.size[0] > 0
         assert img.size[1] > 0
+
+
+@pytest.fixture
+def test_svg(tmp_dir):
+    """Create a minimal valid SVG file."""
+    path = os.path.join(tmp_dir, 'test.svg')
+    with open(path, 'w') as f:
+        f.write(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300">'
+            '<rect width="400" height="300" fill="#006B5E"/>'
+            '</svg>'
+        )
+    return path
+
+
+def test_rasterize_svg_basic(tmp_dir, test_svg):
+    from src.process_image import rasterize_svg
+    output = os.path.join(tmp_dir, 'output.png')
+    result = rasterize_svg(test_svg, output, width=800)
+    assert result['path'] == output
+    assert os.path.exists(output)
+    assert result['width'] == 800
+    assert result['height'] == 600  # maintains 4:3 aspect
+    assert len(result['content_hash']) == 64
+
+
+def test_rasterize_svg_explicit_height(tmp_dir, test_svg):
+    from src.process_image import rasterize_svg
+    output = os.path.join(tmp_dir, 'output.png')
+    result = rasterize_svg(test_svg, output, width=800, height=800, keep_aspect=False)
+    assert result['width'] == 800
+    assert result['height'] == 800
+
+
+def test_rasterize_svg_missing_file(tmp_dir):
+    from src.process_image import rasterize_svg
+    with pytest.raises(FileNotFoundError):
+        rasterize_svg('/no/such/file.svg', os.path.join(tmp_dir, 'out.png'))
+
+
+def test_rasterize_svg_no_rsvg(tmp_dir, test_svg, monkeypatch):
+    from src import process_image
+    monkeypatch.setattr(process_image, '_RSVG_CONVERT_PATH', None)
+    output = os.path.join(tmp_dir, 'output.png')
+    with pytest.raises(RuntimeError, match='rsvg-convert'):
+        process_image.rasterize_svg(test_svg, output)


### PR DESCRIPTION
## Summary
- Add `src/manifest_utils.py` — surgical image-manifest.json updates (load, save, update entry by ID or slide number, rebuild all hashes)
- Add `rasterize_svg()` to `src/process_image.py` — convert SVG diagrams to deck-ready PNGs via rsvg-convert
- Add `plan_production_upgrade()` to `src/image_router.py` — plan which draft images to upgrade to cloud quality, respecting budget and skipping already-production assets

## Test plan
- [x] 16 new tests (7 manifest, 4 SVG, 5 upgrade planner)
- [x] Full suite: 401 tests pass (385 existing + 16 new)
- [x] SVG rasterisation verified with real rsvg-convert on macOS
- [x] All TDD — tests written first, verified red, then green

🤖 Generated with [Claude Code](https://claude.com/claude-code)