### PR TITLE
docs: post-bug-batch documentation sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,18 @@ The original `src/` directory remains as the development source of truth. Plugin
 
 Claude Code skills and agents for conference-quality PowerPoint presentations. This is NOT a standalone app — it runs inside Claude Code.
 
+### Current Status (2026-05-08)
+
+- **Bug-batch + discipline hook shipped — main is now at:** cloud `1.3.2`, deckhand `1.3.1`, ollama `1.1.1`, msft-smartart `1.2.2`, bridge `0.2.0`, custom-smartart `1.1.0`.
+- **PRs #77 / #78 / #79 merged**, closing issues #72–#76 (surfaced during the 2026-05-07 blog-post asset run):
+  - **#72** — cloud retry decorator extended to cover `httpx.RemoteProtocolError`, `httpx.ConnectError`, `httpx.ReadError` (google-genai's underlying transport layer).
+  - **#73** — Recraft V4 default style changed from `realistic_image` (V3-only, causes 400) to `None`; fall-through to FAL on style-rejection errors when `FAL_KEY` is configured.
+  - **#74** — Imagen Fast resolution guard: `image_size` kwarg omitted for `imagen-4.0-fast-generate-001` (fixed resolution only — rejects the parameter with `400 INVALID_ARGUMENT`).
+  - **#75** — Ollama single-flight lock: `fcntl.flock` at `/tmp/jack-tar-ollama-image.lock` serialises concurrent callers; new `--lock-wait-timeout` (default 600 s) and `--no-lock` flags.
+  - **#76** — Discipline hook auto-installed by `jack-tar-deckhand`: `PreToolUse` hook blocks `Read` on image files; image review must go through `image-reviewer` or `general-purpose` subagent. `ALLOW_PNG_READ=1` bypass for legitimate cases.
+- **Dogfood retrospective:** `docs/superpowers/dogfooding/2026-05-07-blog-post-asset-run.md` — 6-artefact blog-post asset run, $2.99 total, 7 discipline failures and bugs documented.
+- **Plans:** `docs/superpowers/plans/2026-05-08-blog-post-bug-batch.md` · `docs/superpowers/plans/2026-05-08-discipline-hook.md`
+
 ### Current Status (2026-05-07)
 
 - **Superpower Bridge v0.2.0 + EPIC #58 closed — main is now at:** cloud `1.3.0`, deckhand `1.3.0`, msft-smartart `1.2.2`, bridge `0.2.0`, ollama/custom-smartart `1.1.0`.

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -92,6 +92,7 @@ Check your level: `python tools/automation/sdlc-level.py check`
   - Compare each visual against the original intent (visual_direction, enrichment_tier, strategy).
   - Never declare a visual pipeline "done" without having viewed every output.
   - "It compiled" or "file exists" is NOT a review.
