### PR TITLE
feat: wire keynote pipeline into skills and agents

### DIFF
--- a/.claude/agents/deck-conductor.md
+++ b/.claude/agents/deck-conductor.md
@@ -1,7 +1,7 @@
 ---
 name: deck-conductor
 description: Top-level pipeline orchestrator for the Jack-Tar Deckhand presentation engineering pipeline. Use when the user wants to create a conference-quality PowerPoint presentation from a TalkBrief. Sequences all L1 services (brand, style, narrative, notes, images, assembly, QA), manages draft/production lifecycle, tracks budget, and handles QA correction loops.
-tools: Read, Write, Edit, Glob, Grep, Bash, Skill, Agent(presentation-reviewer, image-generation-expert)
+tools: Read, Write, Edit, Glob, Grep, Bash, Skill, Agent(presentation-reviewer, image-generation-expert, prompt-engineer)
 ---
 
 # Deck Conductor
@@ -65,6 +65,41 @@ Invoke the slide-stylist skill. It reads the TalkBrief and BrandProfile, propose
 
 Invoke the narrative-architect skill. It proposes 2-3 narrative arc options, the Speaker selects one, then it produces the full SlideOutline autonomously.
 
+### Step 3.5: Strategy Map
+
+1. Build the strategy map from the outline:
+```bash
+source .venv/bin/activate && python3 -c "
+from src.slide_prompt_composer import build_strategy_map, save_strategy_map
+import json
+with open('./tmp/deck/outline.json') as f:
+    outline = json.load(f)
+strategy_map = build_strategy_map(outline)
+save_strategy_map('./tmp/deck', strategy_map)
+print(json.dumps(strategy_map, indent=2))
+"
+```
+2. **ESCALATE:** Present the strategy map to the Speaker. For each slide, show the recommended strategy (full_render, backdrop_render, or composed) with rationale. The Speaker can override any slide's strategy.
+3. If the Speaker provides overrides, rebuild:
+```bash
+source .venv/bin/activate && python3 -c "
+from src.slide_prompt_composer import build_strategy_map, save_strategy_map
+import json
+with open('./tmp/deck/outline.json') as f:
+    outline = json.load(f)
+overrides = {SLIDE_NUM: 'STRATEGY', ...}  # Speaker's overrides
+strategy_map = build_strategy_map(outline, overrides=overrides)
+save_strategy_map('./tmp/deck', strategy_map)
+"
+```
+4. Log approval:
+```bash
+source .venv/bin/activate && python3 -c "
+from src.conductor import log_speaker_approval
+log_speaker_approval('./tmp/deck', 'strategy_map_approved', 'Speaker approved strategy map with N overrides')
+"
+```
+
 ### Step 4: Speaker Notes — `/speaker-notes-writer`
 
 Invoke the speaker-notes-writer skill. It gathers 3 lightweight preferences from the Speaker, then produces timed SpeakerNotes autonomously.
@@ -72,6 +107,8 @@ Invoke the speaker-notes-writer skill. It gathers 3 lightweight preferences from
 ### Step 5: Image Generation — `/imagegen-bridge`
 
 Invoke the imagegen-bridge skill. In **draft phase**, it uses Ollama (free) or cloud at reduced quality. In **production phase**, it renders at full quality.
+
+For slides with strategy `full_render` or `backdrop_render` in the strategy map, the imagegen-bridge uses the three-stage render funnel (Ollama draft → cloud low-tier 720p → cloud full-tier 2K+). For `composed` slides, it uses the standard routing matrix.
 
 Before invoking, check budget state:
 ```bash
@@ -135,7 +172,17 @@ print(pipeline_summary_markdown('./tmp/deck'))
 > "Here's the draft deck and review. Would you like to:
 > 1. **Approve for production** — I'll re-render all images at full quality
 > 2. **Request changes** — tell me what to adjust and I'll run another draft cycle
-> 3. **Adjust budget** — if you want to increase/decrease the image quality budget"
+> 3. **Upgrade slides to keynote** — select individual slides to upgrade to full_render or backdrop_render quality
+> 4. **Adjust budget** — if you want to increase/decrease the image quality budget"
+
+If the Speaker requests a keynote upgrade for specific slides:
+```bash
+source .venv/bin/activate && python3 -c "
+from src.conductor import upgrade_slide_strategy
+upgrade_slide_strategy('./tmp/deck', slide_number=N, new_strategy='full_render')
+"
+```
+Then re-run Steps 5-8 for the upgraded slides only (surgical re-render via manifest_utils).
 
 If the Speaker approves:
 ```bash
@@ -186,6 +233,8 @@ print(tracker.cost_summary_markdown())
 | Routing to cheaper model on budget degradation | Architecture-defined policy |
 | Skipping chart-renderer when no data_chart slides | Deterministic from outline |
 | Marking pipeline complete | No judgement required |
+| Strategy classification per slide | Deterministic from slide type and bullet count |
+| Selecting Ollama for funnel Stage 1 | Free, always the first stage |
 
 ## Escalated Decisions (Must Ask Speaker)
 
@@ -201,6 +250,8 @@ print(tracker.cost_summary_markdown())
 | Reviewer structural concerns | Creative direction, not fixable by re-invocation |
 | Brand profile review | Speaker validates extraction |
 | Design direction choices | Creative preference |
+| Strategy map approval | Speaker controls rendering approach per slide |
+| Keynote slide upgrades | Creative and budget decision |
 
 ## Prohibited Actions
 

--- a/.claude/skills/deck-assembler/SKILL.md
+++ b/.claude/skills/deck-assembler/SKILL.md
@@ -17,6 +17,7 @@ All of these DeckContext files must exist before running:
 - `./tmp/deck/image-manifest.json` (ImageManifest)
 - `./tmp/deck/chart-manifest.json` (ChartManifest)
 - `./tmp/deck/speaker-notes.json` (SpeakerNotes)
+- `./tmp/deck/strategy-map.json` (StrategyMap) — optional, controls per-slide rendering approach
 - `./tmp/deck/images/` directory with referenced image files
 
 ## Usage
@@ -42,6 +43,7 @@ Default deck-dir is `./tmp/deck` if not specified.
    - Images from ImageManifest placed in correct zones
    - Chart images from ChartManifest for data_chart slides
    - Speaker notes from SpeakerNotes contract
+   - If strategy-map.json exists, routes slides to full_render (full-bleed AI image), backdrop_render (AI background + text overlay), or composed (standard) assembly paths
 5. Generates progressive build slides for bullets with build_animation cues
 6. Writes the assembled .pptx to the output directory
 7. Reports file size and any asset warnings

--- a/.claude/skills/deck-qa/SKILL.md
+++ b/.claude/skills/deck-qa/SKILL.md
@@ -48,6 +48,14 @@ source .venv/bin/activate && python -m src.qa.run_qa --pptx-path ./tmp/deck/outp
 - AP-12: Image Resolution Too Low for Placement Size
 - AP-13: Image Aspect Ratio Distortion (>5%)
 
+**Keynote Slide Checks (strategy-aware):**
+- AP-26: Palette Drift — dominant colours in full_render/backdrop_render images compared against brand palette (RGB distance threshold)
+
+When `strategy-map.json` exists in the deck directory, QA routes checks per slide:
+- **full_render** slides: skip text checks (AP-01, AP-02, etc.), run image quality + palette drift
+- **backdrop_render** slides: run all standard checks + palette drift
+- **composed** slides: standard 25 checks (unchanged)
+
 **Animations & Charts:**
 - AP-21: Excessive Animation/Transition Types (>2)
 - AP-22: Poor Data-Ink Ratio (3D charts, minor gridlines)

--- a/.claude/skills/imagegen-bridge/SKILL.md
+++ b/.claude/skills/imagegen-bridge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: imagegen-bridge
-description: Top-level image orchestrator. Routes all slide image generation to the appropriate skill (ollama-image, ollama-icon, ollama-pattern, ollama-diagram, cloud-generate-image, cloud-generate-icon, render_chart). Produces ImageManifest and ChartManifest.
+description: Top-level image orchestrator. Routes all slide image generation to the appropriate skill (ollama-image, ollama-icon, ollama-pattern, ollama-diagram, cloud-generate-image, cloud-generate-icon, render_chart). Produces ImageManifest and ChartManifest. Also reads strategy-map.json to determine per-slide rendering approach (full_render, backdrop_render, composed).
 argument-hint: --mode draft|production
 allowed-tools: Bash(python *), Bash(curl *), Read, Glob, Skill
 ---
@@ -45,8 +45,10 @@ Read the required DeckContext files:
 1. Read `./tmp/deck/outline.json` (SlideOutline) using the Read tool
 2. Read `./tmp/deck/style-guide.json` (StyleGuide) using the Read tool
 3. Read `./tmp/deck/talk-brief.json` (TalkBrief) using the Read tool -- needed for data_sources (charts)
+4. Read `./tmp/deck/strategy-map.json` (StrategyMap) if it exists — determines per-slide rendering strategy
+5. Read `./tmp/deck/brand-profile.json` (BrandProfile) if it exists — provides palette for prompt constraints
 
-Verify all three files exist. If any is missing, report the error and stop.
+Verify all three required files exist. If any is missing, report the error and stop.
 
 Parse the JSON content of each file.
 
@@ -70,6 +72,10 @@ else:
 Parse the budget state. The `state` field is one of: `allow`, `allow_with_caps`, `degrade`, `typography_only`.
 
 ## Step 4: Route All Slides
+
+If a strategy map exists, check each slide's strategy before routing:
+- **full_render** or **backdrop_render** slides: Use the three-stage render funnel. Dispatch the `prompt-engineer` agent (Haiku model) with a structured brief from `assemble_brief()`, then render through Ollama → cloud_low → cloud_full stages.
+- **composed** slides: Use the standard routing matrix (unchanged).
 
 Use the image router to determine which skill handles each slide:
 
@@ -100,6 +106,46 @@ Review the routing decisions. Report a summary table:
 
 | Slide | Visual Type | Skill | Provider | Model | Est. Cost | Fallback? |
 |-------|-------------|-------|----------|-------|-----------|-----------|
+
+### Step 4.5: Render Funnel (for keynote slides)
+
+For slides with strategy `full_render` or `backdrop_render`:
+
+1. Assemble a structured brief:
+```bash
+source .venv/bin/activate && python3 -c "
+from src.slide_prompt_composer import assemble_brief
+import json
+with open('./tmp/deck/outline.json') as f:
+    outline = json.load(f)
+with open('./tmp/deck/style-guide.json') as f:
+    style_guide = json.load(f)
+brief = assemble_brief(outline['slides'][SLIDE_INDEX], 'STRATEGY', style_guide, brand_profile, 'FUNNEL_STAGE')
+print(json.dumps(brief, indent=2))
+"
+```
+
+2. Dispatch the `prompt-engineer` agent with the brief to generate the image prompt.
+
+3. Execute the funnel stage:
+```bash
+source .venv/bin/activate && python3 -c "
+from src.render_funnel import execute_funnel_stage
+result = execute_funnel_stage(
+    deck_dir='./tmp/deck',
+    slide_number=N,
+    strategy='STRATEGY',
+    prompt='GENERATED_PROMPT',
+    funnel_stage='STAGE',
+    model='MODEL',
+    output_path='./tmp/deck/images/slide-NN-hero.png',
+)
+import json; print(json.dumps(result, indent=2))
+"
+```
+
+4. After Stage 1 (Ollama), review the result. If acceptable, proceed to Stage 2 (cloud_low). If not, refine the prompt and retry (up to 3 iterations).
+5. After Stage 2 (cloud_low), if acceptable, proceed to Stage 3 (cloud_full). This is the final render -- no iteration at this tier.
 
 ## Step 5: Check Cache for Each Image
 

--- a/.claude/skills/strategy-map/SKILL.md
+++ b/.claude/skills/strategy-map/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: strategy-map
+description: Classify each slide's rendering strategy (full_render, backdrop_render, composed) and generate image prompts via the prompt-engineer agent.
+argument-hint: [--deck-dir PATH] [--approval-mode review|one_shot]
+allowed-tools: Bash(python *), Read, Glob, Agent(prompt-engineer)
+---
+
+# /strategy-map
+
+Classify rendering strategies for each slide and produce the StrategyMap contract. This is Step 3.5 in the pipeline — invoked after the SlideOutline is finalised and before image generation.
+
+## Prerequisites
+
+- `./tmp/deck/outline.json` (SlideOutline)
+- `./tmp/deck/style-guide.json` (StyleGuide)
+- `./tmp/deck/brand-profile.json` (BrandProfile) — optional
+
+## What It Does
+
+1. Reads the SlideOutline and classifies each slide into a rendering strategy:
+   - **full_render** — entire slide generated as one AI image (title, section divider, closing, sparse content)
+   - **backdrop_render** — AI background with programmatic text overlay (dense content slides)
+   - **composed** — standard PptxGenJS assembly (data charts, diagrams, code)
+
+2. Presents the strategy map to the Speaker with rationale per slide
+3. Accepts Speaker overrides for individual slides
+4. Saves the approved strategy map to `./tmp/deck/strategy-map.json`
+
+## Usage
+
+```bash
+source .venv/bin/activate && python3 -c "
+from src.slide_prompt_composer import build_strategy_map, save_strategy_map
+import json
+with open('./tmp/deck/outline.json') as f:
+    outline = json.load(f)
+strategy_map = build_strategy_map(outline)
+save_strategy_map('./tmp/deck', strategy_map)
+print(json.dumps(strategy_map, indent=2))
+"
+```
+
+## Speaker Interaction
+
+Present the strategy map as a table:
+
+| Slide | Type | Strategy | Rationale |
+|-------|------|----------|-----------|
+| 1 | title | full_render | Short text, dramatic visual |
+| 2 | content | backdrop_render | 4 bullets — AI background + text overlay |
+| 4 | diagram | composed | Precise labels require programmatic rendering |
+
+Ask: "Would you like to override any slide strategies?"
+
+If overrides are provided, rebuild with the overrides dict and save again.
+
+## Output
+
+`./tmp/deck/strategy-map.json` conforming to the StrategyMap schema.

