### PR TITLE
fix(jack-tar-ollama): single-flight protection — parallel callers serialise on flock (#75)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "jack-tar-ollama",
       "description": "Local AI image generation via Ollama — images, icons, patterns, diagrams, and quick presentations",
       "source": "./plugins/jack-tar-ollama",
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     {
       "name": "jack-tar-cloud",

--- a/plugins/jack-tar-ollama/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-ollama/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-ollama",
   "description": "Local AI image generation via Ollama — images, icons, patterns, diagrams, and quick presentations",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-ollama/src/generate_image.py
+++ b/plugins/jack-tar-ollama/src/generate_image.py
@@ -1,10 +1,29 @@
 #!/usr/bin/env python3
-"""Generate an image via Ollama's REST API and save it as PNG."""
+"""Generate an image via Ollama's REST API and save it as PNG.
+
+Issue #75 — Single-flight protection. Ollama's image-generation
+backends (z-image-turbo, flux2-klein) serialise on a single GPU
+context; parallel API calls don't run in parallel, they queue inside
+Ollama. Combined with the per-call 120s timeout, queued calls timeout
+while waiting. This module wraps the API call in a process-level
+``fcntl.flock`` so multiple concurrent invocations of this script
+serialise politely and each call gets its full GPU-time budget once it
+acquires the lock. The lock is automatically released by the kernel
+on process exit (graceful or crash), so stale lock recovery is not
+strictly required — but a defensive 30-minute mtime guard reclaims a
+lock if a process held it without updating mtime for that long
+(filesystem clock skew, suspended process, etc.).
+"""
 
 import argparse
 import base64
+import errno
+import fcntl
 import os
 import sys
+import tempfile
+import time
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 
@@ -19,6 +38,104 @@ MODEL_TIMEOUTS = {
 }
 DEFAULT_TIMEOUT = 300
 
+# Single-flight lock — covers the whole image-generation API call. The
+# lock file is at the OS tmpdir so concurrent invocations of this
+# script (across processes, terminals, plugins) serialise on a single
+# Ollama instance.
+LOCK_PATH = Path(tempfile.gettempdir()) / "jack-tar-ollama-image.lock"
+
+DEFAULT_LOCK_WAIT_TIMEOUT = 600  # 10 minutes — covers ~5 sequential 120s renders.
+STALE_LOCK_AGE_SECONDS = 1800    # 30 minutes — older than this and we reclaim.
+
+
+@contextmanager
+def _single_flight_lock(timeout_seconds: int):
+    """Acquire an exclusive flock on LOCK_PATH, yield, release on exit.
+
+    Issue #75 — protects Ollama's single-GPU-context image API from
+    parallel callers queueing internally and timing out waiting. The
+    lock is released by the kernel automatically when the file
+    descriptor closes (on success, on exception, or on SIGTERM/SIGKILL).
+
+    Stale-lock recovery: if acquisition is still blocked after
+    ``STALE_LOCK_AGE_SECONDS`` AND the lock file's mtime is older than
+    that, force-reclaim by removing the file and re-trying. Catches
+    the rare case where a process held the lock without crashing
+    cleanly (suspended, killed -9 with the file still mapped, etc.).
+
+    Raises:
+        TimeoutError: lock could not be acquired within ``timeout_seconds``.
+    """
+    LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    deadline = time.monotonic() + timeout_seconds
+
+    def _open_fd():
+        return os.open(str(LOCK_PATH), os.O_CREAT | os.O_RDWR, 0o644)
+
+    fd = _open_fd()
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break  # acquired
+            except (BlockingIOError, OSError) as exc:
+                if isinstance(exc, OSError) and exc.errno not in (errno.EAGAIN, errno.EWOULDBLOCK):
+                    raise
+
+                if time.monotonic() > deadline:
+                    raise TimeoutError(
+                        f"Could not acquire Ollama single-flight lock at "
+                        f"{LOCK_PATH} within {timeout_seconds}s. Another "
+                        f"image generation is in progress; serialise your "
+                        f"callers or use cloud generation for parallelism."
+                    ) from exc
+
+                # Stale-lock recovery: if the lock file is genuinely
+                # ancient, reclaim it. The kernel releases fcntl flocks
+                # automatically when the holding process dies, so this
+                # is only needed for the rare edge case of a long-running
+                # suspended process holding the fd. After unlinking, our
+                # current fd still points to the old (now-detached)
+                # inode; we need a fresh fd on the new path so we can
+                # compete on equal footing with future callers.
+                try:
+                    age = time.time() - LOCK_PATH.stat().st_mtime
+                except FileNotFoundError:
+                    age = -1.0
+                if age > STALE_LOCK_AGE_SECONDS:
+                    try:
+                        LOCK_PATH.unlink()
+                    except FileNotFoundError:
+                        pass
+                    # Reopen onto the new inode so flock targets the file
+                    # the next acquirer will see.
+                    try:
+                        os.close(fd)
+                    except OSError:
+                        pass
+                    fd = _open_fd()
+
+                time.sleep(1)
+        # Touch mtime so stale-lock detection doesn't trip on a long-but-
+        # legitimate hold (e.g. flux2-klein at 600s timeout). Best-effort:
+        # if the file was unlinked between acquisition and now (rare
+        # interleaving), don't fail the whole operation.
+        try:
+            os.utime(str(LOCK_PATH), None)
+        except OSError:
+            pass
+        yield fd
+    finally:
+        if fd is not None:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Generate an image via Ollama")
@@ -30,6 +147,25 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--steps", type=int, default=8, help="Number of inference steps")
     parser.add_argument("--seed", type=int, default=None, help="Seed for reproducibility")
     parser.add_argument("--timeout", type=int, default=None, help="HTTP timeout in seconds (auto-detected from model if not set)")
+    parser.add_argument(
+        "--lock-wait-timeout",
+        type=int,
+        default=DEFAULT_LOCK_WAIT_TIMEOUT,
+        help=(
+            "Seconds to wait for the Ollama single-flight lock before "
+            "giving up. Default 600s (10 min) — covers ~5 sequential "
+            "renders on a single GPU. Issue #75."
+        ),
+    )
+    parser.add_argument(
+        "--no-lock",
+        action="store_true",
+        help=(
+            "Disable the single-flight lock. Use ONLY when you know "
+            "Ollama is being driven by a single caller (debugging, "
+            "test fixtures). Default: lock is on. Issue #75."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -50,7 +186,8 @@ def resolve_timeout(model: str, explicit_timeout: int | None) -> int:
     return MODEL_TIMEOUTS.get(base_model, DEFAULT_TIMEOUT)
 
 
-def generate(args: argparse.Namespace) -> None:
+def _do_api_call(args: argparse.Namespace) -> None:
+    """Inner generation logic — assumes the lock has already been acquired."""
     output_path = resolve_output_path(args.output)
     timeout = resolve_timeout(args.model, args.timeout)
 
@@ -97,6 +234,27 @@ def generate(args: argparse.Namespace) -> None:
 
     output_path.write_bytes(base64.b64decode(image_b64))
     print(str(output_path))
+
+
+def generate(args: argparse.Namespace) -> None:
+    """Generate an image, holding the single-flight lock across the API call.
+
+    Issue #75 — concurrent invocations of this script against the same
+    Ollama instance now serialise on the lock. Pass ``--no-lock`` to
+    bypass for legitimate single-caller scenarios (test fixtures,
+    debugging).
+    """
+    if getattr(args, "no_lock", False):
+        _do_api_call(args)
+        return
+
+    lock_wait = getattr(args, "lock_wait_timeout", DEFAULT_LOCK_WAIT_TIMEOUT)
+    try:
+        with _single_flight_lock(lock_wait):
+            _do_api_call(args)
+    except TimeoutError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/plugins/jack-tar-ollama/tests/test_generate_image.py
+++ b/plugins/jack-tar-ollama/tests/test_generate_image.py
@@ -37,6 +37,9 @@ def make_args(**overrides):
         "steps": 8,
         "seed": None,
         "timeout": None,
+        # Issue #75 — single-flight lock kwargs.
+        "lock_wait_timeout": generate_image.DEFAULT_LOCK_WAIT_TIMEOUT,
+        "no_lock": True,  # default to no-lock for fast unit tests
     }
     defaults.update(overrides)
     import argparse
@@ -204,3 +207,236 @@ class TestArgumentParsing:
 
         body = mock_post.call_args.kwargs["json"]
         assert body["model"] == "x/flux2-klein"
+
+
+class TestSingleFlightLock:
+    """Issue #75 — Ollama image gen serialises on a single GPU context.
+    Concurrent invocations queue inside Ollama and timeout. The
+    single-flight lock makes parallel callers serialise politely on the
+    process side so each call gets its full GPU-time budget once it
+    acquires the lock."""
+
+    def test_no_lock_flag_skips_lock_machinery(self, tmp_path):
+        """--no-lock bypasses _single_flight_lock entirely. Used by test
+        fixtures and operator-driven debug sessions."""
+        output = tmp_path / "test.png"
+        args = make_args(output=str(output), no_lock=True)
+
+        with patch("generate_image._single_flight_lock") as mock_lock, \
+             patch("generate_image.requests.post", return_value=mock_response(
+                 json_data={"done": True, "image": FAKE_IMAGE_B64}
+             )):
+            generate_image.generate(args)
+
+        mock_lock.assert_not_called()
+        assert output.exists()
+
+    def test_default_invocation_acquires_and_releases_lock(self, tmp_path):
+        """When --no-lock is NOT set, the API call is wrapped in the
+        single-flight context manager."""
+        output = tmp_path / "test.png"
+        args = make_args(output=str(output), no_lock=False)
+
+        # Patch the context manager to record entry/exit but otherwise
+        # behave as a no-op so the inner _do_api_call still runs.
+        from contextlib import contextmanager
+        events = []
+
+        @contextmanager
+        def fake_lock(timeout_seconds):
+            events.append(("acquire", timeout_seconds))
+            try:
+                yield 0
+            finally:
+                events.append(("release", None))
+
+        with patch("generate_image._single_flight_lock", fake_lock), \
+             patch("generate_image.requests.post", return_value=mock_response(
+                 json_data={"done": True, "image": FAKE_IMAGE_B64}
+             )):
+            generate_image.generate(args)
+
+        kinds = [e[0] for e in events]
+        assert kinds == ["acquire", "release"]
+        # Default timeout was passed through.
+        assert events[0][1] == generate_image.DEFAULT_LOCK_WAIT_TIMEOUT
+
+    def test_lock_wait_timeout_propagates(self, tmp_path):
+        """A custom --lock-wait-timeout is honoured by the lock context."""
+        output = tmp_path / "test.png"
+        args = make_args(output=str(output), no_lock=False, lock_wait_timeout=42)
+
+        from contextlib import contextmanager
+        captured = []
+
+        @contextmanager
+        def fake_lock(timeout_seconds):
+            captured.append(timeout_seconds)
+            yield 0
+
+        with patch("generate_image._single_flight_lock", fake_lock), \
+             patch("generate_image.requests.post", return_value=mock_response(
+                 json_data={"done": True, "image": FAKE_IMAGE_B64}
+             )):
+            generate_image.generate(args)
+
+        assert captured == [42]
+
+    def test_lock_acquisition_timeout_exits_with_clear_message(self, tmp_path, capsys):
+        """If the lock cannot be acquired within the timeout, exit code 1
+        and a clear stderr message — not a silent hang."""
+        output = tmp_path / "test.png"
+        args = make_args(output=str(output), no_lock=False, lock_wait_timeout=1)
+
+        from contextlib import contextmanager
+
+        @contextmanager
+        def fake_lock(timeout_seconds):
+            raise TimeoutError(
+                f"Could not acquire Ollama single-flight lock at /tmp/x.lock "
+                f"within {timeout_seconds}s. Another image generation is "
+                f"in progress; serialise your callers or use cloud "
+                f"generation for parallelism."
+            )
+            yield  # noqa: unreachable, satisfies decorator shape
+
+        with patch("generate_image._single_flight_lock", fake_lock):
+            with pytest.raises(SystemExit) as exc_info:
+                generate_image.generate(args)
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "single-flight lock" in captured.err
+        assert "Another image generation is in progress" in captured.err
+
+
+class TestLockMechanism:
+    """Lower-level tests of _single_flight_lock itself."""
+
+    def test_lock_acquired_when_uncontended(self, tmp_path, monkeypatch):
+        """A single caller acquires the lock immediately and the context
+        body executes. The lock file gets created."""
+        lock_path = tmp_path / "test.lock"
+        monkeypatch.setattr(generate_image, "LOCK_PATH", lock_path)
+
+        ran = []
+        with generate_image._single_flight_lock(timeout_seconds=5):
+            ran.append("body")
+            assert lock_path.exists()
+        assert ran == ["body"]
+
+    def test_lock_released_on_exception(self, tmp_path, monkeypatch):
+        """If the body raises, the lock is still released so subsequent
+        callers don't deadlock."""
+        lock_path = tmp_path / "test.lock"
+        monkeypatch.setattr(generate_image, "LOCK_PATH", lock_path)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            with generate_image._single_flight_lock(timeout_seconds=5):
+                raise RuntimeError("boom")
+
+        # Verify subsequent acquisition succeeds (lock is released).
+        with generate_image._single_flight_lock(timeout_seconds=5):
+            pass
+
+    def test_lock_blocked_then_acquired(self, tmp_path, monkeypatch):
+        """When the lock file is held by another process (simulated via a
+        second fd holding the flock), the first caller's acquisition
+        attempts block. Once the holding fd releases, the next attempt
+        succeeds. We only check that the lock-recovery path runs and
+        eventually exits successfully — timing details are out of scope.
+        """
+        import fcntl
+        lock_path = tmp_path / "test.lock"
+        monkeypatch.setattr(generate_image, "LOCK_PATH", lock_path)
+
+        # Acquire and hold the lock externally.
+        held_fd = open(str(lock_path), "w")
+        fcntl.flock(held_fd, fcntl.LOCK_EX)
+
+        sleeps = []
+
+        def fake_sleep(s):
+            sleeps.append(s)
+            # On second sleep, release the holder so acquisition succeeds.
+            if len(sleeps) == 2:
+                fcntl.flock(held_fd, fcntl.LOCK_UN)
+                held_fd.close()
+
+        monkeypatch.setattr(generate_image.time, "sleep", fake_sleep)
+
+        ran = []
+        with generate_image._single_flight_lock(timeout_seconds=10):
+            ran.append("body")
+        assert ran == ["body"]
+        # We slept at least once while waiting.
+        assert len(sleeps) >= 1
+
+    def test_lock_timeout_raises(self, tmp_path, monkeypatch):
+        """Timeout propagates as TimeoutError when the lock can't be
+        acquired in time."""
+        import fcntl
+        lock_path = tmp_path / "test.lock"
+        monkeypatch.setattr(generate_image, "LOCK_PATH", lock_path)
+
+        # Hold the lock for the duration of the test.
+        held_fd = open(str(lock_path), "w")
+        fcntl.flock(held_fd, fcntl.LOCK_EX)
+
+        # Fast-forward time so the timeout deadline is exceeded
+        # immediately on the first poll.
+        clock = [0.0]
+
+        def fake_monotonic():
+            t = clock[0]
+            clock[0] += 5.0
+            return t
+
+        monkeypatch.setattr(generate_image.time, "monotonic", fake_monotonic)
+        monkeypatch.setattr(generate_image.time, "sleep", lambda s: None)
+
+        with pytest.raises(TimeoutError, match="single-flight lock"):
+            with generate_image._single_flight_lock(timeout_seconds=2):
+                pass
+
+        fcntl.flock(held_fd, fcntl.LOCK_UN)
+        held_fd.close()
+
+    def test_stale_lock_is_reclaimed(self, tmp_path, monkeypatch):
+        """A lock file with mtime older than STALE_LOCK_AGE_SECONDS is
+        reclaimed: the file is unlinked so the next acquisition can
+        proceed. Defensive recovery for crashed-without-cleanup processes
+        (suspended, killed -9 with the file still mapped, etc.)."""
+        import fcntl
+        lock_path = tmp_path / "test.lock"
+        monkeypatch.setattr(generate_image, "LOCK_PATH", lock_path)
+
+        # Create a "stale" lock file: held externally, but with old mtime.
+        held_fd = open(str(lock_path), "w")
+        fcntl.flock(held_fd, fcntl.LOCK_EX)
+        # Backdate mtime past the stale threshold.
+        old_time = generate_image.time.time() - generate_image.STALE_LOCK_AGE_SECONDS - 60
+        os_module = generate_image.os
+        os_module.utime(str(lock_path), (old_time, old_time))
+
+        sleeps_taken = []
+        def fake_sleep(s):
+            sleeps_taken.append(s)
+            # After the first sleep, simulate the holder releasing too.
+            # Actual reclaim path: our code unlinks the file, then on the
+            # next iteration creates a fresh fd and acquires.
+            if len(sleeps_taken) == 1:
+                # The holder still has the kernel-level flock, but our
+                # code already unlinked the file. Release the flock now
+                # so the next acquisition can complete.
+                try:
+                    fcntl.flock(held_fd, fcntl.LOCK_UN)
+                    held_fd.close()
+                except OSError:
+                    pass
+
+        monkeypatch.setattr(generate_image.time, "sleep", fake_sleep)
+
+        ran = []
+        with generate_image._single_flight_lock(timeout_seconds=30):
+            ran.append("body")
+        assert ran == ["body"]


### PR DESCRIPTION
Closes #75.

**Surfaced** during the [2026-05-07 blog-post asset run dogfood](docs/superpowers/dogfooding/2026-05-07-blog-post-asset-run.md) (bug #4): 4 parallel image generations dispatched against one Ollama instance — only one succeeded, three timed out at the 120s skill timeout while queued behind the first inside Ollama's single GPU context.

**Plan:** [`docs/superpowers/plans/2026-05-08-blog-post-bug-batch.md`](docs/superpowers/plans/2026-05-08-blog-post-bug-batch.md) (Phase 4).

## What changes

- New `_single_flight_lock` context manager in `plugins/jack-tar-ollama/src/generate_image.py` using `fcntl.flock` at `/tmp/jack-tar-ollama-image.lock`. Acquired before the API call, released by the kernel on process exit (graceful or crash).
- Two new CLI flags:
  - `--lock-wait-timeout SECONDS` — default 600 (10 min, ~5 sequential 120s renders)
  - `--no-lock` — bypass for test fixtures and operator-driven debugging
- Stale-lock recovery: if the lock file's mtime is older than 30 minutes, unlink and reopen the fd onto the new inode. Defensive only — fcntl auto-releases on process death; this only matters for the rare suspended-but-not-dead holder.
- Clear stderr message + exit 1 on acquisition timeout.

## Test results

- All 27 ollama plugin tests pass (was 18; +9).
- New `TestSingleFlightLock` class covers `--no-lock` bypass, default acquisition, custom timeout propagation, and timeout-error message shape.
- New `TestLockMechanism` class tests the lock context manager directly: uncontended acquisition, release-on-exception, contended-then-released, timeout exhaustion, stale-lock reclamation.

## Coordinated release

One of three PRs landing together as the post-dogfood cleanup. Bumps **jack-tar-ollama 1.1.0 → 1.1.1**. Marketplace manifest synced.

## Test plan

- [ ] CI green
- [ ] Local: `cd plugins/jack-tar-ollama && pytest -q` — 27 passed expected
- [ ] Live verification: spawn 3 parallel `--prompt` calls against a real Ollama, confirm sequential execution with no timeouts (was: 1 success, 2 timeouts pre-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)