+  - **How it is enforced (issue #76):** The `jack-tar-deckhand` plugin installs a `PreToolUse` hook that structurally blocks `Read` on image files. Review must happen via subagent dispatch — `jack-tar-deckhand:image-reviewer` (Haiku, compact JSON verdict) or `general-purpose` (Sonnet/Opus, higher visual accuracy). Both agents read the image into their own context and return text, keeping the orchestration context lean. Bypass: `ALLOW_PNG_READ=1` when the image IS the user-facing answer. This enforcement was introduced after the 2026-05-07 dogfood run where the in-memory rule was broken nine times before the operator intervened.
 
 ## Article 10: Progressive Levels
 

--- a/plugins/jack-tar-cloud/CLAUDE.md
+++ b/plugins/jack-tar-cloud/CLAUDE.md
@@ -51,6 +51,39 @@ providers["google"]["models"]["gemini-3-pro-image-preview"]["supported_resolutio
 
 SKILL.md `--resolution` flag wiring + render-funnel integration land in [Issue #60](https://github.com/SteveGJones/jack-tar-deckhand/issues/60); Recraft V4 raster as a first-class provider lands in [#61](https://github.com/SteveGJones/jack-tar-deckhand/issues/61). Until those merge, callers using `generate_cloud_image()` directly get the resolution kwarg; the per-provider SKILL.md flag surface stays unchanged from v1.1.x.
 
+## Resilience — connection retry decorator (v1.3.2, issue #72)
+
+All cloud API calls are wrapped in a `retry_on_connection_reset` decorator that retries on transient transport failures. As of v1.3.2 the retryable set covers:
+
+- `ConnectionResetError`, `ConnectionError` (stdlib)
+- `requests.exceptions.ConnectionError` (requests library)
+- `httpx.RemoteProtocolError`, `httpx.ConnectError`, `httpx.ReadError` (httpx layer — raised by google-genai's underlying httpx client)
+
+HTTP status errors (`httpx.HTTPStatusError`, `requests.exceptions.HTTPError`) are **not** retried — those represent deliberate server responses (4xx/5xx) and should propagate immediately. Retry uses a (1, 2, 5) second backoff with three attempts before re-raising.
+
+**Related:** issue [#72](https://github.com/SteveGJones/jack-tar-deckhand/issues/72).
+
+## Recraft V4 default style and fall-through (v1.3.2, issue #73)
+
+The `generate_recraft_direct` function previously defaulted to `style='realistic_image'` — a V3 preset that Recraft V4 rejects with `400 invalid_image_type`. As of v1.3.2:
+
+- The default is now `style=None`. When `None`, the `style` key is omitted from the request body entirely, and Recraft V4 picks a style server-side.
+- Explicit V4-compatible styles (e.g. `digital_illustration`, `vector_illustration`) still pass through unchanged.
+- If the direct API returns `400 invalid_image_type` AND `FAL_KEY` is configured in the environment, the dispatcher falls through to `generate_recraft_fal()` with the same arguments. This provides a transparent escape hatch for future Recraft API changes. Other 400 errors (content policy, rate limit) propagate immediately without fall-through.
+
+**Related:** issue [#73](https://github.com/SteveGJones/jack-tar-deckhand/issues/73).
+
+## Imagen Fast resolution guard (v1.3.2, issue #74)
+
+Imagen Fast (`imagen-4.0-fast-generate-001`) renders at a fixed native resolution and rejects the `image_size`/`sampleImageSize` parameter with `400 INVALID_ARGUMENT: sampleImageSize is not adjustable`. As of v1.3.2 the Imagen path in `generate_google()` uses a `_IMAGEN_FIXED_RESOLUTION_MODELS` set to determine whether to pass `image_size` in the request body:
+
+- **Imagen Fast** — not in the set; `image_size` is omitted. If the caller requests `resolution='2K'` or higher, a warning is logged and the call proceeds at native 1K.
+- **Imagen Standard / Ultra** — in the set; `image_size` is passed as before (supports 1K, 2K).
+
+The resolution table in the "Resolution control" section above reflects this: Imagen Fast is listed with supported tier `1K` only; `n/a` in the native parameter column indicates the kwarg is intentionally absent.
+
+**Related:** issue [#74](https://github.com/SteveGJones/jack-tar-deckhand/issues/74).
+
 ## Quick Start
 
 ```

--- a/plugins/jack-tar-cloud/skills/recraft-image/SKILL.md
+++ b/plugins/jack-tar-cloud/skills/recraft-image/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: recraft-image
 description: Generate raster images using Recraft V4 (1K standard, 2K Pro, 4K via Creative Upscale). Brand-color-fidelity provider — best for slides where exact hex compliance matters more than photorealistic detail. Requires RECRAFT_API_KEY (direct) or FAL_KEY (via FAL).
-argument-hint: "image description" [--output PATH] [--tier standard|pro] [--resolution 1K|2K|4K] [--colors HEX,HEX,...] [--style realistic_image|digital_illustration|vector_illustration]
+argument-hint: "image description" [--output PATH] [--tier standard|pro] [--resolution 1K|2K|4K] [--colors HEX,HEX,...] [--style digital_illustration|vector_illustration|...]
 allowed-tools: Bash(python *), Read, Glob
 ---
 
@@ -48,7 +48,7 @@ fi
 
   Unsupported combinations raise `ProviderResolutionUnsupportedError` with the supported tier list.
 - **--colors COLORS**: Comma-separated hex (e.g. `003366,FFCC00,F5F5F5`). Forwarded as RGB control dicts to Recraft's brand-color preservation.
-- **--style STYLE**: Recraft style — `realistic_image` (default), `digital_illustration`, `vector_illustration`. Direct API only; FAL ignores style.
+- **--style STYLE**: Recraft V4-compatible style preset (e.g. `digital_illustration`, `vector_illustration`). Default `None` — omits the style key from the request body, letting Recraft V4 choose server-side. The old V3 default `realistic_image` is **not** valid for V4 and will be rejected with a 400 error. Direct API only; FAL ignores style. If the direct API returns `400 invalid_image_type` AND `FAL_KEY` is set, the call automatically falls through to the FAL route (issue #73).
 
 ## Check Provider Availability
 

--- a/plugins/jack-tar-deckhand/CLAUDE.md
+++ b/plugins/jack-tar-deckhand/CLAUDE.md
@@ -40,6 +40,27 @@ Without engine plugins, the pipeline produces text-only slides with placeholder 
 
 Then use the deck-conductor agent to orchestrate a full deck build.
 
+## Discipline hook (issue #76)
+
+This plugin auto-installs a `PreToolUse` hook that **blocks `Read` on image files** (PNG, JPG, JPEG, GIF, WEBP, BMP, TIF, TIFF — case-insensitive). The hook is declared in `.claude-plugin/plugin.json` and is registered automatically when the plugin is enabled; no separate setup skill or manual `settings.json` edit is needed.
+
+**Why it exists:** During the 2026-05-07 blog-post asset run, 9 generated PNGs were `Read` directly into the orchestration context before the user caught it. Each PNG carries thousands of tokens that compound across every subsequent turn — that single failure consumed more context than the rest of the run combined. The feedback memory rule was already present and was broken anyway; memory alone does not bind. The harness must enforce.
+
+**What it does:** When a `Read` call targets a file with an image extension, the hook emits a clear remediation message to stderr and exits non-zero, blocking the call. The message names the two correct alternatives:
+
+- **`jack-tar-deckhand:image-reviewer`** agent — dispatches Haiku with the image path + intent, returns a compact JSON verdict. Use for routine per-image review.
+- **`general-purpose`** agent (Sonnet/Opus) — higher visual accuracy for complex scenes or when cross-validation with the image-reviewer is needed.
+
+Both subagents read the image into their own context and return text — the orchestration context stays lean.
+
+**Bypass:** Set `ALLOW_PNG_READ=1` in the environment when the image IS the user-facing answer — for example, the user explicitly said "show me X". The bypass requires exact string `1`; other truthy values do not bypass. Treat this as a deliberate signal, not a workaround. For test fixtures that need to inspect generated images, document the bypass in the test and scope it tightly.
+
+**Hook script location:** `plugins/jack-tar-deckhand/hooks/block-png-read.sh`
+
+**Verify the hook is active:** `/jack-tar-deckhand:verify` reports a "DISCIPLINE HOOK" section with three checks — script present + executable, registration in operator settings, and a synthetic fire test (PNG blocked, `ALLOW_PNG_READ` bypassed, non-image passed through).
+
+**Related:** issue [#76](https://github.com/SteveGJones/jack-tar-deckhand/issues/76), retrospective at `docs/superpowers/dogfooding/2026-05-07-blog-post-asset-run.md` (failure #1), plan at `docs/superpowers/plans/2026-05-08-discipline-hook.md`.
+
 ## See also — Superpower Bridge route
 
 If you'd rather start from `/pptx` (the upstream skill in the

--- a/plugins/jack-tar-ollama/CLAUDE.md
+++ b/plugins/jack-tar-ollama/CLAUDE.md
@@ -18,6 +18,24 @@ Local AI image generation using Ollama. Generate images, icons, patterns, diagra
 | `/presentation` | Generate a complete PowerPoint with AI images |
 | `/verify` | Check Ollama availability and list installed models |
 
+## Single-flight protection (issue #75)
+
+Ollama's image-generation backends (`x/z-image-turbo`, `x/flux2-klein`) are GPU-resident and serialise requests on a single GPU context. Parallel callers do not run in parallel — they queue inside Ollama. With the per-call 120 s skill timeout, queued calls time out while waiting behind the first caller.
+
+As of v1.1.1, `generate_image.py` wraps every API call in an `fcntl.flock` at `/tmp/jack-tar-ollama-image.lock` (exact path: `Path(tempfile.gettempdir()) / "jack-tar-ollama-image.lock"`). Multiple concurrent invocations of the skill now serialise politely; each call gets its full GPU-time budget once the lock is acquired. The lock is released automatically by the kernel on process exit (success, exception, or SIGTERM), so a crashed holder does not block subsequent callers indefinitely.
+
+**New CLI flags (v1.1.1):**
+
+- `--lock-wait-timeout SECONDS` — how long a waiting caller will queue before giving up with a `TimeoutError`. Default `600` (10 minutes — covers roughly five sequential 120 s renders). Increase this for flux models with long queue depths.
+- `--no-lock` — skip the lock entirely. Use this in test fixtures or operator-driven debug scenarios where you control parallelism yourself and do not want the overhead of lock file I/O.
+
+**When to use `--no-lock`:**
+- Running isolated unit tests that mock the Ollama API (no real GPU involved).
+- Debugging a single invocation in a terminal where you have confirmed no other image generation is in flight.
+- Never use `--no-lock` in a production pipeline where multiple skills might invoke Ollama concurrently — the timeout failures that motivated issue #75 will return.
+
+**Related:** issue [#75](https://github.com/SteveGJones/jack-tar-deckhand/issues/75), retrospective at `docs/superpowers/dogfooding/2026-05-07-blog-post-asset-run.md` (failure #5).
+
 ## Quick Start
 
 ```

--- a/plugins/jack-tar-ollama/skills/image/SKILL.md
+++ b/plugins/jack-tar-ollama/skills/image/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ollama-image
 description: Generate images using local Ollama models with optional iterative refinement. Accepts a text prompt or prompt file, generates via Ollama, optionally reviews and refines using vision, saves to a specified path, and returns the file path.
-argument-hint: "a description of the image" [--model MODEL] [--output PATH] [--prompt-file FILE] [--iterations N] [--width INT] [--height INT] [--steps INT] [--seed INT]
+argument-hint: "a description of the image" [--model MODEL] [--output PATH] [--prompt-file FILE] [--iterations N] [--width INT] [--height INT] [--steps INT] [--seed INT] [--lock-wait-timeout SECONDS] [--no-lock]
 allowed-tools: Bash(python *), Bash(curl *), Bash(ollama *), Read, Glob
 ---
 
@@ -22,6 +22,8 @@ Parse `$ARGUMENTS` for:
 - **--height INT**: Image height (default: 1024)
 - **--steps INT**: Inference steps (default: 8 for z-image-turbo, 20 for flux models)
 - **--seed INT**: Seed for reproducibility (optional)
+- **--lock-wait-timeout SECONDS**: How long to wait for the single-flight lock before giving up (default: 600). Ollama serialises on a single GPU context; this flag controls the maximum queue wait for a concurrent caller. Increase for flux models with long queue depths.
+- **--no-lock**: Skip the single-flight lock. For test fixtures or debug scenarios where you control parallelism yourself. Do not use in production pipelines with concurrent image generation (see issue #75).
 
 If `--prompt-file` is specified, read the file contents as the prompt using the Read tool.
 
@@ -93,7 +95,7 @@ If iterations is 1 (the default), run a single generation with no review:
 
 1. Run the helper script:
    ```bash
-   python3 "$PLUGIN_ROOT/src/generate_image.py" --prompt "THE PROMPT" --model "THE MODEL" --output "THE PATH" --width WIDTH --height HEIGHT --steps STEPS [--seed SEED]
+   python3 "$PLUGIN_ROOT/src/generate_image.py" --prompt "THE PROMPT" --model "THE MODEL" --output "THE PATH" --width WIDTH --height HEIGHT --steps STEPS [--seed SEED] [--lock-wait-timeout SECONDS] [--no-lock]
    ```
 2. If exit code is 0: read the output path from stdout.
 3. If exit code is non-zero: read stderr and report the error.
@@ -114,7 +116,7 @@ Determine the output path for this iteration. If `--output` was specified, use i
 
 Run the helper script with the current prompt:
 ```bash
-python3 "$PLUGIN_ROOT/src/generate_image.py" --prompt "CURRENT PROMPT" --model "MODEL" --output "ITER PATH" --width WIDTH --height HEIGHT --steps STEPS
+python3 "$PLUGIN_ROOT/src/generate_image.py" --prompt "CURRENT PROMPT" --model "MODEL" --output "ITER PATH" --width WIDTH --height HEIGHT --steps STEPS [--lock-wait-timeout SECONDS] [--no-lock]
 ```
 
 If the helper fails, report the error and stop.


### PR DESCRIPTION
Closes the plugin-level and constitution-level documentation gaps left after PRs #77 / #78 / #79 merged (cloud 1.3.2, ollama 1.1.1, deckhand 1.3.1). Code and version bumps already on main; this PR is **docs only** — no code, no test, no manifest schema changes.

## Gap closures

| # | File | Gap | Closed |
|---|------|-----|--------|
| 1 | `plugins/jack-tar-ollama/CLAUDE.md` | No mention of single-flight lock or new CLI flags | New "Single-flight protection (issue #75)" section |
| 2 | `plugins/jack-tar-ollama/skills/image/SKILL.md` | New CLI flags absent from operator-visible surface | `--lock-wait-timeout` / `--no-lock` in argument-hint, Parse Arguments, and both script invocation blocks |
| 3 | `plugins/jack-tar-deckhand/CLAUDE.md` | No mention of the discipline hook | New "Discipline hook (issue #76)" section |
| 4 | `plugins/jack-tar-cloud/CLAUDE.md` | httpx retry, Recraft V4 style change, Imagen Fast guard undocumented | Three new sections for issues #72, #73, #74 |
| 5 | `plugins/jack-tar-cloud/skills/recraft-image/SKILL.md` | `style='realistic_image'` stale V3 default still documented as current | argument-hint and `--style` description updated to reflect `None` default and V4 fall-through |
| 6 | `CONSTITUTION.md` Article 9.4 | Rule stated but enforcement mechanism not referenced | "How it is enforced (issue #76)" sub-clause added; requirements unchanged |
| 7 | `CLAUDE.md` current status | No 2026-05-08 entry for the release | New "Current Status (2026-05-08)" entry with PRs, issues, version bumps, doc links |
| 8 | `README.md` plugin version table | N/A — no version table present; skipped per instructions | — |

## Notes (additional gaps observed, out of scope for this sweep)

- `README.md` Status section cites test count (1010 + 33) and "EPIC #58 in progress" — both stale post-release but outside the gap list scope.
- `plugins/jack-tar-cloud/skills/recraft-icon/SKILL.md` has `vector_illustration` and `icon` style mentions in prompt-engineering tips (not defaults) — these are valid V4 styles, no change needed.
- `plugins/jack-tar-deckhand/skills/verify/SKILL.md` already had the DISCIPLINE HOOK section from PR #79 — no update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)