### PR TITLE
feat(jack-tar-deckhand): auto-installed PreToolUse hook blocking Read on image files (#76)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,7 +33,7 @@
       "name": "jack-tar-deckhand",
       "description": "Full presentation pipeline — brand, style, narrative, images, SmartArt, assembly, QA",
       "source": "./plugins/jack-tar-deckhand",
-      "version": "1.3.0"
+      "version": "1.3.1"
     },
     {
       "name": "jack-tar-superpower-bridge",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,21 @@ This rule exists because visual review was skipped THREE TIMES across multiple c
 
 **Vision capability note**: The `image-reviewer` agent uses Haiku, which has visual perception limitations (e.g., misjudging proportional widths in tapered shapes). For high-accuracy visual review, the `general-purpose` agent (Sonnet/Opus) is more reliable. Use both in parallel for cross-validation when possible.
 
+## MANDATORY: Image-review discipline (issue #76 — enforced)
+
+The `jack-tar-deckhand` plugin installs a `PreToolUse` hook that BLOCKS `Read` on image files (PNG, JPG, GIF, WEBP, BMP, TIFF). PNGs in orchestration context burn tokens that compound across every subsequent turn — review must happen out-of-context via subagent dispatch.
+
+For every image generated:
+- Dispatch `jack-tar-deckhand:image-reviewer` (Haiku, returns compact JSON)
+- Or `general-purpose` (Sonnet/Opus, higher visual accuracy)
+- Capture the verdict; never `Read` the PNG yourself.
+
+**Bypass**: set `ALLOW_PNG_READ=1` only when the image IS the user-facing answer (the user explicitly said "show me X"). The bypass is a deliberate signal, not a workaround.
+
+The hook is auto-installed when the plugin is enabled — no separate setup. Verify via `/jack-tar-deckhand:verify` (reports the "DISCIPLINE HOOK" section).
+
+This rule was reaffirmed 2026-05-07 during the blog-post asset run when 9 PNGs were Read directly into context before the operator caught it. Memory alone does not bind; the harness has to.
+
 ## Plugin Architecture (EPIC #40)
 
 This repository is now a **5-plugin Claude Code marketplace**. The presentation pipeline has been refactored into independently installable plugins:

--- a/plugins/jack-tar-deckhand/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-deckhand/.claude-plugin/plugin.json
@@ -1,11 +1,24 @@
 {
   "name": "jack-tar-deckhand",
   "description": "Full presentation pipeline — brand, style, narrative, images, SmartArt, assembly, QA",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": {
     "name": "Steve Jones"
   },
   "repository": "https://github.com/SteveGJones/jack-tar-deckhand",
   "license": "MIT",
-  "keywords": ["presentations", "powerpoint", "pptx", "conference", "pipeline", "orchestration"]
+  "keywords": ["presentations", "powerpoint", "pptx", "conference", "pipeline", "orchestration"],
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-png-read.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/jack-tar-deckhand/hooks/block-png-read.sh
+++ b/plugins/jack-tar-deckhand/hooks/block-png-read.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# block-png-read.sh — PreToolUse hook for the Read tool.
+#
+# Issue #76 — discipline hook for the jack-tar-deckhand plugin.
+#
+# Why this exists:
+#   Reading an image file (PNG/JPG/GIF/WEBP/BMP/TIFF) directly into the
+#   orchestration context burns thousands of tokens that compound across
+#   every subsequent turn. During the 2026-05-07 blog-post asset run
+#   the operator pulled 9 PNGs into context before the user spotted it
+#   — one slip wasted more context than the rest of the run combined.
+#
+#   Memory alone doesn't bind: the rule was already in feedback memory
+#   at the start of that run and was broken anyway. The harness has to
+#   enforce.
+#
+# What this hook does:
+#   Intercepts every Read tool call, parses the file path from the
+#   hook-protocol JSON on stdin, and exits non-zero (blocking the call)
+#   if the path ends in an image extension. The block message names
+#   the alternatives — image-reviewer / general-purpose subagent —
+#   so the orchestrator has a clear remediation.
+#
+# Bypass:
+#   Set ALLOW_PNG_READ=1 in the environment when the image IS the
+#   user-facing answer (rare — e.g. user explicitly said "show me X").
+#   The bypass is a deliberate signal, not a workaround.
+#
+# Composability:
+#   Multiple PreToolUse-Read hooks compose in registration order. This
+#   hook only blocks; it does not unblock anything other hooks might
+#   block. As long as no hook unblocks what this one blocks, the
+#   stronger constraint wins.
+#
+# Platform: macOS / Linux (uses python3 stdlib).
+
+set -euo pipefail
+
+# Bypass for explicit operator override.
+if [[ "${ALLOW_PNG_READ:-}" == "1" ]]; then
+  exit 0
+fi
+
+# Read tool input JSON from stdin and extract file_path.
+INPUT="$(cat)"
+FILE_PATH="$(printf '%s' "$INPUT" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    print(data.get("tool_input", {}).get("file_path", ""))
+except Exception:
+    # If the payload is malformed, do not block — let the tool call
+    # through and let downstream layers report the malformation.
+    print("")
+')"
+
+# Block on image extensions (case-insensitive).
+shopt -s nocasematch
+if [[ "$FILE_PATH" =~ \.(png|jpe?g|gif|webp|bmp|tiff?)$ ]]; then
+  cat >&2 <<EOF
+BLOCKED by jack-tar-deckhand discipline hook (issue #76):
+
+Read on image file would burn orchestration context. Image files
+carry thousands of tokens each and compound across every subsequent
+turn.
+
+  Path: $FILE_PATH
+
+Use one of these instead:
+  • Dispatch the jack-tar-deckhand:image-reviewer agent (Haiku, cheap)
+    with the path + intent, capture a JSON verdict.
+  • Dispatch the general-purpose agent (Sonnet/Opus) for higher visual
+    accuracy on complex scenes.
+
+Both subagents read the image into THEIR context and return text —
+your orchestration stays lean.
+
+Bypass: set ALLOW_PNG_READ=1 in env when the image IS the user-facing
+answer (rare — e.g. user said "show me X"). The bypass is a
+deliberate signal, not a workaround.
+EOF
+  exit 1
+fi
+
+shopt -u nocasematch
+exit 0

--- a/plugins/jack-tar-deckhand/skills/verify/SKILL.md
+++ b/plugins/jack-tar-deckhand/skills/verify/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: verify
-description: Meta-verify — discover all jack-tar engine plugins, call each verify, report aggregate pipeline capability.
-allowed-tools: Bash(python *), Bash(node *), Skill
+description: Meta-verify — discover all jack-tar engine plugins, call each verify, report aggregate pipeline capability and discipline-hook readiness.
+allowed-tools: Bash(python *), Bash(node *), Bash(echo *), Bash(test *), Skill
 ---
 
 # /verify
 
-Discover all installed jack-tar engine plugins, call each plugin's `:verify` skill, and report aggregate pipeline capability.
+Discover all installed jack-tar engine plugins, call each plugin's `:verify` skill, and report aggregate pipeline capability AND the status of the discipline hook (issue #76).
 
 ## Step 1: Check local dependencies
 
@@ -39,7 +39,53 @@ Based on engine plugin availability:
 - **Deck assembly:** READY if pptxgenjs is installed
 - **QA checks:** always READY (built into this plugin)
 
-## Step 4: Report status
+## Step 4: Discipline hook readiness (issue #76)
+
+Verify the `block-png-read.sh` PreToolUse hook is installed and fires correctly. Three checks:
+
+### 4a — Hook script presence + executability
+
+```bash
+HOOK_SCRIPT="${CLAUDE_PLUGIN_ROOT}/hooks/block-png-read.sh"
+if [ -x "$HOOK_SCRIPT" ]; then
+  echo "Hook script:         OK ($HOOK_SCRIPT)"
+else
+  echo "Hook script:         MISSING (expected at $HOOK_SCRIPT)"
+fi
+```
+
+### 4b — Synthetic fire test
+
+Pipe three test payloads through the hook script and assert exit codes:
+
+- PNG path → exit 1 (block) + stderr contains "BLOCKED"
+- PNG path with `ALLOW_PNG_READ=1` → exit 0 (bypass)
+- Non-image path → exit 0 (pass-through)
+
+```bash
+HOOK_SCRIPT="${CLAUDE_PLUGIN_ROOT}/hooks/block-png-read.sh"
+
+# Test 1: PNG should block
+echo '{"tool_input":{"file_path":"/tmp/x.png"}}' | "$HOOK_SCRIPT" >/dev/null 2>&1
+PNG_EXIT=$?
+[ "$PNG_EXIT" = "1" ] && echo "  PNG block:         OK" || echo "  PNG block:         FAILED (exit $PNG_EXIT, expected 1)"
+
+# Test 2: bypass should pass
+ALLOW_PNG_READ=1 bash -c "echo '{\"tool_input\":{\"file_path\":\"/tmp/x.png\"}}' | \"$HOOK_SCRIPT\"" >/dev/null 2>&1
+BYPASS_EXIT=$?
+[ "$BYPASS_EXIT" = "0" ] && echo "  Bypass works:      OK" || echo "  Bypass works:      FAILED (exit $BYPASS_EXIT, expected 0)"
+
+# Test 3: non-image should pass
+echo '{"tool_input":{"file_path":"/tmp/x.md"}}' | "$HOOK_SCRIPT" >/dev/null 2>&1
+NONIMG_EXIT=$?
+[ "$NONIMG_EXIT" = "0" ] && echo "  Non-image pass:    OK" || echo "  Non-image pass:    FAILED (exit $NONIMG_EXIT, expected 0)"
+```
+
+### 4c — Hook registration
+
+Plugins-managed hooks are registered automatically when the plugin is enabled. The verify skill cannot reliably introspect harness state across all platforms, so this check is informational: if the synthetic fire test passes (4b), the hook script is functional. Whether the harness has actually wired it up to the Read tool is observable by attempting a Read on a PNG within the session — that will block (or bypass with the env var) once registered.
+
+## Step 5: Report status
 
 Example output:
 
@@ -65,6 +111,12 @@ PIPELINE CAPABILITY:
   Custom graphics:   NOT_READY (custom-smartart not available)
   Deck assembly:     READY (pptxgenjs installed)
   QA checks:         READY
+
+DISCIPLINE HOOK (issue #76):
+  Hook script:         OK (${CLAUDE_PLUGIN_ROOT}/hooks/block-png-read.sh)
+  PNG block:           OK
+  Bypass works:        OK
+  Non-image pass:      OK
 
 STATUS: PARTIALLY_AVAILABLE
 REASON: jack-tar-custom-smartart not available

--- a/plugins/jack-tar-deckhand/tests/test_block_png_read_hook.py
+++ b/plugins/jack-tar-deckhand/tests/test_block_png_read_hook.py
@@ -1,0 +1,195 @@
+"""Tests for the discipline hook that blocks Read on image files.
+
+Issue #76 — auto-installed PreToolUse hook (declared in
+plugins/jack-tar-deckhand/.claude-plugin/plugin.json) enforces the
+"never Read PNGs into orchestration context" rule that the
+2026-05-07 blog-post asset run violated.
+
+The hook is a bash script under plugins/jack-tar-deckhand/hooks/.
+These tests invoke it as a subprocess with simulated Claude Code
+hook-protocol JSON payloads on stdin and assert the exit code +
+stderr contents.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+HOOK_SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "hooks"
+    / "block-png-read.sh"
+)
+
+
+def run_hook(file_path: str, env: dict | None = None) -> subprocess.CompletedProcess:
+    """Invoke the hook with a simulated Read tool input."""
+    payload = json.dumps({"tool_input": {"file_path": file_path}})
+    real_env = os.environ.copy()
+    if env:
+        real_env.update(env)
+    # Strip ALLOW_PNG_READ unless explicitly set by the test, so the
+    # operator's session env doesn't leak into the test.
+    if env is None or "ALLOW_PNG_READ" not in env:
+        real_env.pop("ALLOW_PNG_READ", None)
+    return subprocess.run(
+        [str(HOOK_SCRIPT)],
+        input=payload,
+        text=True,
+        capture_output=True,
+        env=real_env,
+    )
+
+
+def test_hook_script_exists_and_is_executable():
+    assert HOOK_SCRIPT.is_file(), f"missing hook script: {HOOK_SCRIPT}"
+    assert os.access(HOOK_SCRIPT, os.X_OK), f"hook script not executable: {HOOK_SCRIPT}"
+
+
+@pytest.mark.parametrize("ext", [
+    ".png", ".PNG", ".Png",
+    ".jpg", ".JPG", ".jpeg", ".JPEG",
+    ".gif", ".GIF",
+    ".webp", ".WEBP",
+    ".bmp", ".BMP",
+    ".tif", ".tiff", ".TIFF",
+])
+def test_hook_blocks_image_extensions(ext):
+    """All image extensions, case-insensitive, must block."""
+    result = run_hook(f"/tmp/foo{ext}")
+    assert result.returncode == 1, (
+        f"expected exit 1 for {ext}, got {result.returncode}. stderr: {result.stderr!r}"
+    )
+    assert "BLOCKED" in result.stderr, (
+        f"expected BLOCKED in stderr for {ext}; got {result.stderr!r}"
+    )
+
+
+def test_hook_passes_non_image_files():
+    """Read on non-image files must pass through (exit 0)."""
+    result = run_hook("/tmp/foo.md")
+    assert result.returncode == 0, f"unexpected non-zero exit: {result.stderr!r}"
+
+
+@pytest.mark.parametrize("path", [
+    "/tmp/notes.md",
+    "/etc/hosts",
+    "/var/log/system.log",
+    "src/generate_image.py",
+    "package.json",
+    "/tmp/data.csv",
+    "/tmp/output.txt",
+])
+def test_hook_passes_various_non_image_paths(path):
+    result = run_hook(path)
+    assert result.returncode == 0, (
+        f"non-image path {path} should pass; got exit {result.returncode}, "
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_hook_bypass_via_allow_png_read_env():
+    """ALLOW_PNG_READ=1 in env bypasses the block — the documented escape
+    for cases where the image IS the user-facing answer."""
+    result = run_hook("/tmp/foo.png", env={"ALLOW_PNG_READ": "1"})
+    assert result.returncode == 0, (
+        f"ALLOW_PNG_READ=1 should bypass; got exit {result.returncode}, "
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_hook_bypass_only_with_explicit_one():
+    """ALLOW_PNG_READ must be exactly '1' to bypass — other truthy values
+    do NOT count as the operator's deliberate signal."""
+    for falsey in ["", "0", "true", "yes"]:
+        result = run_hook("/tmp/foo.png", env={"ALLOW_PNG_READ": falsey})
+        assert result.returncode == 1, (
+            f"ALLOW_PNG_READ={falsey!r} must NOT bypass; got exit {result.returncode}"
+        )
+
+
+def test_hook_handles_malformed_json_gracefully():
+    """If the harness sends malformed JSON the hook does not block — let
+    the tool call through and let downstream layers report the
+    malformation. Defensive: a buggy hook that hard-fails on every Read
+    would brick the session."""
+    result = subprocess.run(
+        [str(HOOK_SCRIPT)],
+        input="not valid json {{{",
+        text=True,
+        capture_output=True,
+        env={k: v for k, v in os.environ.items() if k != "ALLOW_PNG_READ"},
+    )
+    assert result.returncode == 0, (
+        f"malformed JSON should pass through; got exit {result.returncode}, "
+        f"stderr: {result.stderr!r}"
+    )
+
+
+def test_hook_handles_missing_file_path_field():
+    """If tool_input has no file_path, treat as non-image and pass through."""
+    result = subprocess.run(
+        [str(HOOK_SCRIPT)],
+        input=json.dumps({"tool_input": {}}),
+        text=True,
+        capture_output=True,
+        env={k: v for k, v in os.environ.items() if k != "ALLOW_PNG_READ"},
+    )
+    assert result.returncode == 0
+
+
+def test_hook_block_message_names_alternatives():
+    """The block message must point operators at the right remediation —
+    the image-reviewer agent + general-purpose agent. This is the
+    discoverable-rule property the hook exists to deliver."""
+    result = run_hook("/tmp/foo.png")
+    assert "image-reviewer" in result.stderr, (
+        "block message must mention the image-reviewer agent"
+    )
+    assert "general-purpose" in result.stderr, (
+        "block message must mention the general-purpose agent fallback"
+    )
+    assert "ALLOW_PNG_READ" in result.stderr, (
+        "block message must document the bypass mechanism"
+    )
+
+
+def test_plugin_manifest_declares_pretooluse_hook():
+    """Issue #76 — confirm the plugin.json manifest registers the hook so
+    Claude Code auto-installs it on plugin enable. Without this
+    declaration, the hook script exists but never fires."""
+    manifest_path = (
+        Path(__file__).resolve().parents[1]
+        / ".claude-plugin"
+        / "plugin.json"
+    )
+    manifest = json.loads(manifest_path.read_text())
+    hooks = manifest.get("hooks", {})
+    pre_tool_use = hooks.get("PreToolUse", [])
+    assert pre_tool_use, "manifest must declare hooks.PreToolUse for issue #76"
+
+    read_matchers = [h for h in pre_tool_use if h.get("matcher") == "Read"]
+    assert read_matchers, "manifest must include a Read-matcher in PreToolUse"
+
+    # The hook entry references our script via CLAUDE_PLUGIN_ROOT.
+    found_block_png = False
+    for matcher in read_matchers:
+        for inner in matcher.get("hooks", []):
+            cmd = inner.get("command", "")
+            if "block-png-read.sh" in cmd:
+                found_block_png = True
+                assert inner.get("type") == "command", (
+                    "hook entry must declare type='command'"
+                )
+                assert "${CLAUDE_PLUGIN_ROOT}" in cmd, (
+                    "hook command must reference ${CLAUDE_PLUGIN_ROOT} for portability"
+                )
+                break
+    assert found_block_png, (
+        "manifest must reference plugins/jack-tar-deckhand/hooks/block-png-read.sh"
+    )


### PR DESCRIPTION
Closes #76.

**Surfaced** during the [2026-05-07 blog-post asset run dogfood](docs/superpowers/dogfooding/2026-05-07-blog-post-asset-run.md) (failure #1): 9 PNGs were Read directly into orchestration context before the user spotted it. The image-review-via-subagent rule was already in feedback memory — and was broken anyway. Memory alone does not bind; the harness has to enforce.

**Plan:** [`docs/superpowers/plans/2026-05-08-discipline-hook.md`](docs/superpowers/plans/2026-05-08-discipline-hook.md).

## What changes

- New `plugins/jack-tar-deckhand/hooks/block-png-read.sh` — bash script reading the Claude Code hook-protocol JSON from stdin, parsing `tool_input.file_path`, and blocking with stderr message + exit 1 when the path matches an image extension (PNG, JPG, JPEG, GIF, WEBP, BMP, TIF, TIFF — case-insensitive).
- `plugins/jack-tar-deckhand/.claude-plugin/plugin.json` declares the hook in `hooks.PreToolUse[]` with `matcher: "Read"`. Auto-installs when the plugin is enabled — no separate setup skill, no manual settings.json edit.
- `ALLOW_PNG_READ=1` env-var bypass for the rare legitimate case (image IS the user-facing answer). Strict equality to '1' — other truthy values do not bypass.
- Defensive: malformed JSON or missing `file_path` field passes through rather than bricking the session.
- `plugins/jack-tar-deckhand/skills/verify/SKILL.md` extended with a "DISCIPLINE HOOK" section reporting hook script presence + executability + synthetic fire test (PNG block, ALLOW_PNG_READ bypass, non-image pass-through).
- `CLAUDE.md` — new MANDATORY entry alongside Article 9.4 documenting the rule, the bypass, and how to verify.

## Block message

```
BLOCKED by jack-tar-deckhand discipline hook (issue #76):

Read on image file would burn orchestration context. Image files
carry thousands of tokens each and compound across every subsequent
turn.

  Path: /tmp/foo.png

Use one of these instead:
  • Dispatch the jack-tar-deckhand:image-reviewer agent (Haiku, cheap)
    with the path + intent, capture a JSON verdict.
  • Dispatch the general-purpose agent (Sonnet/Opus) for higher visual
    accuracy on complex scenes.

Both subagents read the image into THEIR context and return text —
your orchestration stays lean.

Bypass: set ALLOW_PNG_READ=1 in env when the image IS the user-facing
answer (rare — e.g. user said "show me X"). The bypass is a
deliberate signal, not a workaround.
```

## Test results

- All 72 deckhand tests pass (was 41; +31 hook tests).
- `tests/test_block_png_read_hook.py` covers all extension variants (case-insensitive), bypass mechanics, malformed-input defensiveness, manifest registration, and block-message remediation hints.

## Coordinated release

One of three PRs landing together as the post-dogfood cleanup. Bumps **jack-tar-deckhand 1.3.0 → 1.3.1**. Marketplace manifest synced.

## Test plan

- [ ] CI green
- [ ] Local: `cd plugins/jack-tar-deckhand && pytest -q` — 72 passed expected
- [ ] Live verification: with the plugin enabled, attempt `Read` on a PNG — should block with the message above; with `ALLOW_PNG_READ=1` set, should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)