--- a/docs/superpowers/plans/2026-03-29-image-pipeline-gaps.md
+++ b/docs/superpowers/plans/2026-03-29-image-pipeline-gaps.md
@@ -1,0 +1,826 @@
+# Image Pipeline Gaps Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add three modules that close gaps in the image pipeline: manifest utilities for surgical updates, SVG-to-PNG rasterisation, and draft-to-production image upgrading.
+
+**Architecture:** Three focused modules with clear dependencies — `manifest_utils.py` provides the foundation (read/update/write manifest entries), `process_image.py` gains `rasterize_svg()` using `rsvg-convert` CLI, and `image_router.py` gains `plan_production_upgrade()` that uses both. All TDD with existing test patterns.
+
+**Tech Stack:** Python 3.14, Pillow (existing), `rsvg-convert` CLI (installed at `/opt/homebrew/bin/rsvg-convert`), pytest, existing JSON schema validation.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/manifest_utils.py` | Create | Read, update, validate, write image-manifest.json entries |
+| `tests/test_manifest_utils.py` | Create | Unit tests for all manifest utility functions |
+| `src/process_image.py` | Modify | Add `rasterize_svg()` function |
+| `tests/test_process_image.py` | Modify | Add SVG rasterisation tests |
+| `src/image_router.py` | Modify | Add `plan_production_upgrade()` function, `UpgradeDecision` namedtuple |
+| `tests/test_image_router.py` | Modify | Add upgrade planning tests |
+
+---
+
+### Task 1: Manifest Utilities — Core Read/Write
+
+**Files:**
+- Create: `src/manifest_utils.py`
+- Create: `tests/test_manifest_utils.py`
+
+- [ ] **Step 1: Write failing test for `load_manifest`**
+
+```python
+"""Tests for manifest utilities."""
+
+import json
+import os
+import shutil
+import tempfile
+
+import pytest
+from PIL import Image
+
+
+@pytest.fixture
+def deck_dir():
+    d = tempfile.mkdtemp()
+    os.makedirs(os.path.join(d, 'images'), exist_ok=True)
+    yield d
+    shutil.rmtree(d)
+
+
+@pytest.fixture
+def sample_image(deck_dir):
+    """Create a 200x100 red PNG in the deck images dir."""
+    path = os.path.join(deck_dir, 'images', 'slide-01-hero.png')
+    img = Image.new('RGB', (200, 100), color=(255, 0, 0))
+    img.save(path)
+    return path
+
+
+@pytest.fixture
+def sample_manifest(deck_dir, sample_image):
+    """Write a minimal valid image-manifest.json."""
+    manifest = {
+        'images': [
+            {
+                'image_id': 'slide-01-hero_image',
+                'slide_number': 1,
+                'file_path': sample_image,
+                'status': 'generated',
+                'dimensions': {'width': 200, 'height': 100},
+                'model_used': 'x/z-image-turbo',
+                'alt_text': 'Test image',
+                'content_hash': 'abc123',
+            }
+        ],
+        'summary': {
+            'total_images': 1,
+            'generated_count': 1,
+            'cached_count': 0,
+            'placeholder_count': 0,
+            'failed_count': 0,
+            'total_generation_seconds': 0.0,
+        },
+    }
+    manifest_path = os.path.join(deck_dir, 'image-manifest.json')
+    with open(manifest_path, 'w') as f:
+        json.dump(manifest, f)
+    return manifest_path
+
+
+def test_load_manifest(deck_dir, sample_manifest):
+    from src.manifest_utils import load_manifest
+    manifest = load_manifest(deck_dir)
+    assert len(manifest['images']) == 1
+    assert manifest['images'][0]['image_id'] == 'slide-01-hero_image'
+
+
+def test_load_manifest_missing_file(deck_dir):
+    from src.manifest_utils import load_manifest
+    with pytest.raises(FileNotFoundError):
+        load_manifest(deck_dir)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_manifest_utils.py::test_load_manifest -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.manifest_utils'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+"""Manifest utilities for surgical image-manifest.json updates.
+
+Provides functions to load, update individual entries, and save
+the image manifest without requiring a full pipeline re-run.
+Uses process_image.py primitives for dimension/hash computation.
+"""
+
+import json
+import os
+
+
+def load_manifest(deck_dir):
+    """Load image-manifest.json from a deck directory.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+
+    Returns:
+        dict: The parsed manifest.
+
+    Raises:
+        FileNotFoundError: If manifest does not exist.
+    """
+    path = os.path.join(deck_dir, 'image-manifest.json')
+    if not os.path.exists(path):
+        raise FileNotFoundError(f'No image-manifest.json in {deck_dir}')
+    with open(path) as f:
+        return json.load(f)
+
+
+def save_manifest(deck_dir, manifest):
+    """Write image-manifest.json atomically.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+        manifest: The manifest dict to write.
+    """
+    path = os.path.join(deck_dir, 'image-manifest.json')
+    tmp_path = path + '.tmp'
+    with open(tmp_path, 'w') as f:
+        json.dump(manifest, f, indent=2)
+        f.write('\n')
+    os.replace(tmp_path, path)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_manifest_utils.py -v`
+Expected: 2 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/manifest_utils.py tests/test_manifest_utils.py
+git commit -m "feat: add manifest_utils with load/save functions"
+```
+
+---
+
+### Task 2: Manifest Utilities — Update Entry
+
+**Files:**
+- Modify: `src/manifest_utils.py`
+- Modify: `tests/test_manifest_utils.py`
+
+- [ ] **Step 1: Write failing tests for `update_manifest_entry` and `replace_image_in_manifest`**
+
+```python
+def test_update_manifest_entry(deck_dir, sample_manifest, sample_image):
+    from src.manifest_utils import load_manifest, update_manifest_entry
+    entry = update_manifest_entry(
+        deck_dir,
+        image_id='slide-01-hero_image',
+        model_used='openai/gpt-image-1.5',
+        alt_text='Updated alt text',
+    )
+    assert entry['model_used'] == 'openai/gpt-image-1.5'
+    assert entry['alt_text'] == 'Updated alt text'
+    assert entry['dimensions'] == {'width': 200, 'height': 100}
+    assert len(entry['content_hash']) == 64  # SHA-256 hex
+
+    # Verify persisted
+    manifest = load_manifest(deck_dir)
+    assert manifest['images'][0]['model_used'] == 'openai/gpt-image-1.5'
+
+
+def test_update_manifest_entry_unknown_id(deck_dir, sample_manifest):
+    from src.manifest_utils import update_manifest_entry
+    with pytest.raises(KeyError, match='no-such-id'):
+        update_manifest_entry(deck_dir, image_id='no-such-id')
+
+
+def test_replace_image_in_manifest(deck_dir, sample_manifest, sample_image):
+    from src.manifest_utils import load_manifest, replace_image_in_manifest
+    # Create a new replacement image
+    new_path = os.path.join(deck_dir, 'images', 'slide-01-hero-v2.png')
+    img = Image.new('RGB', (400, 300), color=(0, 255, 0))
+    img.save(new_path)
+
+    entry = replace_image_in_manifest(
+        deck_dir,
+        slide_number=1,
+        new_file_path=new_path,
+        model_used='svg-convert',
+    )
+    assert entry['file_path'] == new_path
+    assert entry['dimensions'] == {'width': 400, 'height': 300}
+    assert entry['model_used'] == 'svg-convert'
+
+    manifest = load_manifest(deck_dir)
+    assert manifest['images'][0]['file_path'] == new_path
+
+
+def test_replace_image_unknown_slide(deck_dir, sample_manifest):
+    from src.manifest_utils import replace_image_in_manifest
+    with pytest.raises(KeyError, match='slide 99'):
+        replace_image_in_manifest(deck_dir, slide_number=99, new_file_path='/x', model_used='test')
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_manifest_utils.py -v`
+Expected: 4 FAIL — `ImportError: cannot import name 'update_manifest_entry'`
+
+- [ ] **Step 3: Write implementation**
+
+```python
+from src.process_image import get_dimensions, compute_content_hash
+
+
+def _find_entry(manifest, *, image_id=None, slide_number=None):
+    """Find an entry in the manifest by image_id or slide_number."""
+    for entry in manifest.get('images', []):
+        if image_id and entry.get('image_id') == image_id:
+            return entry
+        if slide_number is not None and entry.get('slide_number') == slide_number:
+            return entry
+    key = image_id if image_id else f'slide {slide_number}'
+    raise KeyError(f'No manifest entry for {key}')
+
+
+def update_manifest_entry(deck_dir, image_id, model_used=None, alt_text=None):
+    """Update a single entry in the manifest by image_id.
+
+    Recomputes dimensions and content_hash from the file on disk.
+    Only updates model_used and alt_text if provided.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+        image_id: The image_id to update.
+        model_used: Optional new model attribution.
+        alt_text: Optional new alt text.
+
+    Returns:
+        dict: The updated entry.
+
+    Raises:
+        KeyError: If image_id not found.
+    """
+    manifest = load_manifest(deck_dir)
+    entry = _find_entry(manifest, image_id=image_id)
+
+    file_path = entry['file_path']
+    w, h = get_dimensions(file_path)
+    entry['dimensions'] = {'width': w, 'height': h}
+    entry['content_hash'] = compute_content_hash(file_path)
+
+    if model_used is not None:
+        entry['model_used'] = model_used
+    if alt_text is not None:
+        entry['alt_text'] = alt_text
+
+    save_manifest(deck_dir, manifest)
+    return entry
+
+
+def replace_image_in_manifest(deck_dir, slide_number, new_file_path, model_used, alt_text=None):
+    """Replace an image entry by slide_number with a new file.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+        slide_number: Slide number to update.
+        new_file_path: Path to the replacement image.
+        model_used: Model/tool attribution string.
+        alt_text: Optional new alt text.
+
+    Returns:
+        dict: The updated entry.
+
+    Raises:
+        KeyError: If slide_number not found.
+    """
+    manifest = load_manifest(deck_dir)
+    entry = _find_entry(manifest, slide_number=slide_number)
+
+    entry['file_path'] = new_file_path
+    w, h = get_dimensions(new_file_path)
+    entry['dimensions'] = {'width': w, 'height': h}
+    entry['content_hash'] = compute_content_hash(new_file_path)
+    entry['model_used'] = model_used
+
+    if alt_text is not None:
+        entry['alt_text'] = alt_text
+
+    save_manifest(deck_dir, manifest)
+    return entry
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_manifest_utils.py -v`
+Expected: 6 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/manifest_utils.py tests/test_manifest_utils.py
+git commit -m "feat: add update_manifest_entry and replace_image_in_manifest"
+```
+
+---
+
+### Task 3: Manifest Utilities — Rebuild Hashes
+
+**Files:**
+- Modify: `src/manifest_utils.py`
+- Modify: `tests/test_manifest_utils.py`
+
+- [ ] **Step 1: Write failing test for `rebuild_manifest_hashes`**
+
+```python
+def test_rebuild_manifest_hashes(deck_dir, sample_manifest, sample_image):
+    from src.manifest_utils import load_manifest, rebuild_manifest_hashes
+    from src.process_image import compute_content_hash
+
+    result = rebuild_manifest_hashes(deck_dir)
+    assert len(result['images']) == 1
+
+    expected_hash = compute_content_hash(sample_image)
+    assert result['images'][0]['content_hash'] == expected_hash
+    assert result['images'][0]['dimensions'] == {'width': 200, 'height': 100}
+
+    # Verify persisted
+    manifest = load_manifest(deck_dir)
+    assert manifest['images'][0]['content_hash'] == expected_hash
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_manifest_utils.py::test_rebuild_manifest_hashes -v`
+Expected: FAIL — `ImportError: cannot import name 'rebuild_manifest_hashes'`
+
+- [ ] **Step 3: Write implementation**
+
+```python
+def rebuild_manifest_hashes(deck_dir):
+    """Recompute dimensions and content_hash for every image in the manifest.
+
+    Useful after bulk image replacement (e.g., production re-render).
+
+    Args:
+        deck_dir: Path to the deck working directory.
+
+    Returns:
+        dict: The full updated manifest.
+    """
+    manifest = load_manifest(deck_dir)
+    for entry in manifest.get('images', []):
+        file_path = entry.get('file_path', '')
+        if os.path.exists(file_path):
+            w, h = get_dimensions(file_path)
+            entry['dimensions'] = {'width': w, 'height': h}
+            entry['content_hash'] = compute_content_hash(file_path)
+    save_manifest(deck_dir, manifest)
+    return manifest
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_manifest_utils.py -v`
+Expected: 7 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/manifest_utils.py tests/test_manifest_utils.py
+git commit -m "feat: add rebuild_manifest_hashes for bulk updates"
+```
+
+---
+
+### Task 4: SVG Rasterisation
+
+**Files:**
+- Modify: `src/process_image.py`
+- Modify: `tests/test_process_image.py`
+
+- [ ] **Step 1: Write failing tests for `rasterize_svg`**
+
+```python
+# Add to tests/test_process_image.py
+
+@pytest.fixture
+def test_svg(tmp_dir):
+    """Create a minimal valid SVG file."""
+    path = os.path.join(tmp_dir, 'test.svg')
+    with open(path, 'w') as f:
+        f.write(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="400" height="300">'
+            '<rect width="400" height="300" fill="#006B5E"/>'
+            '</svg>'
+        )
+    return path
+
+
+def test_rasterize_svg_basic(tmp_dir, test_svg):
+    from src.process_image import rasterize_svg
+    output = os.path.join(tmp_dir, 'output.png')
+    result = rasterize_svg(test_svg, output, width=800)
+    assert result['path'] == output
+    assert os.path.exists(output)
+    assert result['width'] == 800
+    assert result['height'] == 600  # maintains 4:3 aspect
+    assert len(result['content_hash']) == 64
+
+
+def test_rasterize_svg_explicit_height(tmp_dir, test_svg):
+    from src.process_image import rasterize_svg
+    output = os.path.join(tmp_dir, 'output.png')
+    result = rasterize_svg(test_svg, output, width=800, height=800, keep_aspect=False)
+    assert result['width'] == 800
+    assert result['height'] == 800
+
+
+def test_rasterize_svg_missing_file(tmp_dir):
+    from src.process_image import rasterize_svg
+    with pytest.raises(FileNotFoundError):
+        rasterize_svg('/no/such/file.svg', os.path.join(tmp_dir, 'out.png'))
+
+
+def test_rasterize_svg_no_rsvg(tmp_dir, test_svg, monkeypatch):
+    from src import process_image
+    monkeypatch.setattr(process_image, '_RSVG_CONVERT_PATH', None)
+    output = os.path.join(tmp_dir, 'output.png')
+    with pytest.raises(RuntimeError, match='rsvg-convert'):
+        process_image.rasterize_svg(test_svg, output)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_process_image.py::test_rasterize_svg_basic -v`
+Expected: FAIL — `ImportError: cannot import name 'rasterize_svg'`
+
+- [ ] **Step 3: Write implementation**
+
+Add to `src/process_image.py`:
+
+```python
+import shutil
+import subprocess
+
+# Detect rsvg-convert at module load
+_RSVG_CONVERT_PATH = shutil.which('rsvg-convert')
+
+
+def rasterize_svg(svg_path, output_path, width=2048, height=None, keep_aspect=True):
+    """Convert an SVG file to a PNG using rsvg-convert.
+
+    Args:
+        svg_path: Path to the source SVG file.
+        output_path: Where to save the PNG.
+        width: Target width in pixels.
+        height: Target height in pixels. If None and keep_aspect is True,
+                height is computed from the SVG's native aspect ratio.
+        keep_aspect: If True (default), maintain the SVG's aspect ratio.
+
+    Returns:
+        dict: {path, width, height, content_hash}
+
+    Raises:
+        FileNotFoundError: If svg_path does not exist.
+        RuntimeError: If rsvg-convert is not installed.
+    """
+    if not os.path.exists(svg_path):
+        raise FileNotFoundError(f'SVG not found: {svg_path}')
+    if _RSVG_CONVERT_PATH is None:
+        raise RuntimeError(
+            'rsvg-convert is not installed. '
+            'Install via: brew install librsvg (macOS) or apt install librsvg2-bin (Linux)'
+        )
+
+    cmd = [_RSVG_CONVERT_PATH, '-w', str(width)]
+    if height is not None:
+        cmd.extend(['-h', str(height)])
+    if keep_aspect:
+        cmd.append('--keep-aspect-ratio')
+    cmd.extend([svg_path, '-o', output_path])
+
+    os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
+    subprocess.run(cmd, check=True, capture_output=True)
+
+    w, h = get_dimensions(output_path)
+    content_hash = compute_content_hash(output_path)
+
+    return {
+        'path': output_path,
+        'width': w,
+        'height': h,
+        'content_hash': content_hash,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_process_image.py -k rasterize -v`
+Expected: 4 PASSED
+
+- [ ] **Step 5: Run full process_image test suite**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_process_image.py -v`
+Expected: All PASSED (19 existing + 4 new = 23)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/process_image.py tests/test_process_image.py
+git commit -m "feat: add rasterize_svg using rsvg-convert"
+```
+
+---
+
+### Task 5: Production Upgrade Planning
+
+**Files:**
+- Modify: `src/image_router.py`
+- Modify: `tests/test_image_router.py`
+
+- [ ] **Step 1: Write failing tests for `plan_production_upgrade`**
+
+```python
+# Add to tests/test_image_router.py
+
+import pytest
+from src.image_router import plan_production_upgrade, UpgradeDecision
+
+
+@pytest.fixture
+def draft_manifest():
+    return {
+        'images': [
+            {
+                'image_id': 'slide-01-hero_image',
+                'slide_number': 1,
+                'file_path': '/tmp/deck/images/slide-01-hero.png',
+                'status': 'generated',
+                'model_used': 'x/z-image-turbo',
+                'source_prompt': 'Dramatic teal composition',
+                'dimensions': {'width': 1024, 'height': 576},
+            },
+            {
+                'image_id': 'slide-04-diagram',
+                'slide_number': 4,
+                'file_path': '/tmp/deck/images/slide-04-diagram.png',
+                'status': 'generated',
+                'model_used': 'svg-convert',
+                'dimensions': {'width': 1705, 'height': 1536},
+            },
+            {
+                'image_id': 'slide-05-hero_image',
+                'slide_number': 5,
+                'file_path': '/tmp/deck/images/slide-05-hero.png',
+                'status': 'generated',
+                'model_used': 'x/z-image-turbo',
+                'source_prompt': 'Abstract collaboration',
+                'dimensions': {'width': 1024, 'height': 576},
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def outline():
+    return {
+        'slides': [
+            {'slide_number': 1, 'visual_type': 'hero_image'},
+            {'slide_number': 4, 'visual_type': 'diagram'},
+            {'slide_number': 5, 'visual_type': 'hero_image'},
+        ],
+    }
+
+
+@pytest.fixture
+def all_providers():
+    return {
+        'ollama': {'available': True, 'models': ['x/z-image-turbo']},
+        'openai': {'available': True, 'model': 'gpt-image-1.5'},
+        'google': {'available': True, 'model': 'imagen-4'},
+        'fal': {'available': True, 'models': ['flux-2-pro']},
+    }
+
+
+@pytest.fixture
+def budget_allow():
+    return {'budget_state': 'allow', 'remaining_usd': 5.0}
+
+
+def test_plan_upgrade_upgrades_hero_images(draft_manifest, outline, all_providers, budget_allow):
+    decisions = plan_production_upgrade(draft_manifest, outline, all_providers, budget_allow)
+    heroes = [d for d in decisions if d.action == 'upgrade']
+    assert len(heroes) == 2
+    assert heroes[0].slide_number == 1
+    assert heroes[1].slide_number == 5
+
+
+def test_plan_upgrade_keeps_svg_diagrams(draft_manifest, outline, all_providers, budget_allow):
+    decisions = plan_production_upgrade(draft_manifest, outline, all_providers, budget_allow)
+    kept = [d for d in decisions if d.action == 'keep']
+    assert len(kept) == 1
+    assert kept[0].slide_number == 4
+    assert 'already' in kept[0].reason.lower()
+
+
+def test_plan_upgrade_respects_budget(draft_manifest, outline, all_providers):
+    tight_budget = {'budget_state': 'allow', 'remaining_usd': 0.02}
+    decisions = plan_production_upgrade(draft_manifest, outline, all_providers, tight_budget)
+    # Should skip upgrades that exceed remaining budget
+    upgrades = [d for d in decisions if d.action == 'upgrade']
+    total_cost = sum(d.estimated_cost_usd for d in upgrades)
+    assert total_cost <= 0.02
+
+
+def test_plan_upgrade_carries_source_prompt(draft_manifest, outline, all_providers, budget_allow):
+    decisions = plan_production_upgrade(draft_manifest, outline, all_providers, budget_allow)
+    slide_1 = [d for d in decisions if d.slide_number == 1][0]
+    assert slide_1.draft_prompt == 'Dramatic teal composition'
+
+
+def test_plan_upgrade_returns_upgrade_decisions(draft_manifest, outline, all_providers, budget_allow):
+    decisions = plan_production_upgrade(draft_manifest, outline, all_providers, budget_allow)
+    assert all(isinstance(d, UpgradeDecision) for d in decisions)
+    assert len(decisions) == 3
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_image_router.py -k plan_upgrade -v`
+Expected: FAIL — `ImportError: cannot import name 'plan_production_upgrade'`
+
+- [ ] **Step 3: Write implementation**
+
+Add to `src/image_router.py`:
+
+```python
+UpgradeDecision = namedtuple('UpgradeDecision', [
+    'slide_number',
+    'image_id',
+    'action',           # 'upgrade' or 'keep'
+    'reason',
+    'draft_prompt',     # carried from draft manifest (None if absent)
+    'target_provider',  # provider for upgrade (None if keep)
+    'target_model',     # model for upgrade (None if keep)
+    'target_size',      # size string e.g. '1536x1024' (None if keep)
+    'estimated_cost_usd',
+])
+
+# Models/tools that already produce high-quality output
+_PRODUCTION_QUALITY_SOURCES = {'svg-convert', 'matplotlib', 'render_chart'}
+
+# Visual types that benefit from cloud upgrade
+_UPGRADEABLE_VISUAL_TYPES = {'hero_image', 'pattern_background', 'icon_set'}
+
+
+def plan_production_upgrade(draft_manifest, outline, available_providers, budget_state):
+    """Plan which images to upgrade from draft to production quality.
+
+    Args:
+        draft_manifest: dict from image-manifest.json.
+        outline: dict from outline.json with 'slides' array.
+        available_providers: dict from provider_discovery.
+        budget_state: dict with 'budget_state' and 'remaining_usd'.
+
+    Returns:
+        list[UpgradeDecision]: One decision per manifest entry.
+    """
+    remaining = budget_state.get('remaining_usd', 0.0)
+    slide_types = {
+        s['slide_number']: classify_visual_type(s)
+        for s in outline.get('slides', [])
+    }
+
+    decisions = []
+    for entry in draft_manifest.get('images', []):
+        slide_num = entry.get('slide_number', 0)
+        image_id = entry.get('image_id', '')
+        model_used = entry.get('model_used', '')
+        visual_type = slide_types.get(slide_num, 'none')
+        draft_prompt = entry.get('source_prompt')
+
+        # Already production quality?
+        if model_used in _PRODUCTION_QUALITY_SOURCES:
+            decisions.append(UpgradeDecision(
+                slide_number=slide_num,
+                image_id=image_id,
+                action='keep',
+                reason=f'Already production quality ({model_used})',
+                draft_prompt=draft_prompt,
+                target_provider=None,
+                target_model=None,
+                target_size=None,
+                estimated_cost_usd=0.0,
+            ))
+            continue
+
+        # Not a type that benefits from upgrade?
+        if visual_type not in _UPGRADEABLE_VISUAL_TYPES:
+            decisions.append(UpgradeDecision(
+                slide_number=slide_num,
+                image_id=image_id,
+                action='keep',
+                reason=f'Visual type {visual_type} does not benefit from cloud upgrade',
+                draft_prompt=draft_prompt,
+                target_provider=None,
+                target_model=None,
+                target_size=None,
+                estimated_cost_usd=0.0,
+            ))
+            continue
+
+        # Find the best production route
+        route = route_slide(
+            {'slide_number': slide_num, 'visual_type': visual_type},
+            'production',
+            available_providers,
+            budget_state.get('budget_state', 'allow'),
+        )
+
+        # Budget check
+        if route.cost_per_image > remaining:
+            decisions.append(UpgradeDecision(
+                slide_number=slide_num,
+                image_id=image_id,
+                action='keep',
+                reason=f'Upgrade cost ${route.cost_per_image:.3f} exceeds remaining ${remaining:.2f}',
+                draft_prompt=draft_prompt,
+                target_provider=None,
+                target_model=None,
+                target_size=None,
+                estimated_cost_usd=0.0,
+            ))
+            continue
+
+        remaining -= route.cost_per_image
+        decisions.append(UpgradeDecision(
+            slide_number=slide_num,
+            image_id=image_id,
+            action='upgrade',
+            reason=f'{visual_type} benefits from cloud quality',
+            draft_prompt=draft_prompt,
+            target_provider=route.provider,
+            target_model=route.model,
+            target_size='1536x1024',
+            estimated_cost_usd=route.cost_per_image,
+        ))
+
+    return decisions
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_image_router.py -k plan_upgrade -v`
+Expected: 5 PASSED
+
+- [ ] **Step 5: Run full image_router test suite**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_image_router.py -v`
+Expected: All PASSED (35 existing + 5 new = 40)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/image_router.py tests/test_image_router.py
+git commit -m "feat: add plan_production_upgrade for surgical draft-to-production upgrade"
+```
+
+---
+
+### Task 6: Full Suite Verification
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `source .venv/bin/activate && python -m pytest tests/ -v`
+Expected: All tests pass (385 existing + 16 new = 401)
+
+- [ ] **Step 2: Run QA on the current deck to verify nothing regressed**
+
+Run: `node src/assembler/build_deck.js --deck-dir ./tmp/deck && source .venv/bin/activate && python -m src.qa.run_qa --pptx-path ./tmp/deck/output/presentation.pptx --deck-dir ./tmp/deck --duration 11`
+Expected: Same QA output as before (7 accepted contrast errors, 5 accepted warnings)
+
+- [ ] **Step 3: Final commit with updated CLAUDE.md module table**
+
+Update the Implementation Status table in CLAUDE.md to add:
+
+| Module | Location | Tests | Status |
+|--------|----------|-------|--------|
+| Manifest utilities | `src/manifest_utils.py` | 7 | Done |
+| SVG rasterisation | `src/process_image.py` | 23 | Done |
+| Production upgrade planner | `src/image_router.py` | 40 | Done |
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md with new image pipeline modules"
+```

--- a/docs/superpowers/plans/2026-03-29-keynote-pipeline-a-strategy-map.md
+++ b/docs/superpowers/plans/2026-03-29-keynote-pipeline-a-strategy-map.md
@@ -1,0 +1,887 @@
+# Keynote Pipeline Sub-Plan A: Strategy Map + Prompt Composer
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the Strategy Map contract, strategy classification logic, slide prompt composer, and prompt engineer agent — the foundation for keynote-quality slide rendering.
+
+**Architecture:** A new JSON schema (`strategy_map.schema.json`) defines the per-slide strategy classification. A Python module (`slide_prompt_composer.py`) analyses each slide and recommends a rendering strategy (full_render, backdrop_render, composed), then assembles structured briefs for the Prompt Engineer agent. The Prompt Engineer is a single agent definition dispatched at Haiku or Sonnet via the model override parameter.
+
+**Tech Stack:** Python 3.14, jsonschema, pytest, existing image_router.py classify_visual_type
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/schemas/strategy_map.schema.json` | Create | JSON schema for StrategyMap contract |
+| `src/slide_prompt_composer.py` | Create | Strategy classification + structured brief assembly + validation |
+| `tests/test_slide_prompt_composer.py` | Create | Unit tests for composer |
+| `tests/test_schemas.py` | Modify | Add StrategyMap schema validation tests |
+| `.claude/agents/prompt-engineer.md` | Create | Agent definition for prompt engineering |
+
+---
+
+### Task 1: StrategyMap JSON Schema
+
+**Files:**
+- Create: `src/schemas/strategy_map.schema.json`
+- Modify: `tests/test_schemas.py`
+
+- [ ] **Step 1: Write failing schema validation tests**
+
+Append to `tests/test_schemas.py`:
+
+```python
+class TestStrategyMapSchema:
+    @pytest.fixture
+    def schema(self):
+        with open('src/schemas/strategy_map.schema.json') as f:
+            return json.load(f)
+
+    def test_valid_strategy_map(self, schema):
+        data = {
+            "created_at": "2026-03-29T12:00:00Z",
+            "approval_mode": "review",
+            "slides": [
+                {
+                    "slide_number": 1,
+                    "strategy": "full_render",
+                    "rationale": "Title slide with dramatic visual",
+                    "render_funnel": ["ollama", "cloud_low", "cloud_full"],
+                    "speaker_override": None
+                }
+            ]
+        }
+        jsonschema.Draft202012Validator(schema).validate(data)
+
+    def test_invalid_strategy_fails(self, schema):
+        data = {
+            "created_at": "2026-03-29T12:00:00Z",
+            "approval_mode": "review",
+            "slides": [
+                {
+                    "slide_number": 1,
+                    "strategy": "invalid_strategy",
+                    "rationale": "Test",
+                    "render_funnel": ["ollama"]
+                }
+            ]
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.Draft202012Validator(schema).validate(data)
+
+    def test_invalid_approval_mode_fails(self, schema):
+        data = {
+            "created_at": "2026-03-29T12:00:00Z",
+            "approval_mode": "invalid",
+            "slides": []
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.Draft202012Validator(schema).validate(data)
+
+    def test_invalid_funnel_stage_fails(self, schema):
+        data = {
+            "created_at": "2026-03-29T12:00:00Z",
+            "approval_mode": "review",
+            "slides": [
+                {
+                    "slide_number": 1,
+                    "strategy": "composed",
+                    "rationale": "Test",
+                    "render_funnel": ["invalid_stage"]
+                }
+            ]
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.Draft202012Validator(schema).validate(data)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_schemas.py::TestStrategyMapSchema -v`
+Expected: FAIL — FileNotFoundError (schema file doesn't exist)
+
+- [ ] **Step 3: Create the schema**
+
+Create `src/schemas/strategy_map.schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jack-tar.dev/schemas/strategy-map.json",
+  "title": "StrategyMap",
+  "description": "Per-slide rendering strategy classification for keynote pipeline.",
+  "type": "object",
+  "required": ["approval_mode", "slides"],
+  "properties": {
+    "created_at": {"type": "string"},
+    "approval_mode": {
+      "type": "string",
+      "enum": ["review", "one_shot"]
+    },
+    "slides": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["slide_number", "strategy", "rationale", "render_funnel"],
+        "properties": {
+          "slide_number": {"type": "integer", "minimum": 1},
+          "strategy": {
+            "type": "string",
+            "enum": ["full_render", "backdrop_render", "composed"]
+          },
+          "rationale": {"type": "string"},
+          "render_funnel": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["ollama", "cloud_low", "cloud_full"]
+            }
+          },
+          "speaker_override": {
+            "type": ["string", "null"],
+            "enum": ["full_render", "backdrop_render", "composed", null]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_schemas.py::TestStrategyMapSchema -v`
+Expected: 4 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/schemas/strategy_map.schema.json tests/test_schemas.py
+git commit -m "feat: add StrategyMap JSON schema"
+```
+
+---
+
+### Task 2: Strategy Classification Logic
+
+**Files:**
+- Create: `src/slide_prompt_composer.py`
+- Create: `tests/test_slide_prompt_composer.py`
+
+- [ ] **Step 1: Write failing tests for classify_slide_strategy**
+
+Create `tests/test_slide_prompt_composer.py`:
+
+```python
+"""Tests for slide prompt composer."""
+
+import json
+import os
+import pytest
+
+
+@pytest.fixture
+def sample_outline():
+    return {
+        "narrative_arc": "Problem-Demo-Impact",
+        "estimated_duration_minutes": 11,
+        "slides": [
+            {"slide_number": 1, "slide_type": "title", "headline": "Big Title",
+             "body_points": ["Speaker Name"], "visual_type": "hero_image",
+             "visual_direction": "Dramatic hero image"},
+            {"slide_number": 2, "slide_type": "content", "headline": "Problem",
+             "body_points": ["Point 1", "Point 2", "Point 3", "Point 4"],
+             "visual_type": "hero_image",
+             "visual_direction": "Abstract fragmentation"},
+            {"slide_number": 3, "slide_type": "section_divider", "headline": "Pivot",
+             "body_points": [], "visual_type": "none"},
+            {"slide_number": 4, "slide_type": "diagram", "headline": "Architecture",
+             "body_points": ["Service A", "Service B", "Service C", "Service D"],
+             "visual_type": "diagram",
+             "visual_direction": "Technical architecture diagram"},
+            {"slide_number": 5, "slide_type": "data_chart", "headline": "Results",
+             "body_points": [], "visual_type": "chart"},
+            {"slide_number": 6, "slide_type": "closing", "headline": "Thank You",
+             "body_points": ["url", "handle"], "visual_type": "none"},
+        ],
+    }
+
+
+@pytest.fixture
+def sample_style_guide():
+    return {
+        "palette": {
+            "primary": "006B5E",
+            "secondary": "4B635B",
+            "accent": "5CDBC0",
+            "background": "F5FBF7",
+            "text_primary": "171D1B",
+        },
+        "typography": {
+            "heading_font": "Inter",
+            "body_font": "Inter",
+        },
+        "image_style_tokens": {
+            "mood": "Professional, precise",
+            "style_modifiers": ["clean flat illustration"],
+        },
+    }
+
+
+@pytest.fixture
+def sample_brand_profile():
+    return {
+        "brand_id": "metamirror",
+        "palette": {"primary": "006B5E"},
+        "approved_image_styles": ["geometric", "clean flat"],
+        "prohibited_image_styles": ["clip art", "stock photo"],
+    }
+
+
+def test_classify_title_as_full_render(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][0])
+    assert result["strategy"] == "full_render"
+
+
+def test_classify_content_with_many_bullets_as_backdrop(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][1])
+    assert result["strategy"] == "backdrop_render"
+
+
+def test_classify_section_divider_as_full_render(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][2])
+    assert result["strategy"] == "full_render"
+
+
+def test_classify_diagram_as_composed(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][3])
+    assert result["strategy"] == "composed"
+
+
+def test_classify_data_chart_as_composed(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][4])
+    assert result["strategy"] == "composed"
+
+
+def test_classify_closing_as_full_render(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][5])
+    assert result["strategy"] == "full_render"
+
+
+def test_classify_returns_rationale(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][0])
+    assert "rationale" in result
+    assert len(result["rationale"]) > 10
+
+
+def test_classify_returns_render_funnel(sample_outline):
+    from src.slide_prompt_composer import classify_slide_strategy
+    result = classify_slide_strategy(sample_outline["slides"][0])
+    assert "render_funnel" in result
+    assert result["render_funnel"] == ["ollama", "cloud_low", "cloud_full"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_slide_prompt_composer.py -v`
+Expected: FAIL — ModuleNotFoundError
+
+- [ ] **Step 3: Write classify_slide_strategy implementation**
+
+Create `src/slide_prompt_composer.py`:
+
+```python
+"""Slide prompt composer — strategy classification and structured brief assembly.
+
+Analyses each slide in a SlideOutline and:
+1. Classifies its rendering strategy (full_render, backdrop_render, composed)
+2. Assembles structured briefs for the Prompt Engineer agent
+3. Validates output prompts contain required brand elements
+
+Strategy classification is deterministic Python logic. Prompt generation
+is delegated to the Prompt Engineer agent (LLM reasoning).
+"""
+
+from src.image_router import classify_visual_type
+
+
+# Slide types that work well as full AI-rendered images (short text, visual impact)
+_FULL_RENDER_TYPES = {'title', 'section_divider', 'closing', 'blank_visual', 'quote'}
+
+# Slide types that must stay programmatic (precise text, data, labels)
+_COMPOSED_TYPES = {'data_chart', 'diagram', 'code'}
+
+# Maximum body points before a content slide should use backdrop instead of full render
+_BACKDROP_BULLET_THRESHOLD = 2
+
+
+def classify_slide_strategy(slide):
+    """Classify a slide's recommended rendering strategy.
+
+    Args:
+        slide: dict from SlideOutline slides array.
+
+    Returns:
+        dict with keys: slide_number, strategy, rationale, render_funnel, speaker_override
+    """
+    slide_number = slide.get('slide_number', 0)
+    slide_type = slide.get('slide_type', 'content')
+    body_points = slide.get('body_points', [])
+    visual_type = classify_visual_type(slide)
+
+    # Charts and diagrams must stay composed (precise text/labels)
+    if slide_type in _COMPOSED_TYPES or visual_type == 'chart':
+        return {
+            'slide_number': slide_number,
+            'strategy': 'composed',
+            'rationale': f'{slide_type} slide requires precise text/label rendering — programmatic assembly',
+            'render_funnel': ['ollama'],
+            'speaker_override': None,
+        }
+
+    # Short-text slide types are ideal for full render
+    if slide_type in _FULL_RENDER_TYPES:
+        return {
+            'slide_number': slide_number,
+            'strategy': 'full_render',
+            'rationale': f'{slide_type} slide with short text — ideal for full AI generation',
+            'render_funnel': ['ollama', 'cloud_low', 'cloud_full'],
+            'speaker_override': None,
+        }
+
+    # Content slides: backdrop if dense text, full render if sparse
+    if len(body_points) > _BACKDROP_BULLET_THRESHOLD:
+        return {
+            'slide_number': slide_number,
+            'strategy': 'backdrop_render',
+            'rationale': f'Content slide with {len(body_points)} bullet points — AI background with programmatic text overlay',
+            'render_funnel': ['ollama', 'cloud_low', 'cloud_full'],
+            'speaker_override': None,
+        }
+
+    return {
+        'slide_number': slide_number,
+        'strategy': 'full_render',
+        'rationale': f'Content slide with {len(body_points)} bullet points — sparse enough for full AI generation',
+        'render_funnel': ['ollama', 'cloud_low', 'cloud_full'],
+        'speaker_override': None,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_slide_prompt_composer.py -v`
+Expected: 8 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/slide_prompt_composer.py tests/test_slide_prompt_composer.py
+git commit -m "feat: add classify_slide_strategy for rendering strategy classification"
+```
+
+---
+
+### Task 3: Build Strategy Map
+
+**Files:**
+- Modify: `src/slide_prompt_composer.py`
+- Modify: `tests/test_slide_prompt_composer.py`
+
+- [ ] **Step 1: Write failing tests for build_strategy_map**
+
+Append to `tests/test_slide_prompt_composer.py`:
+
+```python
+def test_build_strategy_map(sample_outline):
+    from src.slide_prompt_composer import build_strategy_map
+    result = build_strategy_map(sample_outline)
+    assert result["approval_mode"] == "review"
+    assert len(result["slides"]) == 6
+    assert "created_at" in result
+
+
+def test_build_strategy_map_validates_against_schema(sample_outline):
+    import jsonschema
+    from src.slide_prompt_composer import build_strategy_map
+    result = build_strategy_map(sample_outline)
+    with open("src/schemas/strategy_map.schema.json") as f:
+        schema = json.load(f)
+    jsonschema.Draft202012Validator(schema).validate(result)
+
+
+def test_build_strategy_map_with_override(sample_outline):
+    from src.slide_prompt_composer import build_strategy_map
+    overrides = {4: "full_render"}  # Force diagram slide to full_render
+    result = build_strategy_map(sample_outline, overrides=overrides)
+    slide_4 = [s for s in result["slides"] if s["slide_number"] == 4][0]
+    assert slide_4["speaker_override"] == "full_render"
+
+
+def test_build_strategy_map_one_shot_mode(sample_outline):
+    from src.slide_prompt_composer import build_strategy_map
+    result = build_strategy_map(sample_outline, approval_mode="one_shot")
+    assert result["approval_mode"] == "one_shot"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_slide_prompt_composer.py -k build_strategy -v`
+Expected: FAIL — ImportError
+
+- [ ] **Step 3: Write build_strategy_map implementation**
+
+Add to `src/slide_prompt_composer.py`:
+
+```python
+from datetime import datetime, timezone
+
+
+def build_strategy_map(outline, approval_mode='review', overrides=None):
+    """Build a complete StrategyMap from a SlideOutline.
+
+    Args:
+        outline: dict from SlideOutline (must have 'slides' array).
+        approval_mode: 'review' (default) or 'one_shot'.
+        overrides: Optional dict of {slide_number: strategy} Speaker overrides.
+
+    Returns:
+        dict conforming to StrategyMap schema.
+    """
+    overrides = overrides or {}
+    slides = []
+
+    for slide in outline.get('slides', []):
+        entry = classify_slide_strategy(slide)
+        slide_num = entry['slide_number']
+
+        if slide_num in overrides:
+            entry['speaker_override'] = overrides[slide_num]
+            # Override also sets the render funnel for the new strategy
+            if overrides[slide_num] in ('full_render', 'backdrop_render'):
+                entry['render_funnel'] = ['ollama', 'cloud_low', 'cloud_full']
+            else:
+                entry['render_funnel'] = ['ollama']
+
+        slides.append(entry)
+
+    return {
+        'created_at': datetime.now(timezone.utc).isoformat(),
+        'approval_mode': approval_mode,
+        'slides': slides,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_slide_prompt_composer.py -v`
+Expected: 12 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/slide_prompt_composer.py tests/test_slide_prompt_composer.py
+git commit -m "feat: add build_strategy_map for full outline classification"
+```
+
+---
+
+### Task 4: Structured Brief Assembly
+
+**Files:**
+- Modify: `src/slide_prompt_composer.py`
+- Modify: `tests/test_slide_prompt_composer.py`
+
+- [ ] **Step 1: Write failing tests for assemble_brief**
+
+Append to `tests/test_slide_prompt_composer.py`:
+
+```python
+def test_assemble_brief_full_render(sample_outline, sample_style_guide, sample_brand_profile):
+    from src.slide_prompt_composer import assemble_brief
+    slide = sample_outline["slides"][0]  # title slide
+    brief = assemble_brief(slide, "full_render", sample_style_guide, sample_brand_profile, "ollama")
+    assert brief["slide_number"] == 1
+    assert brief["strategy"] == "full_render"
+    assert brief["headline"] == "Big Title"
+    assert "006B5E" in brief["brand_constraints"]["palette_hex"]
+    assert "clip art" in brief["brand_constraints"]["prohibited_styles"]
+    assert brief["funnel_stage"] == "ollama"
+    assert brief["target_resolution"] == "1024x576"
+
+
+def test_assemble_brief_backdrop_excludes_text(sample_outline, sample_style_guide, sample_brand_profile):
+    from src.slide_prompt_composer import assemble_brief
+    slide = sample_outline["slides"][1]  # content slide with 4 bullets
+    brief = assemble_brief(slide, "backdrop_render", sample_style_guide, sample_brand_profile, "cloud_full")
+    assert brief["strategy"] == "backdrop_render"
+    assert brief["text_instruction"] == "NO TEXT in the image — leave clean space for text overlay"
+    assert brief["target_resolution"] == "1920x1080"
+
+
+def test_assemble_brief_cloud_low_resolution(sample_outline, sample_style_guide, sample_brand_profile):
+    from src.slide_prompt_composer import assemble_brief
+    slide = sample_outline["slides"][0]
+    brief = assemble_brief(slide, "full_render", sample_style_guide, sample_brand_profile, "cloud_low")
+    assert brief["target_resolution"] == "1280x720"
+
+
+def test_assemble_brief_includes_visual_direction(sample_outline, sample_style_guide, sample_brand_profile):
+    from src.slide_prompt_composer import assemble_brief
+    slide = sample_outline["slides"][0]
+    brief = assemble_brief(slide, "full_render", sample_style_guide, sample_brand_profile, "ollama")
+    assert brief["visual_direction"] == "Dramatic hero image"
+
+
+def test_assemble_brief_includes_style_tokens(sample_outline, sample_style_guide, sample_brand_profile):
+    from src.slide_prompt_composer import assemble_brief
+    slide = sample_outline["slides"][0]
+    brief = assemble_brief(slide, "full_render", sample_style_guide, sample_brand_profile, "ollama")
+    assert "Professional, precise" in brief["style_tokens"]["mood"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_slide_prompt_composer.py -k assemble_brief -v`
+Expected: FAIL — ImportError
+
+- [ ] **Step 3: Write assemble_brief implementation**
+
+Add to `src/slide_prompt_composer.py`:
+
+```python
+# Resolution targets per funnel stage
+_RESOLUTIONS = {
+    'ollama': '1024x576',
+    'cloud_low': '1280x720',
+    'cloud_full': '1920x1080',
+}
+
+
+def assemble_brief(slide, strategy, style_guide, brand_profile, funnel_stage):
+    """Assemble a structured brief for the Prompt Engineer agent.
+
+    Args:
+        slide: dict from SlideOutline slides array.
+        strategy: 'full_render' or 'backdrop_render'.
+        style_guide: dict from StyleGuide contract.
+        brand_profile: dict from BrandProfile contract (or None).
+        funnel_stage: 'ollama', 'cloud_low', or 'cloud_full'.
+
+    Returns:
+        dict: Structured brief with all context the Prompt Engineer needs.
+    """
+    palette = style_guide.get('palette', {})
+    palette_hex = [v for v in palette.values() if isinstance(v, str) and len(v) == 6]
+
+    brand_constraints = {
+        'palette_hex': palette_hex,
+        'approved_styles': [],
+        'prohibited_styles': [],
+    }
+    if brand_profile:
+        brand_constraints['approved_styles'] = brand_profile.get('approved_image_styles', [])
+        brand_constraints['prohibited_styles'] = brand_profile.get('prohibited_image_styles', [])
+
+    style_tokens = style_guide.get('image_style_tokens', {})
+
+    brief = {
+        'slide_number': slide.get('slide_number', 0),
+        'strategy': strategy,
+        'headline': slide.get('headline', ''),
+        'body_points': slide.get('body_points', []),
+        'visual_direction': slide.get('visual_direction', ''),
+        'slide_type': slide.get('slide_type', 'content'),
+        'brand_constraints': brand_constraints,
+        'style_tokens': style_tokens,
+        'funnel_stage': funnel_stage,
+        'target_resolution': _RESOLUTIONS.get(funnel_stage, '1920x1080'),
+    }
+
+    if strategy == 'backdrop_render':
+        brief['text_instruction'] = 'NO TEXT in the image — leave clean space for text overlay'
+    elif strategy == 'full_render':
+        brief['text_instruction'] = f'Include headline text: "{slide.get("headline", "")}"'
+
+    return brief
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_slide_prompt_composer.py -v`
+Expected: 17 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/slide_prompt_composer.py tests/test_slide_prompt_composer.py
+git commit -m "feat: add assemble_brief for structured prompt engineering briefs"
+```
+
+---
+
+### Task 5: Prompt Engineer Agent Definition
+
+**Files:**
+- Create: `.claude/agents/prompt-engineer.md`
+
+- [ ] **Step 1: Create the agent definition**
+
+Create `.claude/agents/prompt-engineer.md`:
+
+```markdown
+---
+name: prompt-engineer
+description: Transforms structured slide briefs into creative image generation prompts. Composes spatial relationships, visual metaphors, and scene descriptions. Dispatched at Haiku by default, Sonnet on escalation.
+tools: Read, Grep, Glob
+---
+
+# Prompt Engineer
+
+You are the Prompt Engineer — an AI Persona that transforms structured slide briefs into creative image generation prompts for conference-quality presentation slides.
+
+## Identity
+
+**Persona ID:** persona-prompt-engineer
+**Service ID:** image-prompt-engineer
+**Authority Model:** Invoker
+**Default Model:** Haiku (escalated to Sonnet when quality doesn't converge)
+
+## Input
+
+You receive a **structured brief** as a JSON object with these fields:
+
+| Field | Description |
+|-------|-------------|
+| `slide_number` | Which slide this is for |
+| `strategy` | `full_render` (entire slide as image) or `backdrop_render` (visual background only) |
+| `headline` | The slide's headline text |
+| `body_points` | Array of bullet point strings |
+| `visual_direction` | Creative direction from the narrative architect |
+| `slide_type` | title, content, section_divider, closing, etc. |
+| `brand_constraints.palette_hex` | Brand colour hex values to use |
+| `brand_constraints.approved_styles` | Approved image styles |
+| `brand_constraints.prohibited_styles` | Styles to avoid |
+| `style_tokens` | Mood, style modifiers from the StyleGuide |
+| `funnel_stage` | ollama, cloud_low, or cloud_full |
+| `target_resolution` | Target image dimensions |
+| `text_instruction` | Whether to include or exclude text in the image |
+
+## Output
+
+Return a single string: the image generation prompt. Nothing else.
+
+## Prompt Composition Rules
+
+### For `full_render` strategy:
+
+1. **Scene description first** — Describe the overall visual composition, mood, and spatial layout
+2. **Text placement** — Specify where the headline appears (e.g., "bold white sans-serif headline top-left reading '[exact headline text]'")
+3. **Body text** — If body points exist, describe their placement and styling
+4. **Visual elements** — Describe the illustration, imagery, or abstract visuals
+5. **Brand colours** — Include exact hex values from palette_hex (e.g., "deep teal #006B5E")
+6. **Technical specs** — End with: aspect ratio, style descriptors, "professional conference keynote slide"
+
+### For `backdrop_render` strategy:
+
+1. **Scene description** — Describe the visual composition
+2. **Safe zone** — Explicitly state where text will be overlaid (e.g., "left third is a darker region reserved for text overlay")
+3. **No text** — Include "no text, no labels, no words, no typography" in the prompt
+4. **Visual elements** — Describe the background illustration/imagery
+5. **Brand colours** — Include hex values
+6. **Technical specs** — End with: aspect ratio, "presentation background", "clean space for text overlay"
+
+### Funnel stage adaptations:
+
+- **ollama** — Simpler prompts. Focus on composition and concept. Skip fine typography details (Ollama can't handle them). Keep under 100 words.
+- **cloud_low** — Full prompt detail. Include all text, colours, spatial relationships. This validates the prompt works on the target model.
+- **cloud_full** — Same prompt as cloud_low. Do not change the prompt between cloud_low and cloud_full — the point is to render a proven prompt at higher resolution.
+
+## Prohibited
+
+- Do not generate images — only produce text prompts
+- Do not modify the brief or any DeckContext contract
+- Do not add text content that isn't in the brief (don't invent headlines or bullet points)
+- Do not include brand-prohibited styles
+- Do not produce prompts longer than 200 words
+```
+
+- [ ] **Step 2: Verify the agent file is well-formed**
+
+```bash
+head -5 .claude/agents/prompt-engineer.md
+```
+
+Expected: Shows frontmatter with name, description, tools
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/agents/prompt-engineer.md
+git commit -m "feat: add prompt-engineer agent definition"
+```
+
+---
+
+### Task 6: Strategy Map Save/Load and Schema Validation
+
+**Files:**
+- Modify: `src/slide_prompt_composer.py`
+- Modify: `tests/test_slide_prompt_composer.py`
+
+- [ ] **Step 1: Write failing tests for save/load and validation**
+
+Append to `tests/test_slide_prompt_composer.py`:
+
+```python
+import shutil
+import tempfile
+
+
+@pytest.fixture
+def deck_dir():
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d)
+
+
+def test_save_and_load_strategy_map(deck_dir, sample_outline):
+    from src.slide_prompt_composer import build_strategy_map, save_strategy_map, load_strategy_map
+    strategy_map = build_strategy_map(sample_outline)
+    save_strategy_map(deck_dir, strategy_map)
+    loaded = load_strategy_map(deck_dir)
+    assert loaded["approval_mode"] == "review"
+    assert len(loaded["slides"]) == 6
+
+
+def test_save_strategy_map_validates_schema(deck_dir):
+    from src.slide_prompt_composer import save_strategy_map
+    bad_map = {"approval_mode": "invalid", "slides": []}
+    with pytest.raises(Exception):
+        save_strategy_map(deck_dir, bad_map)
+
+
+def test_load_strategy_map_missing_file(deck_dir):
+    from src.slide_prompt_composer import load_strategy_map
+    with pytest.raises(FileNotFoundError):
+        load_strategy_map(deck_dir)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_slide_prompt_composer.py -k "save_and_load or save_strategy_map_validates or load_strategy_map_missing" -v`
+Expected: FAIL — ImportError
+
+- [ ] **Step 3: Write save/load/validate implementation**
+
+Add to `src/slide_prompt_composer.py`:
+
+```python
+import json
+import os
+import jsonschema
+
+_SCHEMA_DIR = os.path.join(os.path.dirname(__file__), 'schemas')
+
+
+def _validate_strategy_map(strategy_map):
+    """Validate a strategy map against the JSON schema."""
+    schema_path = os.path.join(_SCHEMA_DIR, 'strategy_map.schema.json')
+    with open(schema_path) as f:
+        schema = json.load(f)
+    jsonschema.Draft202012Validator(schema).validate(strategy_map)
+
+
+def save_strategy_map(deck_dir, strategy_map):
+    """Save a strategy map to the DeckContext directory.
+
+    Validates against schema before writing.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+        strategy_map: dict conforming to StrategyMap schema.
+
+    Raises:
+        jsonschema.ValidationError: If strategy_map is invalid.
+    """
+    _validate_strategy_map(strategy_map)
+    path = os.path.join(deck_dir, 'strategy-map.json')
+    tmp_path = path + '.tmp'
+    with open(tmp_path, 'w') as f:
+        json.dump(strategy_map, f, indent=2)
+        f.write('\n')
+    os.replace(tmp_path, path)
+
+
+def load_strategy_map(deck_dir):
+    """Load a strategy map from the DeckContext directory.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+
+    Returns:
+        dict: The parsed strategy map.
+
+    Raises:
+        FileNotFoundError: If strategy-map.json does not exist.
+    """
+    path = os.path.join(deck_dir, 'strategy-map.json')
+    if not os.path.exists(path):
+        raise FileNotFoundError(f'No strategy-map.json in {deck_dir}')
+    with open(path) as f:
+        return json.load(f)
+```
+
+- [ ] **Step 4: Run all tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_slide_prompt_composer.py -v`
+Expected: 20 PASSED
+
+- [ ] **Step 5: Run full test suite to ensure no regressions**
+
+Run: `source .venv/bin/activate && python -m pytest tests/ -v 2>&1 | tail -5`
+Expected: All tests pass (401 existing + 20 new + 4 schema = 425)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/slide_prompt_composer.py tests/test_slide_prompt_composer.py
+git commit -m "feat: add strategy map save/load with schema validation"
+```
+
+---
+
+### Task 7: Full Suite Verification and CLAUDE.md Update
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `source .venv/bin/activate && python -m pytest tests/ -v`
+Expected: All tests pass
+
+- [ ] **Step 2: Update CLAUDE.md implementation table**
+
+Add to the Implementation Status table:
+
+| Module | Location | Tests | Status |
+|--------|----------|-------|--------|
+| Strategy Map schema | `src/schemas/strategy_map.schema.json` | 4 | Done |
+| Slide prompt composer | `src/slide_prompt_composer.py` | 20 | Done |
+| Prompt engineer agent | `.claude/agents/prompt-engineer.md` | -- | Done |
+
+Update the total test count in the header.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md with keynote Sub-plan A modules"
+```

--- a/docs/superpowers/plans/2026-03-29-keynote-pipeline-b-render-funnel.md
+++ b/docs/superpowers/plans/2026-03-29-keynote-pipeline-b-render-funnel.md
@@ -1,0 +1,923 @@
+# Keynote Pipeline Sub-Plan B: Render Funnel + Assembler
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the three-stage render funnel for keynote slides and add full_render/backdrop_render assembly paths to the deck assembler.
+
+**Architecture:** A new Python module (`render_funnel.py`) orchestrates the Ollama→cloud_low→cloud_full render stages for each keynote slide, logging every attempt to a RenderLog. The assembler gains two new slide builders (`buildFullRenderSlide`, `buildBackdropRenderSlide`) and reads the strategy-map.json to decide which builder to use per slide.
+
+**Tech Stack:** Python 3.14 (render funnel, render log), Node.js (assembler), PptxGenJS, pytest, existing BudgetTracker + manifest_utils + generate_image + generate_cloud_image
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/schemas/render_log.schema.json` | Create | JSON schema for RenderLog contract |
+| `src/render_funnel.py` | Create | Three-stage render orchestration + render log management |
+| `tests/test_render_funnel.py` | Create | Unit tests for render funnel |
+| `src/assembler/build_deck.js` | Modify | Add buildFullRenderSlide, buildBackdropRenderSlide, strategy map loading |
+| `tests/test_assembler.py` | Modify | Add keynote assembly tests |
+| `tests/test_schemas.py` | Modify | Add RenderLog schema tests |
+
+---
+
+### Task 1: RenderLog JSON Schema
+
+**Files:**
+- Create: `src/schemas/render_log.schema.json`
+- Modify: `tests/test_schemas.py`
+
+- [ ] **Step 1: Write failing schema tests**
+
+Append to `tests/test_schemas.py`:
+
+```python
+class TestRenderLogSchema:
+    @pytest.fixture
+    def schema(self):
+        with open('src/schemas/render_log.schema.json') as f:
+            return json.load(f)
+
+    def test_valid_render_log(self, schema):
+        data = {
+            "entries": [
+                {
+                    "slide_number": 1,
+                    "strategy": "full_render",
+                    "funnel_stage": "ollama",
+                    "prompt_hash": "abc123",
+                    "model": "x/z-image-turbo",
+                    "resolution": "1024x576",
+                    "vision_score": 6.5,
+                    "iteration": 1,
+                    "cost_usd": 0.0,
+                    "timestamp": "2026-03-29T12:00:00Z"
+                }
+            ]
+        }
+        jsonschema.Draft202012Validator(schema).validate(data)
+
+    def test_missing_entries_fails(self, schema):
+        data = {}
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.Draft202012Validator(schema).validate(data)
+
+    def test_invalid_funnel_stage_fails(self, schema):
+        data = {
+            "entries": [
+                {
+                    "slide_number": 1,
+                    "strategy": "full_render",
+                    "funnel_stage": "invalid",
+                    "prompt_hash": "abc",
+                    "model": "test",
+                    "resolution": "1024x576",
+                    "iteration": 1,
+                    "cost_usd": 0.0,
+                    "timestamp": "2026-03-29T12:00:00Z"
+                }
+            ]
+        }
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.Draft202012Validator(schema).validate(data)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_schemas.py::TestRenderLogSchema -v`
+Expected: FAIL — FileNotFoundError
+
+- [ ] **Step 3: Create the schema**
+
+Create `src/schemas/render_log.schema.json`:
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jack-tar.dev/schemas/render-log.json",
+  "title": "RenderLog",
+  "description": "Append-only log of render attempts for cost and convergence analysis.",
+  "type": "object",
+  "required": ["entries"],
+  "properties": {
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["slide_number", "strategy", "funnel_stage", "prompt_hash", "model", "resolution", "iteration", "cost_usd", "timestamp"],
+        "properties": {
+          "slide_number": {"type": "integer", "minimum": 1},
+          "strategy": {"type": "string", "enum": ["full_render", "backdrop_render"]},
+          "funnel_stage": {"type": "string", "enum": ["ollama", "cloud_low", "cloud_full"]},
+          "prompt_hash": {"type": "string"},
+          "model": {"type": "string"},
+          "resolution": {"type": "string"},
+          "vision_score": {"type": ["number", "null"]},
+          "iteration": {"type": "integer", "minimum": 1},
+          "cost_usd": {"type": "number", "minimum": 0},
+          "timestamp": {"type": "string"}
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_schemas.py::TestRenderLogSchema -v`
+Expected: 3 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/schemas/render_log.schema.json tests/test_schemas.py
+git commit -m "feat: add RenderLog JSON schema"
+```
+
+---
+
+### Task 2: Render Log Manager
+
+**Files:**
+- Create: `src/render_funnel.py`
+- Create: `tests/test_render_funnel.py`
+
+- [ ] **Step 1: Write failing tests for render log management**
+
+Create `tests/test_render_funnel.py`:
+
+```python
+"""Tests for render funnel orchestration."""
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+
+import pytest
+
+
+@pytest.fixture
+def deck_dir():
+    d = tempfile.mkdtemp()
+    os.makedirs(os.path.join(d, 'images'), exist_ok=True)
+    yield d
+    shutil.rmtree(d)
+
+
+def test_init_render_log(deck_dir):
+    from src.render_funnel import init_render_log, load_render_log
+    init_render_log(deck_dir)
+    log = load_render_log(deck_dir)
+    assert log['entries'] == []
+
+
+def test_append_render_entry(deck_dir):
+    from src.render_funnel import init_render_log, append_render_entry, load_render_log
+    init_render_log(deck_dir)
+    append_render_entry(deck_dir, {
+        'slide_number': 1,
+        'strategy': 'full_render',
+        'funnel_stage': 'ollama',
+        'prompt_hash': 'abc123',
+        'model': 'x/z-image-turbo',
+        'resolution': '1024x576',
+        'vision_score': 6.5,
+        'iteration': 1,
+        'cost_usd': 0.0,
+        'timestamp': '2026-03-29T12:00:00Z',
+    })
+    log = load_render_log(deck_dir)
+    assert len(log['entries']) == 1
+    assert log['entries'][0]['slide_number'] == 1
+
+
+def test_append_multiple_entries(deck_dir):
+    from src.render_funnel import init_render_log, append_render_entry, load_render_log
+    init_render_log(deck_dir)
+    for i in range(3):
+        append_render_entry(deck_dir, {
+            'slide_number': 1,
+            'strategy': 'full_render',
+            'funnel_stage': 'ollama',
+            'prompt_hash': f'hash_{i}',
+            'model': 'x/z-image-turbo',
+            'resolution': '1024x576',
+            'vision_score': 5.0 + i,
+            'iteration': i + 1,
+            'cost_usd': 0.0,
+            'timestamp': f'2026-03-29T12:0{i}:00Z',
+        })
+    log = load_render_log(deck_dir)
+    assert len(log['entries']) == 3
+
+
+def test_load_render_log_missing(deck_dir):
+    from src.render_funnel import load_render_log
+    with pytest.raises(FileNotFoundError):
+        load_render_log(deck_dir)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_render_funnel.py -v`
+Expected: FAIL — ModuleNotFoundError
+
+- [ ] **Step 3: Write render log implementation**
+
+Create `src/render_funnel.py`:
+
+```python
+"""Render funnel — three-stage render orchestration for keynote slides.
+
+Orchestrates the Ollama → cloud_low → cloud_full render stages for
+full_render and backdrop_render slides. Logs every render attempt to
+render-log.json for cost and convergence analysis.
+"""
+
+import hashlib
+import json
+import os
+
+from datetime import datetime, timezone
+
+
+def init_render_log(deck_dir):
+    """Create an empty render-log.json in the deck directory.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+    """
+    path = os.path.join(deck_dir, 'render-log.json')
+    with open(path, 'w') as f:
+        json.dump({'entries': []}, f, indent=2)
+        f.write('\n')
+
+
+def load_render_log(deck_dir):
+    """Load render-log.json from the deck directory.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+
+    Returns:
+        dict: The parsed render log.
+
+    Raises:
+        FileNotFoundError: If render-log.json does not exist.
+    """
+    path = os.path.join(deck_dir, 'render-log.json')
+    if not os.path.exists(path):
+        raise FileNotFoundError(f'No render-log.json in {deck_dir}')
+    with open(path) as f:
+        return json.load(f)
+
+
+def append_render_entry(deck_dir, entry):
+    """Append a render attempt entry to the render log.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+        entry: dict with render attempt data (must conform to RenderLog entry schema).
+    """
+    log = load_render_log(deck_dir)
+    log['entries'].append(entry)
+    path = os.path.join(deck_dir, 'render-log.json')
+    tmp_path = path + '.tmp'
+    with open(tmp_path, 'w') as f:
+        json.dump(log, f, indent=2)
+        f.write('\n')
+    os.replace(tmp_path, path)
+
+
+def hash_prompt(prompt_text):
+    """Compute a short hash of a prompt for log deduplication.
+
+    Args:
+        prompt_text: The prompt string.
+
+    Returns:
+        str: First 16 chars of SHA-256 hex digest.
+    """
+    return hashlib.sha256(prompt_text.encode('utf-8')).hexdigest()[:16]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_render_funnel.py -v`
+Expected: 4 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/render_funnel.py tests/test_render_funnel.py
+git commit -m "feat: add render log init/load/append for keynote render tracking"
+```
+
+---
+
+### Task 3: Render Funnel Stage Execution
+
+**Files:**
+- Modify: `src/render_funnel.py`
+- Modify: `tests/test_render_funnel.py`
+
+- [ ] **Step 1: Write failing tests for execute_funnel_stage**
+
+Append to `tests/test_render_funnel.py`:
+
+```python
+from unittest.mock import patch, MagicMock
+from PIL import Image
+
+
+def _create_test_image(path, width=1024, height=576):
+    """Helper to create a test image at the given path."""
+    img = Image.new('RGB', (width, height), color=(0, 107, 94))
+    img.save(path)
+    return path
+
+
+def test_execute_ollama_stage(deck_dir):
+    from src.render_funnel import init_render_log, execute_funnel_stage
+    init_render_log(deck_dir)
+    output_path = os.path.join(deck_dir, 'images', 'slide-01-hero.png')
+
+    with patch('src.render_funnel.subprocess.run') as mock_run:
+        # Simulate generate_image.py writing a file
+        def side_effect(*args, **kwargs):
+            _create_test_image(output_path)
+            result = MagicMock()
+            result.stdout = output_path
+            result.returncode = 0
+            return result
+        mock_run.side_effect = side_effect
+
+        result = execute_funnel_stage(
+            deck_dir=deck_dir,
+            slide_number=1,
+            strategy='full_render',
+            prompt='Test prompt for slide 1',
+            funnel_stage='ollama',
+            model='x/z-image-turbo',
+            output_path=output_path,
+        )
+
+    assert result['status'] == 'generated'
+    assert result['file_path'] == output_path
+    assert result['cost_usd'] == 0.0
+    assert os.path.exists(output_path)
+
+
+def test_execute_cloud_stage(deck_dir):
+    from src.render_funnel import init_render_log, execute_funnel_stage
+    init_render_log(deck_dir)
+    output_path = os.path.join(deck_dir, 'images', 'slide-01-hero.png')
+
+    with patch('src.render_funnel._generate_cloud') as mock_cloud:
+        _create_test_image(output_path, 1280, 720)
+        mock_cloud.return_value = {
+            'file_path': output_path,
+            'provider': 'google',
+            'model_used': 'imagen-4-fast',
+            'cost_usd': 0.02,
+            'status': 'generated',
+        }
+
+        result = execute_funnel_stage(
+            deck_dir=deck_dir,
+            slide_number=1,
+            strategy='full_render',
+            prompt='Test prompt for slide 1',
+            funnel_stage='cloud_low',
+            model='imagen-4-fast',
+            output_path=output_path,
+            provider='google',
+        )
+
+    assert result['status'] == 'generated'
+    assert result['cost_usd'] == 0.02
+
+
+def test_execute_stage_logs_to_render_log(deck_dir):
+    from src.render_funnel import init_render_log, execute_funnel_stage, load_render_log
+    init_render_log(deck_dir)
+    output_path = os.path.join(deck_dir, 'images', 'slide-01-hero.png')
+
+    with patch('src.render_funnel.subprocess.run') as mock_run:
+        def side_effect(*args, **kwargs):
+            _create_test_image(output_path)
+            result = MagicMock()
+            result.stdout = output_path
+            result.returncode = 0
+            return result
+        mock_run.side_effect = side_effect
+
+        execute_funnel_stage(
+            deck_dir=deck_dir,
+            slide_number=1,
+            strategy='full_render',
+            prompt='Test prompt',
+            funnel_stage='ollama',
+            model='x/z-image-turbo',
+            output_path=output_path,
+        )
+
+    log = load_render_log(deck_dir)
+    assert len(log['entries']) == 1
+    assert log['entries'][0]['funnel_stage'] == 'ollama'
+    assert log['entries'][0]['slide_number'] == 1
+
+
+def test_execute_stage_failed(deck_dir):
+    from src.render_funnel import init_render_log, execute_funnel_stage
+    init_render_log(deck_dir)
+    output_path = os.path.join(deck_dir, 'images', 'slide-01-hero.png')
+
+    with patch('src.render_funnel.subprocess.run') as mock_run:
+        mock_run.side_effect = Exception('Ollama not running')
+
+        result = execute_funnel_stage(
+            deck_dir=deck_dir,
+            slide_number=1,
+            strategy='full_render',
+            prompt='Test prompt',
+            funnel_stage='ollama',
+            model='x/z-image-turbo',
+            output_path=output_path,
+        )
+
+    assert result['status'] == 'failed'
+    assert 'error' in result
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_render_funnel.py -k execute -v`
+Expected: FAIL — ImportError
+
+- [ ] **Step 3: Write execute_funnel_stage implementation**
+
+Add to `src/render_funnel.py`:
+
+```python
+import subprocess
+import sys
+
+from src.generate_cloud_image import generate_cloud_image as _generate_cloud_raw
+
+
+# Ollama model → resolution defaults
+_OLLAMA_RESOLUTIONS = {
+    'ollama': {'width': 1024, 'height': 576},
+    'cloud_low': {'width': 1280, 'height': 720},
+    'cloud_full': {'width': 1920, 'height': 1080},
+}
+
+# Cloud provider mapping for funnel stages
+_CLOUD_STAGE_QUALITY = {
+    'cloud_low': 'low',
+    'cloud_full': 'medium',
+}
+
+_CLOUD_STAGE_SIZE = {
+    'cloud_low': '1024x1024',
+    'cloud_full': '1536x1024',
+}
+
+
+def _generate_cloud(prompt, provider, output_path, funnel_stage):
+    """Wrapper for cloud generation with funnel-stage-appropriate settings."""
+    quality = _CLOUD_STAGE_QUALITY.get(funnel_stage, 'medium')
+    size = _CLOUD_STAGE_SIZE.get(funnel_stage, '1536x1024')
+    return _generate_cloud_raw(
+        prompt=prompt,
+        provider=provider,
+        output_path=output_path,
+        quality=quality,
+        size=size,
+    )
+
+
+def execute_funnel_stage(deck_dir, slide_number, strategy, prompt, funnel_stage,
+                         model, output_path, provider=None, iteration=1):
+    """Execute a single render funnel stage for one slide.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+        slide_number: Which slide this render is for.
+        strategy: 'full_render' or 'backdrop_render'.
+        prompt: The image generation prompt text.
+        funnel_stage: 'ollama', 'cloud_low', or 'cloud_full'.
+        model: Model identifier (e.g., 'x/z-image-turbo', 'imagen-4-fast').
+        output_path: Where to save the generated image.
+        provider: Cloud provider name (required for cloud stages).
+        iteration: Iteration number for this stage (default 1).
+
+    Returns:
+        dict: {status, file_path, cost_usd, model, resolution, error?}
+    """
+    prompt_h = hash_prompt(prompt)
+    dims = _OLLAMA_RESOLUTIONS.get(funnel_stage, {'width': 1920, 'height': 1080})
+    resolution = f'{dims["width"]}x{dims["height"]}'
+    cost = 0.0
+
+    try:
+        if funnel_stage == 'ollama':
+            os.makedirs(os.path.dirname(output_path) or '.', exist_ok=True)
+            subprocess.run(
+                [sys.executable, 'src/generate_image.py',
+                 '--prompt', prompt,
+                 '--model', model,
+                 '--output', output_path,
+                 '--width', str(dims['width']),
+                 '--height', str(dims['height'])],
+                check=True, capture_output=True, text=True,
+            )
+        else:
+            result = _generate_cloud(prompt, provider, output_path, funnel_stage)
+            cost = result.get('cost_usd', 0.0)
+            resolution = _CLOUD_STAGE_SIZE.get(funnel_stage, '1536x1024')
+
+        # Log the attempt
+        append_render_entry(deck_dir, {
+            'slide_number': slide_number,
+            'strategy': strategy,
+            'funnel_stage': funnel_stage,
+            'prompt_hash': prompt_h,
+            'model': model,
+            'resolution': resolution,
+            'vision_score': None,
+            'iteration': iteration,
+            'cost_usd': cost,
+            'timestamp': datetime.now(timezone.utc).isoformat(),
+        })
+
+        return {
+            'status': 'generated',
+            'file_path': output_path,
+            'cost_usd': cost,
+            'model': model,
+            'resolution': resolution,
+        }
+
+    except Exception as e:
+        # Log the failure too
+        append_render_entry(deck_dir, {
+            'slide_number': slide_number,
+            'strategy': strategy,
+            'funnel_stage': funnel_stage,
+            'prompt_hash': prompt_h,
+            'model': model,
+            'resolution': resolution,
+            'vision_score': None,
+            'iteration': iteration,
+            'cost_usd': 0.0,
+            'timestamp': datetime.now(timezone.utc).isoformat(),
+        })
+
+        return {
+            'status': 'failed',
+            'file_path': output_path,
+            'cost_usd': 0.0,
+            'model': model,
+            'resolution': resolution,
+            'error': str(e),
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_render_funnel.py -v`
+Expected: 8 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/render_funnel.py tests/test_render_funnel.py
+git commit -m "feat: add execute_funnel_stage for three-stage render orchestration"
+```
+
+---
+
+### Task 4: Assembler — Full Render Slide Builder
+
+**Files:**
+- Modify: `src/assembler/build_deck.js`
+
+- [ ] **Step 1: Add buildFullRenderSlide function**
+
+Add this function after the existing `buildClosingSlide` function and before the `// Run` section at the bottom of `src/assembler/build_deck.js`:
+
+```javascript
+/**
+ * Full-render keynote slide: entire slide is a single AI-generated image.
+ * No text boxes, no shapes — just a full-bleed image + speaker notes.
+ * Logo overlay is optional (controlled by style guide).
+ */
+function buildFullRenderSlide(pptx, slideData, ctx) {
+    const { palette, typo, slidePalette, layouts, SLIDE_W, SLIDE_H, MARGIN, logoPath, hasLogo, noteData, imageData } = ctx;
+
+    const slide = pptx.addSlide();
+
+    // Full-bleed image covering the entire slide
+    if (imageData) {
+        const imgPath = resolveImagePath(imageData.file_path);
+        if (fs.existsSync(imgPath)) {
+            slide.addImage({
+                path: imgPath,
+                x: 0,
+                y: 0,
+                w: SLIDE_W,
+                h: SLIDE_H,
+                sizing: { type: 'cover', w: SLIDE_W, h: SLIDE_H },
+                altText: imageData.alt_text || '',
+            });
+        }
+    }
+
+    // Optional logo overlay (bottom-left, same position as title/closing slides)
+    if (hasLogo) {
+        const logoH = 0.55;
+        const logoW = logoH * (169 / 200);
+        slide.addImage({
+            path: logoPath,
+            x: MARGIN,
+            y: SLIDE_H - MARGIN - logoH,
+            w: logoW,
+            h: logoH,
+            altText: 'Logo',
+        });
+    }
+
+    // Speaker notes
+    if (noteData) {
+        slide.addNotes(noteData.text);
+    }
+}
+```
+
+- [ ] **Step 2: Verify file is syntactically valid**
+
+Run: `node -c src/assembler/build_deck.js && echo "Syntax OK"`
+Expected: Syntax OK
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/assembler/build_deck.js
+git commit -m "feat: add buildFullRenderSlide for keynote full-bleed slides"
+```
+
+---
+
+### Task 5: Assembler — Backdrop Render Slide Builder
+
+**Files:**
+- Modify: `src/assembler/build_deck.js`
+
+- [ ] **Step 1: Add buildBackdropRenderSlide function**
+
+Add this function after `buildFullRenderSlide`:
+
+```javascript
+/**
+ * Backdrop-render keynote slide: AI-generated background image with
+ * programmatic text overlay. Text remains editable in PowerPoint.
+ * A semi-transparent backing rectangle ensures text readability.
+ */
+function buildBackdropRenderSlide(pptx, slideData, ctx) {
+    const { palette, typo, slidePalette, layouts, SLIDE_W, SLIDE_H, MARGIN, noteData, imageData } = ctx;
+    const textColor = slidePalette?.content_slides?.text || palette.text_primary;
+
+    const slide = pptx.addSlide();
+
+    // Full-bleed backdrop image
+    if (imageData) {
+        const imgPath = resolveImagePath(imageData.file_path);
+        if (fs.existsSync(imgPath)) {
+            slide.addImage({
+                path: imgPath,
+                x: 0,
+                y: 0,
+                w: SLIDE_W,
+                h: SLIDE_H,
+                sizing: { type: 'cover', w: SLIDE_W, h: SLIDE_H },
+                altText: imageData.alt_text || '',
+            });
+        }
+    }
+
+    // Semi-transparent text backing — left third of the slide
+    const textZoneW = SLIDE_W * 0.45;
+    slide.addShape(pptx.ShapeType.rect, {
+        x: 0,
+        y: 0,
+        w: textZoneW,
+        h: SLIDE_H,
+        fill: { color: '000000', transparency: 60 },
+    });
+
+    // Heading — white text for contrast against the dark backing
+    const safeX = MARGIN;
+    const headingY = Math.max(SLIDE_H * 0.15, MARGIN);
+    const headingW = textZoneW - 2 * MARGIN;
+    slide.addText(slideData.headline, {
+        x: safeX,
+        y: headingY,
+        w: headingW,
+        h: 1.0,
+        fontSize: typo.heading_sizes?.slide_heading || 32,
+        fontFace: typo.heading_font,
+        color: 'FFFFFF',
+        bold: true,
+        valign: 'bottom',
+        wrap: true,
+    });
+
+    // Body points — white text
+    if (slideData.body_points && slideData.body_points.length > 0) {
+        const bodyY = headingY + 1.2;
+        const bodyH = SLIDE_H - bodyY - MARGIN;
+        const bodyText = slideData.body_points.map(bp => ({
+            text: bp,
+            options: {
+                fontSize: typo.body_size || 18,
+                fontFace: typo.body_font,
+                color: 'FFFFFF',
+                bullet: { type: 'bullet' },
+                lineSpacingMultiple: typo.line_spacing || 1.4,
+                breakLine: true,
+                paraSpaceAfter: 8,
+            },
+        }));
+        slide.addText(bodyText, {
+            x: safeX,
+            y: bodyY,
+            w: headingW,
+            h: bodyH,
+            valign: 'top',
+        });
+    }
+
+    // Speaker notes
+    if (noteData) {
+        slide.addNotes(noteData.text);
+    }
+}
+```
+
+- [ ] **Step 2: Verify file is syntactically valid**
+
+Run: `node -c src/assembler/build_deck.js && echo "Syntax OK"`
+Expected: Syntax OK
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/assembler/build_deck.js
+git commit -m "feat: add buildBackdropRenderSlide for keynote text-over-image slides"
+```
+
+---
+
+### Task 6: Assembler — Strategy Map Awareness
+
+**Files:**
+- Modify: `src/assembler/build_deck.js`
+- Modify: `tests/test_assembler.py`
+
+- [ ] **Step 1: Modify the assembleDeck function to load strategy map and route slides**
+
+In `src/assembler/build_deck.js`, modify the `assembleDeck` function. After loading the existing contracts (around line 93), add:
+
+```javascript
+    // Load strategy map (optional — if absent, all slides use 'composed')
+    const strategyMapPath = path.join(DECK_DIR, 'strategy-map.json');
+    const strategyMap = fs.existsSync(strategyMapPath)
+        ? JSON.parse(fs.readFileSync(strategyMapPath, 'utf-8'))
+        : null;
+
+    // Build a lookup: slide_number -> effective strategy
+    const slideStrategies = {};
+    if (strategyMap) {
+        for (const entry of strategyMap.slides || []) {
+            slideStrategies[entry.slide_number] = entry.speaker_override || entry.strategy;
+        }
+    }
+```
+
+Then modify the main slide loop (the `for (const slideData of outline.slides)` section). Replace the `switch (slideData.slide_type)` with a strategy-first check:
+
+```javascript
+    for (const slideData of outline.slides) {
+        const noteData = findNote(speakerNotes, slideData.slide_number);
+        const imageData = findImage(imageManifest, slideData.slide_number);
+        const chartData = findChart(chartManifest, slideData.slide_number);
+        const strategy = slideStrategies[slideData.slide_number] || 'composed';
+
+        // Strategy-first routing: keynote strategies override slide-type routing
+        if (strategy === 'full_render') {
+            buildFullRenderSlide(pptx, slideData, { palette, typo, slidePalette, layouts, SLIDE_W, SLIDE_H, MARGIN, logoPath, hasLogo, noteData, imageData });
+            continue;
+        }
+        if (strategy === 'backdrop_render') {
+            buildBackdropRenderSlide(pptx, slideData, { palette, typo, slidePalette, layouts, SLIDE_W, SLIDE_H, MARGIN, noteData, imageData });
+            continue;
+        }
+
+        // Composed strategy: use existing slide-type routing
+        switch (slideData.slide_type) {
+            case 'title':
+                buildTitleSlide(pptx, slideData, { palette, typo, slidePalette, layouts, SLIDE_W, SLIDE_H, MARGIN, logoPath, hasLogo, noteData, imageData });
+                break;
+            case 'section_divider':
+                buildSectionDivider(pptx, slideData, { palette, typo, slidePalette, layouts, SLIDE_W, SLIDE_H, MARGIN, noteData });
+                break;
+            case 'closing':
+                buildClosingSlide(pptx, slideData, { palette, typo, slidePalette, layouts, SLIDE_W, SLIDE_H, MARGIN, logoPath, hasLogo, noteData });
+                break;
+            case 'diagram':
+                buildDiagramSlide(pptx, slideData, { palette, typo, slidePalette, layouts, SLIDE_W, SLIDE_H, MARGIN, noteData, imageData });
+                break;
+            case 'data_chart':
+                buildDataChartSlide(pptx, slideData, { palette, typo, slidePalette, layouts, SLIDE_W, SLIDE_H, MARGIN, noteData, chartData });
+                break;
+            case 'code':
+                buildCodeSlide(pptx, slideData, { palette, typo, slidePalette, layouts, SLIDE_W, SLIDE_H, MARGIN, noteData });
+                break;
+            default:
+                buildContentSlide(pptx, slideData, { palette, typo, slidePalette, layouts, SLIDE_W, SLIDE_H, MARGIN, noteData, imageData });
+                break;
+        }
+    }
+```
+
+- [ ] **Step 2: Add a test for strategy-map-aware assembly**
+
+Append to `tests/test_assembler.py`:
+
+```python
+def test_build_deck_without_strategy_map(tmp_path):
+    """Assembler works when strategy-map.json is absent (backward compatible)."""
+    import subprocess
+    # Use the existing test deck at ./tmp/deck if available, otherwise skip
+    deck_dir = './tmp/deck'
+    if not os.path.exists(os.path.join(deck_dir, 'outline.json')):
+        pytest.skip('No test deck available at ./tmp/deck')
+    result = subprocess.run(
+        ['node', 'src/assembler/build_deck.js', '--deck-dir', deck_dir],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0
+    assert 'assembled successfully' in result.stdout.lower()
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_assembler.py -v`
+Expected: All PASSED (5 existing + 1 new = 6)
+
+- [ ] **Step 4: Also verify with the existing deck**
+
+Run: `node src/assembler/build_deck.js --deck-dir ./tmp/deck`
+Expected: Assembly succeeds (backward compatible — no strategy-map.json means all slides use 'composed')
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/assembler/build_deck.js tests/test_assembler.py
+git commit -m "feat: assembler reads strategy-map.json, routes to keynote builders"
+```
+
+---
+
+### Task 7: Full Suite Verification + CLAUDE.md
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `source .venv/bin/activate && python -m pytest tests/ -v`
+Expected: All tests pass
+
+- [ ] **Step 2: Update CLAUDE.md implementation table**
+
+Add to the Implementation Status table:
+
+| Module | Location | Tests | Status |
+|--------|----------|-------|--------|
+| RenderLog schema | `src/schemas/render_log.schema.json` | 3 | Done |
+| Render funnel | `src/render_funnel.py` | 8 | Done |
+| Assembler keynote paths | `src/assembler/build_deck.js` | 6 | Done |
+
+Update the total test count in the header.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md with keynote Sub-plan B modules"
+```

--- a/docs/superpowers/plans/2026-03-29-keynote-pipeline-c-qa-conductor.md
+++ b/docs/superpowers/plans/2026-03-29-keynote-pipeline-c-qa-conductor.md
@@ -1,0 +1,699 @@
+# Keynote Pipeline Sub-Plan C: QA + Conductor Integration
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add strategy-aware QA checks for keynote slides (palette drift, text legibility awareness) and integrate the strategy map step into the conductor pipeline.
+
+**Architecture:** A new QA check module (`keynote_checks.py`) handles palette drift detection for full_render/backdrop_render slides. The QA runner gains strategy-map awareness to skip programmatic text checks on full_render slides. The conductor's step order gains `strategy-map` between `narrative-architect` and `speaker-notes-writer`, and a new `upgrade_slide_strategy` function supports post-hoc single-slide upgrades.
+
+**Tech Stack:** Python 3.14, Pillow (colour extraction), pytest, existing QA framework + conductor + DeckContext
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/qa/checks/keynote_checks.py` | Create | Palette drift check for keynote slides |
+| `tests/test_qa_keynote.py` | Create | Tests for keynote QA checks |
+| `src/qa/checks/__init__.py` | Modify | Register keynote checks |
+| `src/qa/run_qa.py` | Modify | Strategy-map-aware check routing |
+| `src/deckcontext.py` | Modify | Add strategy-map to DEFAULT_STEP_ORDER and CONTRACT_SCHEMAS |
+| `src/conductor.py` | Modify | Add upgrade_slide_strategy function |
+| `tests/test_conductor.py` | Modify | Tests for upgrade function |
+
+---
+
+### Task 1: Palette Drift QA Check
+
+**Files:**
+- Create: `src/qa/checks/keynote_checks.py`
+- Create: `tests/test_qa_keynote.py`
+
+- [ ] **Step 1: Write failing tests for check_palette_drift**
+
+Create `tests/test_qa_keynote.py`:
+
+```python
+"""Tests for keynote-specific QA checks."""
+
+import io
+import os
+import shutil
+import tempfile
+
+import pytest
+from PIL import Image
+from pptx import Presentation
+from pptx.util import Inches
+
+
+@pytest.fixture
+def tmp_dir():
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d)
+
+
+def _make_pptx_with_image(tmp_dir, image_color, filename='test.pptx'):
+    """Create a minimal pptx with a single full-bleed image of the given RGB colour."""
+    prs = Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    slide = prs.slides.add_slide(prs.slide_layouts[6])  # blank layout
+
+    # Create image in memory
+    img = Image.new('RGB', (1920, 1080), color=image_color)
+    img_path = os.path.join(tmp_dir, 'test_img.png')
+    img.save(img_path)
+    slide.shapes.add_picture(img_path, 0, 0, Inches(13.333), Inches(7.5))
+
+    pptx_path = os.path.join(tmp_dir, filename)
+    prs.save(pptx_path)
+    return pptx_path
+
+
+def test_palette_drift_within_tolerance(tmp_dir):
+    from src.qa.checks.keynote_checks import check_palette_drift
+    # Image is exact brand teal — no drift
+    pptx_path = _make_pptx_with_image(tmp_dir, (0, 107, 94))  # #006B5E
+    prs = Presentation(pptx_path)
+    slide = prs.slides[0]
+    brand_palette = ['006B5E', '5CDBC0', '4B635B', 'F5FBF7']
+    issues = check_palette_drift(slide, 1, brand_palette=brand_palette)
+    assert len(issues) == 0
+
+
+def test_palette_drift_detected(tmp_dir):
+    from src.qa.checks.keynote_checks import check_palette_drift
+    # Image is bright red — completely off-brand
+    pptx_path = _make_pptx_with_image(tmp_dir, (255, 0, 0))
+    prs = Presentation(pptx_path)
+    slide = prs.slides[0]
+    brand_palette = ['006B5E', '5CDBC0', '4B635B', 'F5FBF7']
+    issues = check_palette_drift(slide, 1, brand_palette=brand_palette)
+    assert len(issues) >= 1
+    assert issues[0]['category'] == 'palette_drift'
+    assert issues[0]['severity'] == 'warning'
+
+
+def test_palette_drift_no_images_no_issues(tmp_dir):
+    from src.qa.checks.keynote_checks import check_palette_drift
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    brand_palette = ['006B5E']
+    issues = check_palette_drift(slide, 1, brand_palette=brand_palette)
+    assert len(issues) == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_qa_keynote.py -v`
+Expected: FAIL — ModuleNotFoundError
+
+- [ ] **Step 3: Write check_palette_drift implementation**
+
+Create `src/qa/checks/keynote_checks.py`:
+
+```python
+"""Keynote-specific QA checks.
+
+Implements palette drift detection for full_render and backdrop_render slides.
+Uses Pillow to extract dominant colours from slide images and compare against
+the brand palette using CIE deltaE distance.
+"""
+
+import io
+import math
+
+from PIL import Image
+
+
+def _hex_to_rgb(hex_str):
+    """Convert 6-char hex to (R, G, B) tuple."""
+    hex_str = hex_str.lstrip('#')
+    return (int(hex_str[0:2], 16), int(hex_str[2:4], 16), int(hex_str[4:6], 16))
+
+
+def _rgb_distance(c1, c2):
+    """Euclidean distance between two RGB tuples. Simple but effective for drift detection."""
+    return math.sqrt(sum((a - b) ** 2 for a, b in zip(c1, c2)))
+
+
+def _extract_dominant_colours(image_blob, num_colours=5):
+    """Extract dominant colours from an image blob using Pillow quantize."""
+    img = Image.open(io.BytesIO(image_blob)).convert('RGB')
+    # Resize for speed, then quantize
+    small = img.resize((100, 100))
+    quantized = small.quantize(colors=num_colours, method=Image.Quantize.MEDIANCUT)
+    palette = quantized.getpalette()[:num_colours * 3]
+    colours = []
+    for i in range(0, len(palette), 3):
+        colours.append((palette[i], palette[i + 1], palette[i + 2]))
+    return colours
+
+
+def _min_distance_to_palette(colour, brand_colours_rgb):
+    """Minimum RGB distance from a colour to any brand palette colour."""
+    if not brand_colours_rgb:
+        return 0
+    return min(_rgb_distance(colour, bc) for bc in brand_colours_rgb)
+
+
+# Threshold: RGB distance above which a dominant colour is considered off-brand.
+# 80 ≈ noticeable colour shift (e.g., teal vs blue). 120 ≈ clearly wrong palette.
+_DRIFT_THRESHOLD = 100
+_DRIFT_MAX_OFF_BRAND = 3  # Max dominant colours allowed to be off-brand
+
+
+def check_palette_drift(slide, slide_number, brand_palette=None, config=None):
+    """Check if images on a slide drift from the brand palette.
+
+    Args:
+        slide: python-pptx slide object.
+        slide_number: 1-based slide index.
+        brand_palette: list of 6-char hex strings (e.g., ['006B5E', '5CDBC0']).
+        config: optional QA config dict.
+
+    Returns:
+        list of finding dicts.
+    """
+    if not brand_palette:
+        return []
+
+    brand_rgb = [_hex_to_rgb(h) for h in brand_palette]
+    # Also consider black, white, and near-black/near-white as always acceptable
+    neutral_colours = [(0, 0, 0), (255, 255, 255), (30, 30, 30), (240, 240, 240)]
+    acceptable_rgb = brand_rgb + neutral_colours
+
+    issues = []
+    for shape in slide.shapes:
+        if shape.shape_type == 13:  # MSO_SHAPE_TYPE.PICTURE
+            try:
+                dominant = _extract_dominant_colours(shape.image.blob, num_colours=5)
+                off_brand_count = 0
+                for colour in dominant:
+                    min_dist = _min_distance_to_palette(colour, acceptable_rgb)
+                    if min_dist > _DRIFT_THRESHOLD:
+                        off_brand_count += 1
+
+                if off_brand_count >= _DRIFT_MAX_OFF_BRAND:
+                    issues.append({
+                        'slide_number': slide_number,
+                        'severity': 'warning',
+                        'category': 'palette_drift',
+                        'description': f'{off_brand_count}/{len(dominant)} dominant colours are off-brand (threshold: RGB distance > {_DRIFT_THRESHOLD})',
+                        'suggested_fix': 'Regenerate image with stronger brand colour constraints in the prompt.',
+                        'affected_element': shape.name,
+                        'auto_fixable': False,
+                    })
+            except Exception:
+                pass  # Skip if image can't be read
+
+    return issues
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_qa_keynote.py -v`
+Expected: 3 PASSED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/qa/checks/keynote_checks.py tests/test_qa_keynote.py
+git commit -m "feat: add check_palette_drift for keynote slide colour compliance"
+```
+
+---
+
+### Task 2: Strategy-Aware QA Routing
+
+**Files:**
+- Modify: `src/qa/checks/__init__.py`
+- Modify: `src/qa/run_qa.py`
+- Modify: `tests/test_qa_keynote.py`
+
+- [ ] **Step 1: Write failing tests for strategy-aware QA**
+
+Append to `tests/test_qa_keynote.py`:
+
+```python
+def test_run_qa_skips_text_checks_on_full_render(tmp_dir):
+    """full_render slides should not get wall-of-text or font-size errors."""
+    import json
+    from src.qa.run_qa import run_qa
+
+    # Create a deck dir with a strategy map marking slide 1 as full_render
+    deck_dir = os.path.join(tmp_dir, 'deck')
+    os.makedirs(deck_dir, exist_ok=True)
+    strategy_map = {
+        'approval_mode': 'review',
+        'slides': [{'slide_number': 1, 'strategy': 'full_render', 'rationale': 'test', 'render_funnel': ['ollama']}],
+    }
+    with open(os.path.join(deck_dir, 'strategy-map.json'), 'w') as f:
+        json.dump(strategy_map, f)
+
+    # Create a minimal pptx with one image-only slide
+    pptx_path = _make_pptx_with_image(tmp_dir, (0, 107, 94), 'qa_test.pptx')
+    report = run_qa(pptx_path, deck_dir)
+
+    # Should not have wall-of-text or font-size errors for slide 1
+    text_errors = [f for f in report['findings']
+                   if f['slide_number'] == 1 and f['category'] in ('text_overflow', 'consistency')]
+    assert len(text_errors) == 0
+
+
+def test_run_qa_applies_palette_drift_on_full_render(tmp_dir):
+    """full_render slides should get palette drift checks."""
+    import json
+    from src.qa.run_qa import run_qa
+
+    deck_dir = os.path.join(tmp_dir, 'deck')
+    os.makedirs(deck_dir, exist_ok=True)
+    strategy_map = {
+        'approval_mode': 'review',
+        'slides': [{'slide_number': 1, 'strategy': 'full_render', 'rationale': 'test', 'render_funnel': ['ollama']}],
+    }
+    with open(os.path.join(deck_dir, 'strategy-map.json'), 'w') as f:
+        json.dump(strategy_map, f)
+
+    # Brand profile with palette
+    brand_profile = {'palette': {'primary': '006B5E', 'secondary': '4B635B'}}
+    with open(os.path.join(deck_dir, 'brand-profile.json'), 'w') as f:
+        json.dump(brand_profile, f)
+
+    # Create pptx with an off-brand red image
+    pptx_path = _make_pptx_with_image(tmp_dir, (255, 0, 0), 'drift_test.pptx')
+    report = run_qa(pptx_path, deck_dir)
+
+    drift_findings = [f for f in report['findings'] if f['category'] == 'palette_drift']
+    assert len(drift_findings) >= 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_qa_keynote.py -k "run_qa" -v`
+Expected: FAIL (run_qa doesn't support strategy map yet)
+
+- [ ] **Step 3: Register keynote checks in __init__.py**
+
+Add to the bottom of `src/qa/checks/__init__.py`:
+
+```python
+from .keynote_checks import check_palette_drift
+
+# Per-slide keynote checks (applied only to full_render/backdrop_render slides)
+KEYNOTE_CHECKS = [
+    check_palette_drift,
+]
+```
+
+- [ ] **Step 4: Modify run_qa to load strategy map and route checks**
+
+Modify `src/qa/run_qa.py` — the `run_qa` function needs to:
+
+1. Load the strategy map (optional) and brand profile palette
+2. For each slide, check if its strategy is `full_render` — if so, skip programmatic text checks and run keynote checks instead
+3. For `backdrop_render` slides, run both standard checks and keynote checks
+4. For `composed` slides, run standard checks only (unchanged)
+
+Update the `run_qa` function signature to accept `deck_dir` (already present), load strategy map and brand profile from there. The core change is wrapping the per-slide check loop with strategy awareness:
+
+```python
+def run_qa(pptx_path, deck_dir='./tmp/deck', duration_minutes=None, config=None):
+    """Run QA checks with strategy-aware routing for keynote slides."""
+    cfg = config or QA_CONFIG
+    prs = Presentation(pptx_path)
+    findings = []
+
+    # Load strategy map (optional — absent means all slides are 'composed')
+    strategy_map_path = os.path.join(deck_dir, 'strategy-map.json')
+    slide_strategies = {}
+    if os.path.exists(strategy_map_path):
+        with open(strategy_map_path) as f:
+            strategy_map = json.load(f)
+        for entry in strategy_map.get('slides', []):
+            slide_strategies[entry['slide_number']] = entry.get('speaker_override') or entry['strategy']
+
+    # Load brand palette for palette drift checks
+    brand_palette = []
+    brand_profile_path = os.path.join(deck_dir, 'brand-profile.json')
+    if os.path.exists(brand_profile_path):
+        with open(brand_profile_path) as f:
+            bp = json.load(f)
+        palette = bp.get('palette', {})
+        brand_palette = [v for v in palette.values() if isinstance(v, str) and len(v) == 6]
+
+    # Step 1: Per-slide checks (strategy-aware)
+    for i, slide in enumerate(prs.slides):
+        slide_number = i + 1
+        strategy = slide_strategies.get(slide_number, 'composed')
+
+        if strategy == 'full_render':
+            # Full render: skip text checks, run image + keynote checks
+            for check_fn in IMAGE_QUALITY_CHECKS:
+                findings.extend(check_fn(slide, slide_number, prs, config=cfg))
+            for check_fn in KEYNOTE_CHECKS:
+                findings.extend(check_fn(slide, slide_number, brand_palette=brand_palette, config=cfg))
+        elif strategy == 'backdrop_render':
+            # Backdrop: run standard text checks + image + keynote checks
+            for check_fn in STRUCTURAL_CHECKS:
+                findings.extend(check_fn(slide, slide_number, config=cfg))
+            for check_fn in STRUCTURAL_CHECKS_WITH_PRESENTATION:
+                findings.extend(check_fn(slide, slide_number, prs, config=cfg))
+            for check_fn in IMAGE_QUALITY_CHECKS:
+                findings.extend(check_fn(slide, slide_number, prs, config=cfg))
+            for check_fn in KEYNOTE_CHECKS:
+                findings.extend(check_fn(slide, slide_number, brand_palette=brand_palette, config=cfg))
+            for check_fn in VISUAL_CHECKS:
+                try:
+                    findings.extend(check_fn(slide, slide_number, config=cfg))
+                except Exception:
+                    pass
+        else:
+            # Composed: standard checks (unchanged)
+            for check_fn in STRUCTURAL_CHECKS:
+                findings.extend(check_fn(slide, slide_number, config=cfg))
+            for check_fn in STRUCTURAL_CHECKS_WITH_PRESENTATION:
+                findings.extend(check_fn(slide, slide_number, prs, config=cfg))
+            for check_fn in IMAGE_QUALITY_CHECKS:
+                findings.extend(check_fn(slide, slide_number, prs, config=cfg))
+            for check_fn in VISUAL_CHECKS:
+                try:
+                    findings.extend(check_fn(slide, slide_number, config=cfg))
+                except Exception:
+                    pass
+
+    # Step 2-5: Deck-level checks (unchanged)
+    for check_fn in DECK_STRUCTURAL_CHECKS:
+        findings.extend(check_fn(prs, config=cfg))
+    if duration_minutes:
+        findings.extend(check_slide_count_ratio(prs, duration_minutes, config=cfg))
+    for check_fn in CONSISTENCY_CHECKS:
+        findings.extend(check_fn(prs, config=cfg))
+    for check_fn in ANIMATION_CHECKS:
+        findings.extend(check_fn(prs, config=cfg))
+    colours_used = set()
+    for slide in prs.slides:
+        for shape in slide.shapes:
+            if shape.has_text_frame:
+                for para in shape.text_frame.paragraphs:
+                    for run in para.runs:
+                        try:
+                            if run.font.color and run.font.color.rgb:
+                                rgb = run.font.color.rgb
+                                colours_used.add((rgb[0], rgb[1], rgb[2]))
+                        except (AttributeError, TypeError):
+                            pass
+    for check_fn in COLOUR_CHECKS:
+        findings.extend(check_fn(colours_used, config=cfg))
+
+    return generate_report(findings, pptx_path, len(prs.slides))
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_qa_keynote.py -v`
+Expected: 5 PASSED
+
+- [ ] **Step 6: Run full QA test suite to check for regressions**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_qa.py tests/test_qa_keynote.py -v 2>&1 | tail -5`
+Expected: All pass (60 existing + 5 new)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/qa/checks/__init__.py src/qa/checks/keynote_checks.py src/qa/run_qa.py tests/test_qa_keynote.py
+git commit -m "feat: strategy-aware QA routing with palette drift checks for keynote slides"
+```
+
+---
+
+### Task 3: Conductor — Add Strategy Map to Pipeline Step Order
+
+**Files:**
+- Modify: `src/deckcontext.py`
+- Modify: `tests/test_conductor.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/test_conductor.py`:
+
+```python
+def test_default_step_order_includes_strategy_map():
+    from src.deckcontext import DEFAULT_STEP_ORDER
+    assert 'strategy-map' in DEFAULT_STEP_ORDER
+    # Strategy map should come after narrative-architect and before speaker-notes-writer
+    arch_idx = DEFAULT_STEP_ORDER.index('narrative-architect')
+    strat_idx = DEFAULT_STEP_ORDER.index('strategy-map')
+    notes_idx = DEFAULT_STEP_ORDER.index('speaker-notes-writer')
+    assert arch_idx < strat_idx < notes_idx
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_conductor.py::test_default_step_order_includes_strategy_map -v`
+Expected: FAIL — 'strategy-map' not in list
+
+- [ ] **Step 3: Update DEFAULT_STEP_ORDER and CONTRACT_SCHEMAS**
+
+In `src/deckcontext.py`, add `'strategy-map'` to DEFAULT_STEP_ORDER after `'narrative-architect'`:
+
+```python
+DEFAULT_STEP_ORDER = [
+    'validate-brief',
+    'brand-manager',
+    'slide-stylist',
+    'narrative-architect',
+    'strategy-map',
+    'speaker-notes-writer',
+    'imagegen-bridge',
+    'chart-renderer',
+    'deck-assembler',
+    'deck-qa',
+]
+```
+
+Also add the strategy map to CONTRACT_SCHEMAS:
+
+```python
+CONTRACT_SCHEMAS = {
+    'talk-brief': 'talk_brief.schema.json',
+    'pipeline-state': 'pipeline_state.schema.json',
+    'style-guide': 'style_guide.schema.json',
+    'outline': 'slide_outline.schema.json',
+    'speaker-notes': 'speaker_notes.schema.json',
+    'image-manifest': 'image_manifest.schema.json',
+    'chart-manifest': 'chart_manifest.schema.json',
+    'qa-report': 'qa_report.schema.json',
+    'brand-profile': 'brand_profile.schema.json',
+    'strategy-map': 'strategy_map.schema.json',
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_conductor.py -v`
+Expected: All pass (19 existing + 1 new = 20)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/deckcontext.py tests/test_conductor.py
+git commit -m "feat: add strategy-map to pipeline step order and contract schemas"
+```
+
+---
+
+### Task 4: Conductor — Upgrade Slide Strategy Function
+
+**Files:**
+- Modify: `src/conductor.py`
+- Modify: `tests/test_conductor.py`
+
+- [ ] **Step 1: Write failing tests for upgrade_slide_strategy**
+
+Append to `tests/test_conductor.py`:
+
+```python
+def test_upgrade_slide_strategy(tmp_path):
+    import json
+    from src.conductor import init_pipeline
+    from src.slide_prompt_composer import build_strategy_map, save_strategy_map
+    from src.conductor import upgrade_slide_strategy
+
+    deck_dir = str(tmp_path)
+    init_pipeline(deck_dir, budget_usd=10.0)
+
+    # Create a minimal outline and strategy map
+    outline = {
+        'narrative_arc': 'test',
+        'estimated_duration_minutes': 10,
+        'slides': [
+            {'slide_number': 1, 'slide_type': 'title', 'headline': 'Title', 'visual_type': 'hero_image'},
+            {'slide_number': 2, 'slide_type': 'content', 'headline': 'Content',
+             'body_points': ['A', 'B', 'C', 'D'], 'visual_type': 'hero_image'},
+        ],
+    }
+    strategy_map = build_strategy_map(outline)
+    save_strategy_map(deck_dir, strategy_map)
+
+    # Slide 2 should be backdrop_render (4 bullets)
+    assert strategy_map['slides'][1]['strategy'] == 'backdrop_render'
+
+    # Upgrade slide 2 to full_render
+    updated = upgrade_slide_strategy(deck_dir, slide_number=2, new_strategy='full_render')
+    assert updated['slides'][1]['speaker_override'] == 'full_render'
+    assert updated['slides'][1]['render_funnel'] == ['ollama', 'cloud_low', 'cloud_full']
+
+
+def test_upgrade_slide_strategy_logs_approval(tmp_path):
+    import json
+    from src.conductor import init_pipeline, get_pipeline_state
+    from src.slide_prompt_composer import build_strategy_map, save_strategy_map
+    from src.conductor import upgrade_slide_strategy
+
+    deck_dir = str(tmp_path)
+    init_pipeline(deck_dir, budget_usd=10.0)
+
+    outline = {
+        'narrative_arc': 'test',
+        'estimated_duration_minutes': 10,
+        'slides': [
+            {'slide_number': 1, 'slide_type': 'title', 'headline': 'Title', 'visual_type': 'hero_image'},
+        ],
+    }
+    strategy_map = build_strategy_map(outline)
+    save_strategy_map(deck_dir, strategy_map)
+
+    upgrade_slide_strategy(deck_dir, slide_number=1, new_strategy='backdrop_render')
+    state = get_pipeline_state(deck_dir)
+    approvals = [a for a in state['speaker_approvals'] if a['decision'] == 'strategy_override']
+    assert len(approvals) == 1
+    assert 'slide 1' in approvals[0]['context'].lower()
+
+
+def test_upgrade_slide_strategy_invalid_slide(tmp_path):
+    import json
+    from src.conductor import init_pipeline
+    from src.slide_prompt_composer import build_strategy_map, save_strategy_map
+    from src.conductor import upgrade_slide_strategy
+
+    deck_dir = str(tmp_path)
+    init_pipeline(deck_dir, budget_usd=10.0)
+
+    outline = {
+        'narrative_arc': 'test',
+        'estimated_duration_minutes': 10,
+        'slides': [
+            {'slide_number': 1, 'slide_type': 'title', 'headline': 'Title', 'visual_type': 'hero_image'},
+        ],
+    }
+    strategy_map = build_strategy_map(outline)
+    save_strategy_map(deck_dir, strategy_map)
+
+    with pytest.raises(KeyError, match='slide 99'):
+        upgrade_slide_strategy(deck_dir, slide_number=99, new_strategy='full_render')
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_conductor.py -k upgrade -v`
+Expected: FAIL — ImportError
+
+- [ ] **Step 3: Write upgrade_slide_strategy implementation**
+
+Add to `src/conductor.py`:
+
+```python
+from src.slide_prompt_composer import load_strategy_map, save_strategy_map
+
+
+def upgrade_slide_strategy(deck_dir, slide_number, new_strategy):
+    """Upgrade a single slide's rendering strategy (post-hoc).
+
+    Updates the strategy map with a speaker_override and adjusts the
+    render funnel. Logs a speaker approval entry.
+
+    Args:
+        deck_dir: Path to the deck working directory.
+        slide_number: Which slide to upgrade.
+        new_strategy: 'full_render', 'backdrop_render', or 'composed'.
+
+    Returns:
+        dict: The updated strategy map.
+
+    Raises:
+        KeyError: If slide_number is not in the strategy map.
+    """
+    strategy_map = load_strategy_map(deck_dir)
+    found = False
+    for entry in strategy_map.get('slides', []):
+        if entry['slide_number'] == slide_number:
+            entry['speaker_override'] = new_strategy
+            if new_strategy in ('full_render', 'backdrop_render'):
+                entry['render_funnel'] = ['ollama', 'cloud_low', 'cloud_full']
+            else:
+                entry['render_funnel'] = ['ollama']
+            found = True
+            break
+
+    if not found:
+        raise KeyError(f'No strategy map entry for slide {slide_number}')
+
+    save_strategy_map(deck_dir, strategy_map)
+    log_speaker_approval(
+        deck_dir,
+        'strategy_override',
+        f'Slide {slide_number} upgraded to {new_strategy}',
+    )
+    return strategy_map
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_conductor.py -v`
+Expected: All pass (19 existing + 1 step order + 3 upgrade = 23)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/conductor.py tests/test_conductor.py
+git commit -m "feat: add upgrade_slide_strategy for post-hoc keynote upgrades"
+```
+
+---
+
+### Task 5: Full Suite Verification + CLAUDE.md
+
+- [ ] **Step 1: Run the complete test suite**
+
+Run: `source .venv/bin/activate && python -m pytest tests/ -v`
+Expected: All tests pass
+
+- [ ] **Step 2: Verify existing deck still assembles and QAs correctly**
+
+Run: `node src/assembler/build_deck.js --deck-dir ./tmp/deck && source .venv/bin/activate && python -m src.qa.run_qa --pptx-path ./tmp/deck/output/presentation.pptx --deck-dir ./tmp/deck --duration 11`
+Expected: Assembly succeeds, QA runs (same accepted findings as before)
+
+- [ ] **Step 3: Update CLAUDE.md**
+
+Add to the Implementation Status table:
+
+| Module | Location | Tests | Status |
+|--------|----------|-------|--------|
+| Keynote QA checks | `src/qa/checks/keynote_checks.py` | 5 | Done |
+| Strategy-aware QA routing | `src/qa/run_qa.py` | 5 | Done |
+| Pipeline step order update | `src/deckcontext.py` | 1 | Done |
+| Upgrade slide strategy | `src/conductor.py` | 3 | Done |
+
+Update the total test count.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md with keynote Sub-plan C modules"
+```


### PR DESCRIPTION
## Summary
- Update `deck-conductor.md` — Step 3.5 (strategy map), keynote upgrade workflow, render funnel note, prompt-engineer in tools list
- Update `imagegen-bridge/SKILL.md` — strategy-map.json input, render funnel Step 4.5, prompt-engineer dispatch
- Update `deck-assembler/SKILL.md` — strategy-map.json as optional prerequisite, strategy-aware routing note
- Update `deck-qa/SKILL.md` — keynote checks documentation (AP-26 palette drift), strategy-aware routing
- Create `strategy-map/SKILL.md` — new skill for slide strategy classification
- Add all 4 implementation plan files to docs/superpowers/plans/

This completes the keynote pipeline wiring. All code exists, all skills now know how to use it.

Ref: #7

## Test plan
- [x] No code changes — skill/agent docs only
- [x] `strategy-map` skill visible in Claude Code skill list
- [x] 446 tests still pass (verified before branching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)