### PR TITLE
chore: bump plugin versions to 1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,31 +9,31 @@
       "name": "jack-tar-ollama",
       "description": "Local AI image generation via Ollama — images, icons, patterns, diagrams, and quick presentations",
       "source": "./plugins/jack-tar-ollama",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "name": "jack-tar-cloud",
       "description": "Cloud AI image generation — OpenAI, Google, FAL.ai, Recraft with smart provider routing",
       "source": "./plugins/jack-tar-cloud",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "name": "jack-tar-msft-smartart",
       "description": "Editable PowerPoint SmartArt graphics — 29 layouts, speakers can modify after delivery",
       "source": "./plugins/jack-tar-msft-smartart",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "name": "jack-tar-custom-smartart",
       "description": "Data visualisation and custom graphics — SVG, Mermaid, Vega-Lite, matplotlib charts",
       "source": "./plugins/jack-tar-custom-smartart",
-      "version": "1.0.0"
+      "version": "1.1.0"
     },
     {
       "name": "jack-tar-deckhand",
       "description": "Full presentation pipeline — brand, style, narrative, images, SmartArt, assembly, QA",
       "source": "./plugins/jack-tar-deckhand",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   ]
 }

--- a/plugins/jack-tar-cloud/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-cloud/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-cloud",
   "description": "Cloud AI image generation — OpenAI, Google, FAL.ai, Recraft with smart provider routing",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-custom-smartart/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-custom-smartart/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-custom-smartart",
   "description": "Data visualisation and custom graphics — SVG, Mermaid, Vega-Lite, matplotlib charts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-custom-smartart/package.json
+++ b/plugins/jack-tar-custom-smartart/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jack-tar-custom-smartart",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Custom SmartArt graphics — SVG, Mermaid, Vega-Lite, charts",
   "license": "MIT",
   "dependencies": {

--- a/plugins/jack-tar-deckhand/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-deckhand/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-deckhand",
   "description": "Full presentation pipeline — brand, style, narrative, images, SmartArt, assembly, QA",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-deckhand/package.json
+++ b/plugins/jack-tar-deckhand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jack-tar-deckhand",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Full presentation engineering pipeline",
   "license": "MIT",
   "dependencies": {

--- a/plugins/jack-tar-msft-smartart/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-msft-smartart/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-msft-smartart",
   "description": "Editable PowerPoint SmartArt graphics — 29 layouts, speakers can modify after delivery",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-ollama/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-ollama/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-ollama",
   "description": "Local AI image generation via Ollama — images, icons, patterns, diagrams, and quick presentations",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-ollama/package.json
+++ b/plugins/jack-tar-ollama/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jack-tar-ollama",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Local AI image generation via Ollama",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
## Summary

- Bump all 5 plugins from 1.0.0 → 1.1.0 across marketplace manifest, plugin.json, and package.json files
- The marketplace cache at `~/.claude/plugins/cache/jack-tar/` is keyed by version — without a bump, other projects on this machine keep using stale 1.0.0 copies

Closes #51

## Test plan

- [x] `grep -r '"1.0.0"'` across all manifest files returns zero matches
- [ ] After merge, restart Claude Code in another project and verify plugins report 1.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)