### PR TITLE
feat: keynote Sub-plan A — strategy map, prompt composer, prompt engineer agent

### DIFF
--- a/.claude/agents/prompt-engineer.md
+++ b/.claude/agents/prompt-engineer.md
@@ -1,0 +1,74 @@
+---
+name: prompt-engineer
+description: Transforms structured slide briefs into creative image generation prompts. Composes spatial relationships, visual metaphors, and scene descriptions. Dispatched at Haiku by default, Sonnet on escalation.
+tools: Read, Grep, Glob
+---
+
+# Prompt Engineer
+
+You are the Prompt Engineer — an AI Persona that transforms structured slide briefs into creative image generation prompts for conference-quality presentation slides.
+
+## Identity
+
+**Persona ID:** persona-prompt-engineer
+**Service ID:** image-prompt-engineer
+**Authority Model:** Invoker
+**Default Model:** Haiku (escalated to Sonnet when quality doesn't converge)
+
+## Input
+
+You receive a **structured brief** as a JSON object with these fields:
+
+| Field | Description |
+|-------|-------------|
+| `slide_number` | Which slide this is for |
+| `strategy` | `full_render` (entire slide as image) or `backdrop_render` (visual background only) |
+| `headline` | The slide's headline text |
+| `body_points` | Array of bullet point strings |
+| `visual_direction` | Creative direction from the narrative architect |
+| `slide_type` | title, content, section_divider, closing, etc. |
+| `brand_constraints.palette_hex` | Brand colour hex values to use |
+| `brand_constraints.approved_styles` | Approved image styles |
+| `brand_constraints.prohibited_styles` | Styles to avoid |
+| `style_tokens` | Mood, style modifiers from the StyleGuide |
+| `funnel_stage` | ollama, cloud_low, or cloud_full |
+| `target_resolution` | Target image dimensions |
+| `text_instruction` | Whether to include or exclude text in the image |
+
+## Output
+
+Return a single string: the image generation prompt. Nothing else.
+
+## Prompt Composition Rules
+
+### For `full_render` strategy:
+
+1. **Scene description first** — Describe the overall visual composition, mood, and spatial layout
+2. **Text placement** — Specify where the headline appears (e.g., "bold white sans-serif headline top-left reading '[exact headline text]'")
+3. **Body text** — If body points exist, describe their placement and styling
+4. **Visual elements** — Describe the illustration, imagery, or abstract visuals
+5. **Brand colours** — Include exact hex values from palette_hex (e.g., "deep teal #006B5E")
+6. **Technical specs** — End with: aspect ratio, style descriptors, "professional conference keynote slide"
+
+### For `backdrop_render` strategy:
+
+1. **Scene description** — Describe the visual composition
+2. **Safe zone** — Explicitly state where text will be overlaid (e.g., "left third is a darker region reserved for text overlay")
+3. **No text** — Include "no text, no labels, no words, no typography" in the prompt
+4. **Visual elements** — Describe the background illustration/imagery
+5. **Brand colours** — Include hex values
+6. **Technical specs** — End with: aspect ratio, "presentation background", "clean space for text overlay"
+
+### Funnel stage adaptations:
+
+- **ollama** — Simpler prompts. Focus on composition and concept. Skip fine typography details (Ollama can't handle them). Keep under 100 words.
+- **cloud_low** — Full prompt detail. Include all text, colours, spatial relationships. This validates the prompt works on the target model.
+- **cloud_full** — Same prompt as cloud_low. Do not change the prompt between cloud_low and cloud_full — the point is to render a proven prompt at higher resolution.
+
+## Prohibited
+
+- Do not generate images — only produce text prompts
+- Do not modify the brief or any DeckContext contract
+- Do not add text content that isn't in the brief (don't invent headlines or bullet points)
+- Do not include brand-prohibited styles
+- Do not produce prompts longer than 200 words

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Claude Code skills and agents for conference-quality PowerPoint presentations. T
   - Start with `research/RESEARCH-INDEX.md` for fast lookup
   - Create `research/synthesis-[skill-name].md` before implementing any skill
 
-- **All Phases COMPLETE — 401 tests passing**
+- **All Phases COMPLETE — 425 tests passing**
   - Phase 1: Foundation — 38 tests
   - Phase 2: Design Services (brand-manager, slide-stylist) — 27 tests
   - Phase 3: Content Services (narrative-architect, speaker-notes-writer) — 12 tests
@@ -59,6 +59,9 @@ Claude Code skills and agents for conference-quality PowerPoint presentations. T
 | Manifest utilities | `src/manifest_utils.py` | 7 | Done |
 | SVG rasterisation | `src/process_image.py` | 23 | Done |
 | Production upgrade | `src/image_router.py` | 40 | Done |
+| Strategy Map schema | `src/schemas/strategy_map.schema.json` | 4 | Done |
+| Slide prompt composer | `src/slide_prompt_composer.py` | 20 | Done |
+| Prompt engineer agent | `.claude/agents/prompt-engineer.md` | -- | Done |
 
 ### Architecture Summary
 

--- a/src/schemas/strategy_map.schema.json
+++ b/src/schemas/strategy_map.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jack-tar.dev/schemas/strategy-map.json",
+  "title": "StrategyMap",
+  "description": "Per-slide rendering strategy classification for keynote pipeline.",
+  "type": "object",
+  "required": ["approval_mode", "slides"],
+  "properties": {
+    "created_at": {"type": "string"},
+    "approval_mode": {
+      "type": "string",
+      "enum": ["review", "one_shot"]
+    },
+    "slides": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["slide_number", "strategy", "rationale", "render_funnel"],
+        "properties": {
+          "slide_number": {"type": "integer", "minimum": 1},
+          "strategy": {
+            "type": "string",
+            "enum": ["full_render", "backdrop_render", "composed"]
+          },
+          "rationale": {"type": "string"},
+          "render_funnel": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["ollama", "cloud_low", "cloud_full"]
+            }
+          },
+          "speaker_override": {
+            "type": ["string", "null"],
+            "enum": ["full_render", "backdrop_render", "composed", null]
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/slide_prompt_composer.py
+++ b/src/slide_prompt_composer.py
@@ -9,7 +9,14 @@ Strategy classification is deterministic Python logic. Prompt generation
 is delegated to the Prompt Engineer agent (LLM reasoning).
 """
 
+import json
+import os
+
+import jsonschema
+
 from src.image_router import classify_visual_type
+
+_SCHEMA_DIR = os.path.join(os.path.dirname(__file__), 'schemas')
 
 
 # Slide types that work well as full AI-rendered images (short text, visual impact)
@@ -167,3 +174,60 @@ def assemble_brief(slide, strategy, style_guide, brand_profile, funnel_stage):
         brief['text_instruction'] = f'Include headline text: "{slide.get("headline", "")}"'
 
     return brief
+
+
+def _validate_strategy_map(strategy_map):
+    """Validate a strategy map against the JSON schema.
+
+    Args:
+        strategy_map: dict to validate.
+
+    Raises:
+        jsonschema.ValidationError: If the strategy map does not conform to the schema.
+    """
+    schema_path = os.path.join(_SCHEMA_DIR, 'strategy_map.schema.json')
+    with open(schema_path) as f:
+        schema = json.load(f)
+    jsonschema.Draft202012Validator(schema).validate(strategy_map)
+
+
+def save_strategy_map(deck_dir, strategy_map):
+    """Save a strategy map to the DeckContext directory.
+
+    Validates against the StrategyMap schema before writing.
+    Uses an atomic write (write to .tmp then os.replace) to avoid
+    partial writes.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+        strategy_map: dict conforming to StrategyMap schema.
+
+    Raises:
+        jsonschema.ValidationError: If strategy_map is invalid.
+    """
+    _validate_strategy_map(strategy_map)
+    path = os.path.join(deck_dir, 'strategy-map.json')
+    tmp_path = path + '.tmp'
+    with open(tmp_path, 'w') as f:
+        json.dump(strategy_map, f, indent=2)
+        f.write('\n')
+    os.replace(tmp_path, path)
+
+
+def load_strategy_map(deck_dir):
+    """Load a strategy map from the DeckContext directory.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+
+    Returns:
+        dict: The parsed strategy map.
+
+    Raises:
+        FileNotFoundError: If strategy-map.json does not exist in deck_dir.
+    """
+    path = os.path.join(deck_dir, 'strategy-map.json')
+    if not os.path.exists(path):
+        raise FileNotFoundError(f'No strategy-map.json in {deck_dir}')
+    with open(path) as f:
+        return json.load(f)

--- a/src/slide_prompt_composer.py
+++ b/src/slide_prompt_composer.py
@@ -111,3 +111,59 @@ def build_strategy_map(outline, approval_mode='review', overrides=None):
         'approval_mode': approval_mode,
         'slides': slides,
     }
+
+
+# Resolution targets per funnel stage
+_RESOLUTIONS = {
+    'ollama': '1024x576',
+    'cloud_low': '1280x720',
+    'cloud_full': '1920x1080',
+}
+
+
+def assemble_brief(slide, strategy, style_guide, brand_profile, funnel_stage):
+    """Assemble a structured brief for the Prompt Engineer agent.
+
+    Args:
+        slide: dict from SlideOutline slides array.
+        strategy: 'full_render' or 'backdrop_render'.
+        style_guide: dict from StyleGuide contract.
+        brand_profile: dict from BrandProfile contract (or None).
+        funnel_stage: 'ollama', 'cloud_low', or 'cloud_full'.
+
+    Returns:
+        dict: Structured brief with all context the Prompt Engineer needs.
+    """
+    palette = style_guide.get('palette', {})
+    palette_hex = [v for v in palette.values() if isinstance(v, str) and len(v) == 6]
+
+    brand_constraints = {
+        'palette_hex': palette_hex,
+        'approved_styles': [],
+        'prohibited_styles': [],
+    }
+    if brand_profile:
+        brand_constraints['approved_styles'] = brand_profile.get('approved_image_styles', [])
+        brand_constraints['prohibited_styles'] = brand_profile.get('prohibited_image_styles', [])
+
+    style_tokens = style_guide.get('image_style_tokens', {})
+
+    brief = {
+        'slide_number': slide.get('slide_number', 0),
+        'strategy': strategy,
+        'headline': slide.get('headline', ''),
+        'body_points': slide.get('body_points', []),
+        'visual_direction': slide.get('visual_direction', ''),
+        'slide_type': slide.get('slide_type', 'content'),
+        'brand_constraints': brand_constraints,
+        'style_tokens': style_tokens,
+        'funnel_stage': funnel_stage,
+        'target_resolution': _RESOLUTIONS.get(funnel_stage, '1920x1080'),
+    }
+
+    if strategy == 'backdrop_render':
+        brief['text_instruction'] = 'NO TEXT in the image \u2014 leave clean space for text overlay'
+    elif strategy == 'full_render':
+        brief['text_instruction'] = f'Include headline text: "{slide.get("headline", "")}"'
+
+    return brief

--- a/src/slide_prompt_composer.py
+++ b/src/slide_prompt_composer.py
@@ -73,3 +73,41 @@ def classify_slide_strategy(slide):
         'render_funnel': ['ollama', 'cloud_low', 'cloud_full'],
         'speaker_override': None,
     }
+
+
+from datetime import datetime, timezone
+
+
+def build_strategy_map(outline, approval_mode='review', overrides=None):
+    """Build a complete StrategyMap from a SlideOutline.
+
+    Args:
+        outline: dict from SlideOutline (must have 'slides' array).
+        approval_mode: 'review' (default) or 'one_shot'.
+        overrides: Optional dict of {slide_number: strategy} Speaker overrides.
+
+    Returns:
+        dict conforming to StrategyMap schema.
+    """
+    overrides = overrides or {}
+    slides = []
+
+    for slide in outline.get('slides', []):
+        entry = classify_slide_strategy(slide)
+        slide_num = entry['slide_number']
+
+        if slide_num in overrides:
+            entry['speaker_override'] = overrides[slide_num]
+            # Override also sets the render funnel for the new strategy
+            if overrides[slide_num] in ('full_render', 'backdrop_render'):
+                entry['render_funnel'] = ['ollama', 'cloud_low', 'cloud_full']
+            else:
+                entry['render_funnel'] = ['ollama']
+
+        slides.append(entry)
+
+    return {
+        'created_at': datetime.now(timezone.utc).isoformat(),
+        'approval_mode': approval_mode,
+        'slides': slides,
+    }

--- a/src/slide_prompt_composer.py
+++ b/src/slide_prompt_composer.py
@@ -1,0 +1,75 @@
+"""Slide prompt composer — strategy classification and structured brief assembly.
+
+Analyses each slide in a SlideOutline and:
+1. Classifies its rendering strategy (full_render, backdrop_render, composed)
+2. Assembles structured briefs for the Prompt Engineer agent
+3. Validates output prompts contain required brand elements
+
+Strategy classification is deterministic Python logic. Prompt generation
+is delegated to the Prompt Engineer agent (LLM reasoning).
+"""
+
+from src.image_router import classify_visual_type
+
+
+# Slide types that work well as full AI-rendered images (short text, visual impact)
+_FULL_RENDER_TYPES = {'title', 'section_divider', 'closing', 'blank_visual', 'quote'}
+
+# Slide types that must stay programmatic (precise text, data, labels)
+_COMPOSED_TYPES = {'data_chart', 'diagram', 'code'}
+
+# Maximum body points before a content slide should use backdrop instead of full render
+_BACKDROP_BULLET_THRESHOLD = 2
+
+
+def classify_slide_strategy(slide):
+    """Classify a slide's recommended rendering strategy.
+
+    Args:
+        slide: dict from SlideOutline slides array.
+
+    Returns:
+        dict with keys: slide_number, strategy, rationale, render_funnel, speaker_override
+    """
+    slide_number = slide.get('slide_number', 0)
+    slide_type = slide.get('slide_type', 'content')
+    body_points = slide.get('body_points', [])
+    visual_type = classify_visual_type(slide)
+
+    # Charts and diagrams must stay composed (precise text/labels)
+    if slide_type in _COMPOSED_TYPES or visual_type == 'chart':
+        return {
+            'slide_number': slide_number,
+            'strategy': 'composed',
+            'rationale': f'{slide_type} slide requires precise text/label rendering — programmatic assembly',
+            'render_funnel': ['ollama'],
+            'speaker_override': None,
+        }
+
+    # Short-text slide types are ideal for full render
+    if slide_type in _FULL_RENDER_TYPES:
+        return {
+            'slide_number': slide_number,
+            'strategy': 'full_render',
+            'rationale': f'{slide_type} slide with short text — ideal for full AI generation',
+            'render_funnel': ['ollama', 'cloud_low', 'cloud_full'],
+            'speaker_override': None,
+        }
+
+    # Content slides: backdrop if dense text, full render if sparse
+    if len(body_points) > _BACKDROP_BULLET_THRESHOLD:
+        return {
+            'slide_number': slide_number,
+            'strategy': 'backdrop_render',
+            'rationale': f'Content slide with {len(body_points)} bullet points — AI background with programmatic text overlay',
+            'render_funnel': ['ollama', 'cloud_low', 'cloud_full'],
+            'speaker_override': None,
+        }
+
+    return {
+        'slide_number': slide_number,
+        'strategy': 'full_render',
+        'rationale': f'Content slide with {len(body_points)} bullet points — sparse enough for full AI generation',
+        'render_funnel': ['ollama', 'cloud_low', 'cloud_full'],
+        'speaker_override': None,
+    }

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -3,6 +3,7 @@
 import json
 import os
 import pytest
+import jsonschema
 from jsonschema import validate, ValidationError
 
 SCHEMA_DIR = os.path.join(os.path.dirname(__file__), '..', 'src', 'schemas')
@@ -275,3 +276,67 @@ class TestTalkBriefBrandingExtensions:
         schema = load_schema('talk_brief')
         with pytest.raises(ValidationError):
             validate(instance=brief, schema=schema)
+
+
+class TestStrategyMapSchema:
+    @pytest.fixture
+    def schema(self):
+        with open('src/schemas/strategy_map.schema.json') as f:
+            return json.load(f)
+
+    def test_valid_strategy_map(self, schema):
+        data = {
+            "created_at": "2026-03-29T12:00:00Z",
+            "approval_mode": "review",
+            "slides": [
+                {
+                    "slide_number": 1,
+                    "strategy": "full_render",
+                    "rationale": "Title slide with dramatic visual",
+                    "render_funnel": ["ollama", "cloud_low", "cloud_full"],
+                    "speaker_override": None
+                }
+            ]
+        }
+        jsonschema.Draft202012Validator(schema).validate(data)
+
+    def test_invalid_strategy_fails(self, schema):
+        data = {
+            "created_at": "2026-03-29T12:00:00Z",
+            "approval_mode": "review",
+            "slides": [
+                {
+                    "slide_number": 1,
+                    "strategy": "invalid_strategy",
+                    "rationale": "Test",
+                    "render_funnel": ["ollama"]
+                }
+            ]
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.Draft202012Validator(schema).validate(data)
+
+    def test_invalid_approval_mode_fails(self, schema):
+        data = {
+            "created_at": "2026-03-29T12:00:00Z",
+            "approval_mode": "invalid",
+            "slides": []
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.Draft202012Validator(schema).validate(data)
+
+    def test_invalid_funnel_stage_fails(self, schema):
+        data = {
+            "created_at": "2026-03-29T12:00:00Z",
+            "approval_mode": "review",
+            "slides": [
+                {
+                    "slide_number": 1,
+                    "strategy": "composed",
+                    "rationale": "Test",
+                    "render_funnel": ["invalid_stage"]
+                }
+            ]
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.Draft202012Validator(schema).validate(data)

--- a/tests/test_slide_prompt_composer.py
+++ b/tests/test_slide_prompt_composer.py
@@ -2,6 +2,8 @@
 
 import json
 import os
+import shutil
+import tempfile
 import pytest
 
 
@@ -185,3 +187,32 @@ def test_assemble_brief_includes_style_tokens(sample_outline, sample_style_guide
     slide = sample_outline["slides"][0]
     brief = assemble_brief(slide, "full_render", sample_style_guide, sample_brand_profile, "ollama")
     assert "Professional, precise" in brief["style_tokens"]["mood"]
+
+
+@pytest.fixture
+def deck_dir():
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d)
+
+
+def test_save_and_load_strategy_map(deck_dir, sample_outline):
+    from src.slide_prompt_composer import build_strategy_map, save_strategy_map, load_strategy_map
+    strategy_map = build_strategy_map(sample_outline)
+    save_strategy_map(deck_dir, strategy_map)
+    loaded = load_strategy_map(deck_dir)
+    assert loaded["approval_mode"] == "review"
+    assert len(loaded["slides"]) == 6
+
+
+def test_save_strategy_map_validates_schema(deck_dir):
+    from src.slide_prompt_composer import save_strategy_map
+    bad_map = {"approval_mode": "invalid", "slides": []}
+    with pytest.raises(Exception):
+        save_strategy_map(deck_dir, bad_map)
+
+
+def test_load_strategy_map_missing_file(deck_dir):
+    from src.slide_prompt_composer import load_strategy_map
+    with pytest.raises(FileNotFoundError):
+        load_strategy_map(deck_dir)

--- a/tests/test_slide_prompt_composer.py
+++ b/tests/test_slide_prompt_composer.py
@@ -142,3 +142,46 @@ def test_build_strategy_map_one_shot_mode(sample_outline):
     from src.slide_prompt_composer import build_strategy_map
     result = build_strategy_map(sample_outline, approval_mode="one_shot")
     assert result["approval_mode"] == "one_shot"
+
+
+def test_assemble_brief_full_render(sample_outline, sample_style_guide, sample_brand_profile):
+    from src.slide_prompt_composer import assemble_brief
+    slide = sample_outline["slides"][0]  # title slide
+    brief = assemble_brief(slide, "full_render", sample_style_guide, sample_brand_profile, "ollama")
+    assert brief["slide_number"] == 1
+    assert brief["strategy"] == "full_render"
+    assert brief["headline"] == "Big Title"
+    assert "006B5E" in brief["brand_constraints"]["palette_hex"]
+    assert "clip art" in brief["brand_constraints"]["prohibited_styles"]
+    assert brief["funnel_stage"] == "ollama"
+    assert brief["target_resolution"] == "1024x576"
+
+
+def test_assemble_brief_backdrop_excludes_text(sample_outline, sample_style_guide, sample_brand_profile):
+    from src.slide_prompt_composer import assemble_brief
+    slide = sample_outline["slides"][1]  # content slide with 4 bullets
+    brief = assemble_brief(slide, "backdrop_render", sample_style_guide, sample_brand_profile, "cloud_full")
+    assert brief["strategy"] == "backdrop_render"
+    assert brief["text_instruction"] == "NO TEXT in the image — leave clean space for text overlay"
+    assert brief["target_resolution"] == "1920x1080"
+
+
+def test_assemble_brief_cloud_low_resolution(sample_outline, sample_style_guide, sample_brand_profile):
+    from src.slide_prompt_composer import assemble_brief
+    slide = sample_outline["slides"][0]
+    brief = assemble_brief(slide, "full_render", sample_style_guide, sample_brand_profile, "cloud_low")
+    assert brief["target_resolution"] == "1280x720"
+
+
+def test_assemble_brief_includes_visual_direction(sample_outline, sample_style_guide, sample_brand_profile):
+    from src.slide_prompt_composer import assemble_brief
+    slide = sample_outline["slides"][0]
+    brief = assemble_brief(slide, "full_render", sample_style_guide, sample_brand_profile, "ollama")
+    assert brief["visual_direction"] == "Dramatic hero image"
+
+
+def test_assemble_brief_includes_style_tokens(sample_outline, sample_style_guide, sample_brand_profile):
+    from src.slide_prompt_composer import assemble_brief
+    slide = sample_outline["slides"][0]
+    brief = assemble_brief(slide, "full_render", sample_style_guide, sample_brand_profile, "ollama")
+    assert "Professional, precise" in brief["style_tokens"]["mood"]

--- a/tests/test_slide_prompt_composer.py
+++ b/tests/test_slide_prompt_composer.py
@@ -1,0 +1,113 @@
+"""Tests for slide prompt composer."""
+
+import json
+import os
+import pytest
+
+
+@pytest.fixture
+def sample_outline():
+    return {
+        "narrative_arc": "Problem-Demo-Impact",
+        "estimated_duration_minutes": 11,
+        "slides": [
+            {"slide_number": 1, "slide_type": "title", "headline": "Big Title",
+             "body_points": ["Speaker Name"], "visual_type": "hero_image",
+             "visual_direction": "Dramatic hero image"},
+            {"slide_number": 2, "slide_type": "content", "headline": "Problem",
+             "body_points": ["Point 1", "Point 2", "Point 3", "Point 4"],
+             "visual_type": "hero_image",
+             "visual_direction": "Abstract fragmentation"},
+            {"slide_number": 3, "slide_type": "section_divider", "headline": "Pivot",
+             "body_points": [], "visual_type": "none"},
+            {"slide_number": 4, "slide_type": "diagram", "headline": "Architecture",
+             "body_points": ["Service A", "Service B", "Service C", "Service D"],
+             "visual_type": "diagram",
+             "visual_direction": "Technical architecture diagram"},
+            {"slide_number": 5, "slide_type": "data_chart", "headline": "Results",
+             "body_points": [], "visual_type": "chart"},
+            {"slide_number": 6, "slide_type": "closing", "headline": "Thank You",
+             "body_points": ["url", "handle"], "visual_type": "none"},
+        ],
+    }
+
+
+@pytest.fixture
+def sample_style_guide():
+    return {
+        "palette": {
+            "primary": "006B5E",
+            "secondary": "4B635B",
+            "accent": "5CDBC0",
+            "background": "F5FBF7",
+            "text_primary": "171D1B",
+        },
+        "typography": {
+            "heading_font": "Inter",
+            "body_font": "Inter",
+        },
+        "image_style_tokens": {
+            "mood": "Professional, precise",
+            "style_modifiers": ["clean flat illustration"],
+        },
+    }
+
+
+@pytest.fixture
+def sample_brand_profile():
+    return {
+        "brand_id": "metamirror",
+        "palette": {"primary": "006B5E"},
+        "approved_image_styles": ["geometric", "clean flat"],
+        "prohibited_image_styles": ["clip art", "stock photo"],
+    }
+
+
+def test_classify_title_as_full_render(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][0])
+    assert result["strategy"] == "full_render"
+
+
+def test_classify_content_with_many_bullets_as_backdrop(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][1])
+    assert result["strategy"] == "backdrop_render"
+
+
+def test_classify_section_divider_as_full_render(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][2])
+    assert result["strategy"] == "full_render"
+
+
+def test_classify_diagram_as_composed(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][3])
+    assert result["strategy"] == "composed"
+
+
+def test_classify_data_chart_as_composed(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][4])
+    assert result["strategy"] == "composed"
+
+
+def test_classify_closing_as_full_render(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][5])
+    assert result["strategy"] == "full_render"
+
+
+def test_classify_returns_rationale(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][0])
+    assert "rationale" in result
+    assert len(result["rationale"]) > 10
+
+
+def test_classify_returns_render_funnel(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][0])
+    assert "render_funnel" in result
+    assert result["render_funnel"] == ["ollama", "cloud_low", "cloud_full"]

--- a/tests/test_slide_prompt_composer.py
+++ b/tests/test_slide_prompt_composer.py
@@ -111,3 +111,34 @@ def test_classify_returns_render_funnel(sample_outline):
     result = classify_slide_strategy(sample_outline["slides"][0])
     assert "render_funnel" in result
     assert result["render_funnel"] == ["ollama", "cloud_low", "cloud_full"]
+
+
+def test_build_strategy_map(sample_outline):
+    from src.slide_prompt_composer import build_strategy_map
+    result = build_strategy_map(sample_outline)
+    assert result["approval_mode"] == "review"
+    assert len(result["slides"]) == 6
+    assert "created_at" in result
+
+
+def test_build_strategy_map_validates_against_schema(sample_outline):
+    import jsonschema
+    from src.slide_prompt_composer import build_strategy_map
+    result = build_strategy_map(sample_outline)
+    with open("src/schemas/strategy_map.schema.json") as f:
+        schema = json.load(f)
+    jsonschema.Draft202012Validator(schema).validate(result)
+
+
+def test_build_strategy_map_with_override(sample_outline):
+    from src.slide_prompt_composer import build_strategy_map
+    overrides = {4: "full_render"}  # Force diagram slide to full_render
+    result = build_strategy_map(sample_outline, overrides=overrides)
+    slide_4 = [s for s in result["slides"] if s["slide_number"] == 4][0]
+    assert slide_4["speaker_override"] == "full_render"
+
+
+def test_build_strategy_map_one_shot_mode(sample_outline):
+    from src.slide_prompt_composer import build_strategy_map
+    result = build_strategy_map(sample_outline, approval_mode="one_shot")
+    assert result["approval_mode"] == "one_shot"


### PR DESCRIPTION
## Summary
- Add `strategy_map.schema.json` — per-slide rendering strategy classification (full_render, backdrop_render, composed)
- Add `src/slide_prompt_composer.py` — strategy classification, strategy map builder, structured brief assembly, save/load with schema validation
- Add `.claude/agents/prompt-engineer.md` — AI Persona for creative prompt generation (Haiku default, Sonnet escalation via model override)
- 24 new tests across 2 test files

This is Sub-plan A of the keynote pipeline (ref #7). Foundation for Sub-plans B (render funnel + assembler) and C (QA + conductor integration).

## Test plan
- [x] 425 tests pass (401 existing + 24 new)
- [x] StrategyMap schema validates correct/incorrect inputs (4 tests)
- [x] Strategy classification covers all slide types (8 tests)
- [x] Build strategy map with overrides and one-shot mode (4 tests)
- [x] Structured brief assembly for full_render and backdrop_render (5 tests)
- [x] Save/load with schema validation (3 tests)
- [x] All TDD — tests red first, then green

Ref: #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)