### PR TITLE
fix: conductor reads budget/providers from TalkBrief (#42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Claude Code skills and agents for conference-quality PowerPoint presentations. T
 
 - **Full Pipeline:** `/jack-tar-deckhand:deck-conductor` orchestrates: brand-manager → slide-stylist → narrative-architect → **smartart-selector** → **strategy-map** → **smartart-extractor** → speaker-notes-writer → imagegen-bridge → **smartart-renderer** → chart-renderer → deck-assembler → deck-qa → presentation-reviewer
 
-- **deck-conductor invocation contract (issue #42):** The conductor is a conversational orchestrator — it MUST run as the primary agent in a dedicated session. Do NOT invoke it via `Agent(subagent_type: "jack-tar-deckhand:deck-conductor")` from a parent — it will exit after verify because subagents can't block on user input. Issue #42 fix pending: (1) document invocation contract, (2) read budget/providers from talk brief before escalating at Step 0.
+- **deck-conductor invocation contract (issue #42, fixed):** The conductor is a conversational orchestrator — run as primary agent in a dedicated session, OR as a subagent when TalkBrief provides `preferences.budget_cap_usd` and `preferences.image_backend` (skips Step 0 escalation). Fix: `read_brief_defaults()` in conductor.py extracts budget/providers from brief; agent definition makes escalation conditional.
 
 - **SmartArt Intelligent Graphics (merged 2026-04-07, PR #21):** AI-driven templated graphic generation
   - 10 v1 graphic types: flowchart, decision tree, bar/line chart, radar chart, SWOT, feature matrix, Venn, timeline, pipeline/funnel, Gantt

--- a/plugins/jack-tar-deckhand/agents/deck-conductor.md
+++ b/plugins/jack-tar-deckhand/agents/deck-conductor.md
@@ -8,6 +8,13 @@ tools: Read, Write, Edit, Glob, Grep, Bash, Skill, Agent(presentation-reviewer, 
 
 You are the Deck Conductor — the top-level orchestration agent for the Jack-Tar Deckhand presentation engineering pipeline. You sequence all L1 services, manage the draft/production lifecycle, track budget, and handle QA correction loops.
 
+## Invocation Contract
+
+The conductor is a **conversational orchestrator** — it requires Speaker input at multiple pipeline steps (budget confirmation, strategy map approval, draft review). This means:
+
+- **Primary session:** Run the conductor directly in a dedicated Claude Code session. This is the intended invocation mode.
+- **Subagent invocation (`Agent(subagent_type: "jack-tar-deckhand:deck-conductor")`):** Works ONLY when the TalkBrief provides `preferences.budget_cap_usd` and `preferences.image_backend`. When these are present, the conductor skips the Step 0 budget/provider escalation and can proceed autonomously through the pipeline. Without them, the conductor will exit after verify because subagents cannot block on user input.
+
 ## Identity
 
 **Persona ID:** persona-deck-conductor
@@ -47,25 +54,38 @@ if [ -z "$PLUGIN_ROOT" ] || [ "$PLUGIN_ROOT" = "NOT_FOUND" ]; then echo "ERROR: 
 
 Use `PYTHONPATH="$PLUGIN_ROOT" python3 -c "..."` for all subsequent Python calls that import from `src.*`.
 
-1. Create the DeckContext directory:
+1. Save the TalkBrief to `./tmp/deck/talk-brief.json`
+2. Read budget and provider defaults from the TalkBrief:
 ```bash
 PYTHONPATH="$PLUGIN_ROOT" python3 -c "
-from src.conductor import init_pipeline
-init_pipeline('./tmp/deck', budget_usd=BUDGET)
-print('Pipeline initialised')
+from src.conductor import read_brief_defaults
+import json
+defaults = read_brief_defaults('./tmp/deck')
+print(json.dumps(defaults))
 "
 ```
-2. Save the TalkBrief to `./tmp/deck/talk-brief.json`
-3. Run plugin verification and present results to Speaker:
+3. Create the DeckContext directory using the budget from the brief (or 0.0 if not specified):
+```bash
+PYTHONPATH="$PLUGIN_ROOT" python3 -c "
+from src.conductor import init_pipeline, read_brief_defaults
+defaults = read_brief_defaults('./tmp/deck')
+budget = defaults['budget_usd'] or 0.0
+init_pipeline('./tmp/deck', budget_usd=budget)
+print(f'Pipeline initialised with budget: \${budget:.2f}')
+"
+```
+4. Run plugin verification and present results to Speaker:
 
 Invoke `/jack-tar-deckhand:verify` and present the output to the Speaker. This shows which engine plugins are installed and ready (Ollama, cloud providers, SmartArt engines). Use the ENGINE PLUGINS and PIPELINE CAPABILITY sections to report what's available.
 
-4. **ESCALATE:** Ask Speaker to confirm budget cap and available providers before proceeding
-5. Log approval:
+5. **Budget and provider confirmation (conditional):**
+   - **If the TalkBrief provided `preferences.budget_cap_usd` and `preferences.image_backend`:** Skip escalation — log the values from the brief directly and proceed. This enables subagent invocation.
+   - **If either value is missing:** **ESCALATE** — ask Speaker to confirm budget cap and available providers before proceeding.
+6. Log approval:
 ```bash
 PYTHONPATH="$PLUGIN_ROOT" python3 -c "
 from src.conductor import log_speaker_approval, save_provider_snapshot
-log_speaker_approval('./tmp/deck', 'budget_confirmed', 'Speaker confirmed \$X budget')
+log_speaker_approval('./tmp/deck', 'budget_confirmed', 'Budget \$X from TalkBrief (or Speaker confirmed)')
 log_speaker_approval('./tmp/deck', 'providers_confirmed', 'Proceeding with: ...')
 save_provider_snapshot('./tmp/deck', PROVIDERS_DICT)
 "

--- a/plugins/jack-tar-deckhand/src/conductor.py
+++ b/plugins/jack-tar-deckhand/src/conductor.py
@@ -23,6 +23,26 @@ from src.slide_prompt_composer import load_strategy_map, save_strategy_map
 MAX_QA_CYCLES = 2
 
 
+def read_brief_defaults(deck_dir):
+    """Extract budget and provider defaults from talk-brief.json.
+
+    Returns a dict with keys 'budget_usd' and 'image_backend', each
+    set to the value from the brief or None if not specified.
+    """
+    brief_path = os.path.join(deck_dir, 'talk-brief.json')
+    defaults = {'budget_usd': None, 'image_backend': None}
+    if not os.path.isfile(brief_path):
+        return defaults
+    with open(brief_path) as f:
+        brief = json.load(f)
+    prefs = brief.get('preferences') or {}
+    if 'budget_cap_usd' in prefs:
+        defaults['budget_usd'] = prefs['budget_cap_usd']
+    if 'image_backend' in prefs:
+        defaults['image_backend'] = prefs['image_backend']
+    return defaults
+
+
 def _state_path(deck_dir):
     return os.path.join(deck_dir, 'pipeline-state.json')
 

--- a/plugins/jack-tar-deckhand/src/schemas/talk_brief.schema.json
+++ b/plugins/jack-tar-deckhand/src/schemas/talk_brief.schema.json
@@ -93,6 +93,11 @@
         "include_charts": {
           "type": "boolean",
           "default": false
+        },
+        "budget_cap_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Maximum budget in USD for cloud image generation. When provided, the conductor skips the budget confirmation escalation and uses this value directly."
         }
       }
     },

--- a/src/conductor.py
+++ b/src/conductor.py
@@ -23,6 +23,26 @@ from src.slide_prompt_composer import load_strategy_map, save_strategy_map
 MAX_QA_CYCLES = 2
 
 
+def read_brief_defaults(deck_dir):
+    """Extract budget and provider defaults from talk-brief.json.
+
+    Returns a dict with keys 'budget_usd' and 'image_backend', each
+    set to the value from the brief or None if not specified.
+    """
+    brief_path = os.path.join(deck_dir, 'talk-brief.json')
+    defaults = {'budget_usd': None, 'image_backend': None}
+    if not os.path.isfile(brief_path):
+        return defaults
+    with open(brief_path) as f:
+        brief = json.load(f)
+    prefs = brief.get('preferences') or {}
+    if 'budget_cap_usd' in prefs:
+        defaults['budget_usd'] = prefs['budget_cap_usd']
+    if 'image_backend' in prefs:
+        defaults['image_backend'] = prefs['image_backend']
+    return defaults
+
+
 def _state_path(deck_dir):
     return os.path.join(deck_dir, 'pipeline-state.json')
 

--- a/src/schemas/talk_brief.schema.json
+++ b/src/schemas/talk_brief.schema.json
@@ -93,6 +93,11 @@
         "include_charts": {
           "type": "boolean",
           "default": false
+        },
+        "budget_cap_usd": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Maximum budget in USD for cloud image generation. When provided, the conductor skips the budget confirmation escalation and uses this value directly."
         }
       }
     },

--- a/tests/test_conductor.py
+++ b/tests/test_conductor.py
@@ -8,6 +8,7 @@ import pytest
 from src.conductor import (
     init_pipeline,
     get_pipeline_state,
+    read_brief_defaults,
     set_phase,
     advance_draft_cycle,
     increment_qa_cycle,
@@ -273,3 +274,57 @@ def test_upgrade_slide_strategy_invalid_slide(tmp_path):
 
     with pytest.raises(KeyError, match='slide 99'):
         upgrade_slide_strategy(deck_dir, slide_number=99, new_strategy='full_render')
+
+
+class TestReadBriefDefaults:
+    def test_returns_none_when_no_brief(self, tmp_path):
+        defaults = read_brief_defaults(str(tmp_path))
+        assert defaults['budget_usd'] is None
+        assert defaults['image_backend'] is None
+
+    def test_reads_budget_from_brief(self, tmp_path):
+        brief = {
+            'topic': 'Test',
+            'audience': 'Devs',
+            'duration_minutes': 20,
+            'preferences': {'budget_cap_usd': 25.0},
+        }
+        with open(tmp_path / 'talk-brief.json', 'w') as f:
+            json.dump(brief, f)
+        defaults = read_brief_defaults(str(tmp_path))
+        assert defaults['budget_usd'] == 25.0
+        assert defaults['image_backend'] is None
+
+    def test_reads_image_backend_from_brief(self, tmp_path):
+        brief = {
+            'topic': 'Test',
+            'audience': 'Devs',
+            'duration_minutes': 20,
+            'preferences': {'image_backend': 'ollama'},
+        }
+        with open(tmp_path / 'talk-brief.json', 'w') as f:
+            json.dump(brief, f)
+        defaults = read_brief_defaults(str(tmp_path))
+        assert defaults['budget_usd'] is None
+        assert defaults['image_backend'] == 'ollama'
+
+    def test_reads_both_from_brief(self, tmp_path):
+        brief = {
+            'topic': 'Test',
+            'audience': 'Devs',
+            'duration_minutes': 20,
+            'preferences': {'budget_cap_usd': 50.0, 'image_backend': 'dalle3'},
+        }
+        with open(tmp_path / 'talk-brief.json', 'w') as f:
+            json.dump(brief, f)
+        defaults = read_brief_defaults(str(tmp_path))
+        assert defaults['budget_usd'] == 50.0
+        assert defaults['image_backend'] == 'dalle3'
+
+    def test_no_preferences_section(self, tmp_path):
+        brief = {'topic': 'Test', 'audience': 'Devs', 'duration_minutes': 20}
+        with open(tmp_path / 'talk-brief.json', 'w') as f:
+            json.dump(brief, f)
+        defaults = read_brief_defaults(str(tmp_path))
+        assert defaults['budget_usd'] is None
+        assert defaults['image_backend'] is None


### PR DESCRIPTION
## Summary

- Adds `preferences.budget_cap_usd` to the TalkBrief schema so briefs can carry budget inline
- Adds `read_brief_defaults()` to `conductor.py` to extract budget and image_backend from the brief
- Makes Step 0 escalation conditional in the deck-conductor agent — skips budget/provider confirmation when the brief supplies both values, enabling subagent invocation
- Documents invocation contract at top of agent definition

## Test plan

- [x] 5 new tests for `read_brief_defaults` (no brief, budget only, backend only, both, no preferences section)
- [x] All 29 conductor tests passing
- [x] All 46 schema tests passing
- [x] Plugin copies synced

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)