### PR TITLE
fix(jack-tar-superpower-bridge): SMARTART parser splits on inline · separators (#56)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -39,7 +39,7 @@
       "name": "jack-tar-superpower-bridge",
       "description": "Wraps document-skills:pptx with narrative pre-brief (/bridge-brief) and post-hoc visual enrichment (/enrich-deck) — combine /pptx structural strength with jack-tar visual capabilities (AI backgrounds, element images, editable SmartArt)",
       "source": "./plugins/jack-tar-superpower-bridge",
-      "version": "0.2.0"
+      "version": "0.2.1"
     }
   ]
 }

--- a/plugins/jack-tar-superpower-bridge/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-superpower-bridge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-superpower-bridge",
   "description": "Wraps document-skills:pptx with a narrative pre-brief skill and a post-hoc visual enrichment skill — combine /pptx structural strength with jack-tar visual capabilities (AI backgrounds, element images, editable SmartArt)",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-superpower-bridge/agents/narrative-brief-architect.md
+++ b/plugins/jack-tar-superpower-bridge/agents/narrative-brief-architect.md
@@ -149,6 +149,25 @@ When the deck's narrative has a strategic dichotomy (will / won't, ship / defer,
 
 When the brief's Section B includes a palette table with role keywords (structural / surface / body text / accent), the bridge automatically maps those tokens to SmartArt's colour slots and renders every SmartArt graphic in brand colours. No additional /pptx authoring is needed — Section B's palette IS the SmartArt palette. The "Structural / Primary fill" row pins the load-bearing dark token (Run 4 Finding #12 fix); the "Surface" row pins the text-on-primary contrast colour. If a deck contains SmartArt slides and Section B omits a palette table, SmartArt falls back to Microsoft default colours; flag this as a degraded outcome the speaker should fix.
 
+### SMARTART-FROM-LIST — bullet-line format only (Issue #56 — Finding #4, Run 1)
+
+When Section C describes bullet content for a SMARTART-FROM-LIST marker, **use separate bullet-line items — never inline `·`-separated, ` • `-separated, or ` | `-separated lists on a single line.** The bridge's extractor reads each paragraph of the marker shape as one item. A single paragraph containing `"Edge inference · Operator playbook · Customer overlap · GPU procurement · Registry seam"` produces 1-bullet SmartArt, not 5-bullet SmartArt.
+
+Correct form (separate bullet paragraphs authored by /pptx into the marker text-box):
+
+```
+Edge inference
+Operator playbook
+Customer overlap
+GPU procurement
+Registry seam
+```
+
+The bridge has a downstream split that recovers from inline lists with ≥3 separators, but Section C must coach /pptx toward bullet-line format to avoid the fallback entirely.
+
+- Do NOT include example bullet content in Section C with inline `·` / ` • ` / ` | ` separators — /pptx may transcribe the inline form verbatim.
+- When giving bullet examples in Section C, always write them as separate lines or a markdown list: `- "Edge inference capacity" (23)`.
+
 ### SMARTART-FROM-LIST bullet length (Finding #13 — repeated across Runs 4, 5, 6)
 
 When Section A names a slide whose content is a bullet list that should become SmartArt (3–5 items, parallel form, the "synergy pillars" / "key initiatives" / "pruning principles" pattern), constrain individual bullet length:

--- a/plugins/jack-tar-superpower-bridge/src/creative_brief.py
+++ b/plugins/jack-tar-superpower-bridge/src/creative_brief.py
@@ -317,6 +317,36 @@ def extract_expected_text_for_marker(brief_text: str, marker_id: str) -> list[st
 # "no specific text", "no text content", "no text"} appearing in the
 # marker's block in Section C. The persona's R3b output already uses
 # this language for atmospheric markers; the lint just reads it back.
+#
+# Issue #56 extension (Finding #4, Run 1 dogfood):
+# SMARTART-FROM-LIST marker body text that contains an inline-separated
+# list (3+ occurrences of · / • / |) is flagged as a soft warning. The
+# bridge can recover via downstream splitting, but bullet-line format is
+# the preferred contract. The check is a soft warning only — the lint
+# still returns a list (not an exception), and SKILL.md decides whether
+# to surface it as a halt or a note. This matches the non-throwing
+# pattern of the rest of the lint surface.
+#
+# Inline-separator detection mirrors the threshold in
+# ``enrichment_ops.smartart_from_list._split_inline_separators``:
+# 3+ occurrences of the same separator in a single line of Section C.
+_INLINE_SEP_CANDIDATES: list[str] = ["·", " • ", " | "]
+_INLINE_SEP_THRESHOLD = 3
+
+
+def _detect_inline_separator_in_line(line: str) -> str | None:
+    """Return the first inline separator found ≥3 times in ``line``,
+    or ``None`` if no dominant separator is present.
+
+    Mirrors the threshold in
+    ``enrichment_ops.smartart_from_list._split_inline_separators`` so
+    the lint and the extractor agree on what constitutes an inline list.
+    Issue #56 (Finding #4, Run 1 dogfood).
+    """
+    for sep in _INLINE_SEP_CANDIDATES:
+        if line.count(sep) >= _INLINE_SEP_THRESHOLD:
+            return sep
+    return None
 
 
 class BriefLintError(ValueError):
@@ -423,5 +453,47 @@ def lint_brief_for_extract_compatibility(brief_text: str) -> list[str]:
             f"in the subject brief (use words like \"atmospheric\", "
             f"\"vignette\", or \"no text\") to opt out of the lint."
         )
+
+    # Issue #56 (Finding #4, Run 1 dogfood) — soft-warn on inline-separator
+    # lists in SMARTART-FROM-LIST marker body text. The bridge can recover
+    # via downstream splitting, but bullet-line format is preferred.
+    # We scan every line of Section C that doesn't look like a heading,
+    # codeblock, or marker-name line for inline-list patterns (3+ separators).
+    smartart_list_marker_re = re.compile(r"\bSMARTART-FROM-LIST:[a-z0-9_-]+")
+    current_smartart_marker: str | None = None
+    in_code_block = False
+    for line in section_c.splitlines():
+        # Track fenced code blocks — don't lint inside them
+        if line.strip().startswith("```"):
+            in_code_block = not in_code_block
+            continue
+        if in_code_block:
+            continue
+        # Detect entering a new SMARTART-FROM-LIST marker reference
+        sm_match = smartart_list_marker_re.search(line)
+        if sm_match:
+            current_smartart_marker = sm_match.group(0)
+            continue
+        # Detect entering any other marker kind — stop attributing to last
+        # SMARTART-FROM-LIST marker
+        if _MARKER_REF_RE.search(line) and current_smartart_marker:
+            if not smartart_list_marker_re.search(line):
+                current_smartart_marker = None
+            continue
+        # Only warn while we're inside a SMARTART-FROM-LIST block
+        if current_smartart_marker is None:
+            continue
+        sep = _detect_inline_separator_in_line(line)
+        if sep is not None:
+            errors.append(
+                f"{current_smartart_marker}: Section C contains an inline "
+                f"separator-separated list (separator: {sep!r}, "
+                f"≥{_INLINE_SEP_THRESHOLD} occurrences). "
+                f"SMARTART-FROM-LIST content should use bullet-line format "
+                f"(one item per line) rather than inline-separated lists. "
+                f"The bridge will attempt to split at render time, but "
+                f"bullet-line format is more reliable."
+            )
+            current_smartart_marker = None  # warn once per marker block
 
     return errors

--- a/plugins/jack-tar-superpower-bridge/src/enrichment_ops/smartart_from_list.py
+++ b/plugins/jack-tar-superpower-bridge/src/enrichment_ops/smartart_from_list.py
@@ -28,8 +28,80 @@ than silent truncation. Run 7 evidence: silent ellipsis-truncation
 mangles operator content (mid-word "ent..."). Better to fail loudly so
 the operator can either rewrite within 60 chars or pick a different
 layout.
+
+Inline-separator splitting (Issue #56, Finding #4 from Run 1 dogfood):
+The narrative-brief-architect persona occasionally produces inline lists
+separated by ``·`` (U+00B7 middle dot), `` • `` (U+2022 with surrounding
+spaces), or `` | `` (pipe with surrounding spaces) instead of bullet-line
+lists. When /pptx faithfully transcribes these, the extractor reads the
+WHOLE paragraph as one bullet. ``_split_inline_separators`` detects this
+pattern and splits the paragraph into sibling items. The 3+ threshold
+avoids splitting prose that incidentally contains a single decorative
+separator character.
 """
 from __future__ import annotations
+
+import logging
+
+_log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Inline-separator splitting (Issue #56 — Finding #4, Run 1 dogfood)
+# ---------------------------------------------------------------------------
+#
+# Three separators the narrative-brief-architect is known to emit inside a
+# single paragraph instead of using bullet-line format. Listed in preference
+# order: if a paragraph contains ≥3 occurrences of the first separator that
+# matches, we split on that one and ignore the rest. The preference order is:
+#
+#   1. · (U+00B7 middle dot, no surrounding spaces required)
+#   2.   •   (U+2022 with surrounding spaces — distinguished from bullet-list
+#             form by the space requirement)
+#   3.  |   (pipe with surrounding spaces — low-priority: pipe appears in
+#             prose and tables, so require surrounding spaces to be safe)
+#
+# The 3+ threshold is defensive: prose can contain one or two decorative ·
+# characters (e.g., mathematical or typographical), but three is strong
+# evidence of an inline list. A single separator → leave the paragraph alone.
+
+_INLINE_SEPARATORS: list[str] = [
+    "·",   # · middle dot (no spaces required)
+    " • ", # • bullet with surrounding spaces
+    " | ",      # pipe with surrounding spaces
+]
+
+_INLINE_SPLIT_THRESHOLD = 3  # minimum separator count to trigger splitting
+
+
+def _split_inline_separators(text: str) -> list[str] | None:
+    """Detect and split an inline-separated list within a single paragraph.
+
+    Scans ``text`` for the dominant inline separator (preferred order:
+    ``·``, `` • ``, `` | ``). If any separator occurs ≥3 times in the
+    string, splits on that separator and returns the resulting items
+    (whitespace-trimmed, empty items dropped).
+
+    Returns ``None`` when no dominant separator is detected — the caller
+    should treat the text as a plain bullet.
+
+    Issue #56 — this is the load-bearing downstream defence. The upstream
+    prevention lives in the persona doc (Section C SMARTART-FROM-LIST
+    guidance) and the brief-save lint (``lint_brief_for_extract_compatibility``
+    in ``creative_brief.py``).
+    """
+    for sep in _INLINE_SEPARATORS:
+        if text.count(sep) >= _INLINE_SPLIT_THRESHOLD:
+            parts = [part.strip() for part in text.split(sep)]
+            parts = [p for p in parts if p]  # drop empty items
+            _log.debug(
+                "inline-separator split: separator=%r count=%d → %d items",
+                sep,
+                text.count(sep),
+                len(parts),
+            )
+            return parts
+    return None
 
 
 class SmartArtFromListExtractError(LookupError):
@@ -187,7 +259,17 @@ def extract_list_items_from_marker_shape(
     for paragraph in target_shape.text_frame.paragraphs:
         # Concatenate runs in the paragraph; strip whitespace
         text = "".join(run.text for run in paragraph.runs).strip()
-        if text:
+        if not text:
+            continue
+        # Issue #56 — detect inline-separator lists (Finding #4, Run 1
+        # dogfood). The narrative-brief-architect may emit a single paragraph
+        # like "A · B · C · D · E" instead of five separate bullet paragraphs.
+        # When ≥3 separators are detected, split and surface each fragment as
+        # a sibling bullet. When <3 separators, treat as ordinary prose bullet.
+        split = _split_inline_separators(text)
+        if split is not None:
+            items.extend(split)
+        else:
             items.append(text)
 
     if not items:

--- a/plugins/jack-tar-superpower-bridge/tests/test_lint_brief_for_extract_compatibility.py
+++ b/plugins/jack-tar-superpower-bridge/tests/test_lint_brief_for_extract_compatibility.py
@@ -239,3 +239,93 @@ def test_brief_lint_error_class_exists() -> None:
     """SKILL.md may want to raise BriefLintError when surfacing the lint
     failure to the operator. The class exists in the public surface."""
     assert issubclass(BriefLintError, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# Issue #56 — soft-warn on inline separators in SMARTART-FROM-LIST blocks
+# ---------------------------------------------------------------------------
+
+
+def test_inline_middle_dot_list_in_smartart_from_list_block_warns() -> None:
+    """Issue #56: inline · list inside a SMARTART-FROM-LIST block generates
+    a soft warning. The bridge can recover at render time, but bullet-line
+    format is preferred."""
+    brief = """## Section C — Placeholder Instructions
+
+`SMARTART-FROM-LIST:capability-themes` — process flow, 3–5 items.
+Edge inference · Operator playbook · Customer overlap · GPU procurement · Registry seam
+"""
+    errors = lint_brief_for_extract_compatibility(brief)
+    assert len(errors) == 1
+    assert "SMARTART-FROM-LIST:capability-themes" in errors[0]
+    assert "inline" in errors[0].lower() or "separator" in errors[0].lower()
+
+
+def test_inline_pipe_list_in_smartart_from_list_block_warns() -> None:
+    """Issue #56: inline | list also triggers the soft warning."""
+    brief = """## Section C — Placeholder Instructions
+
+`SMARTART-FROM-LIST:phase-steps` — 4-phase pipeline.
+Discovery | Design | Build | Test | Ship
+"""
+    errors = lint_brief_for_extract_compatibility(brief)
+    assert len(errors) == 1
+    assert "SMARTART-FROM-LIST:phase-steps" in errors[0]
+
+
+def test_inline_separator_in_image_marker_block_not_linted() -> None:
+    """Issue #56: only SMARTART-FROM-LIST blocks are scanned for inline
+    separators. An inline · in an IMAGE marker block does NOT trigger the
+    warning (that pattern is fine for prose descriptions)."""
+    brief = """## Section C — Placeholder Instructions
+
+`IMAGE:schematic-trio` — three boxes: Alpha · Beta · Gamma · Delta
+
+> EXACT spelled labels REQUIRED:
+> - left: "Alpha"
+> - middle: "Beta"
+> - right: "Gamma"
+"""
+    errors = lint_brief_for_extract_compatibility(brief)
+    assert errors == []
+
+
+def test_inline_separator_below_threshold_not_warned() -> None:
+    """Issue #56: two · characters in a SMARTART-FROM-LIST block is below
+    the 3+ threshold and does NOT trigger the warning."""
+    brief = """## Section C — Placeholder Instructions
+
+`SMARTART-FROM-LIST:two-items` — just two items.
+Phase A · Phase B (complete)
+"""
+    errors = lint_brief_for_extract_compatibility(brief)
+    assert errors == []
+
+
+def test_bullet_line_format_in_smartart_block_passes_lint() -> None:
+    """Issue #56: the preferred bullet-line format has no inline separators
+    and passes lint cleanly."""
+    brief = """## Section C — Placeholder Instructions
+
+`SMARTART-FROM-LIST:capability-themes` — process flow, ≤24 chars each:
+- Edge inference
+- Operator playbook
+- Customer overlap
+- GPU procurement
+- Registry seam
+"""
+    errors = lint_brief_for_extract_compatibility(brief)
+    assert errors == []
+
+
+def test_inline_separator_lint_is_soft_warning_not_exception() -> None:
+    """Issue #56: inline-separator detection must not raise — lint always
+    returns a list so SKILL.md controls severity."""
+    brief = """## Section C — Placeholder Instructions
+
+`SMARTART-FROM-LIST:phases` — all phases.
+Alpha · Beta · Gamma · Delta · Epsilon
+"""
+    errors = lint_brief_for_extract_compatibility(brief)
+    assert isinstance(errors, list)
+    assert all(isinstance(e, str) for e in errors)

--- a/plugins/jack-tar-superpower-bridge/tests/test_smartart_from_list.py
+++ b/plugins/jack-tar-superpower-bridge/tests/test_smartart_from_list.py
@@ -30,6 +30,7 @@ from src.enrichment_ops.smartart_from_list import (
     BulletsTooLongError,
     LAYOUT_BULLET_CAPS,
     SmartArtFromListExtractError,
+    _split_inline_separators,
     extract_list_items_from_marker_shape,
     select_layout_for_bullets,
 )
@@ -495,3 +496,172 @@ def test_apply_enrichment_smartart_from_list_routes_to_list1_for_longer_bullets(
         layout_xml = z.read(layout_parts[0]).decode("utf-8")
     # The list1 layout URI must appear in the injected layout part
     assert "list1" in layout_xml or "List1" in layout_xml
+
+
+# ---------------------------------------------------------------------------
+# Issue #56 — Inline-separator splitting (Finding #4, Run 1 dogfood)
+# ---------------------------------------------------------------------------
+#
+# The narrative-brief-architect persona may emit a single paragraph like
+# "A · B · C · D · E" instead of five separate bullet paragraphs. These
+# tests validate the downstream defence (_split_inline_separators) and its
+# integration into extract_list_items_from_marker_shape.
+
+
+# --- Unit tests for _split_inline_separators --------------------------------
+
+def test_split_middle_dot_five_items():
+    """Round-trip: inline list with middle-dot separator splits into 5 items."""
+    text = "Edge inference · Operator playbook · Customer overlap · GPU procurement · Registry seam"
+    result = _split_inline_separators(text)
+    assert result == [
+        "Edge inference",
+        "Operator playbook",
+        "Customer overlap",
+        "GPU procurement",
+        "Registry seam",
+    ]
+
+
+def test_split_bullet_with_spaces_three_items():
+    """Spaced bullet (U+2022) separator with 3 occurrences splits correctly."""
+    text = "Alpha • Beta • Gamma • Delta"
+    result = _split_inline_separators(text)
+    assert result == ["Alpha", "Beta", "Gamma", "Delta"]
+
+
+def test_split_pipe_with_spaces_three_items():
+    """Spaced pipe separator with 3 occurrences splits correctly."""
+    text = "North | South | East | West"
+    result = _split_inline_separators(text)
+    assert result == ["North", "South", "East", "West"]
+
+
+def test_split_does_not_fire_on_single_middle_dot():
+    """A single decorative · in prose must NOT trigger splitting.
+    Threshold is ≥3 occurrences."""
+    text = "A beautifully crafted · experience for engineers"
+    assert _split_inline_separators(text) is None
+
+
+def test_split_does_not_fire_on_two_middle_dots():
+    """Two occurrences are below the 3+ threshold — leave as prose."""
+    text = "Phase A · Phase B · end"
+    assert _split_inline_separators(text) is None
+
+
+def test_split_drops_empty_items():
+    """Empty fragments after splitting are dropped (e.g. trailing separator)."""
+    text = "A · B ·  · C"  # third separator produces an empty fragment
+    result = _split_inline_separators(text)
+    assert result == ["A", "B", "C"]
+
+
+def test_split_prefers_middle_dot_over_pipe_when_both_present():
+    """When both · and | appear with ≥3 counts, · wins (higher priority)."""
+    text = "A · B · C · D | E | F | G"
+    result = _split_inline_separators(text)
+    # · has 3+ occurrences and is first in the preference list
+    assert result is not None
+    # The split must be on · — result contains items from the · split
+    assert "A" in result
+    assert "B" in result
+    assert "C" in result
+
+
+def test_split_returns_none_when_no_dominant_separator():
+    """Plain prose without inline separators returns None."""
+    text = "This is a normal sentence with no list separators at all."
+    assert _split_inline_separators(text) is None
+
+
+def test_split_trims_whitespace_from_items():
+    """Each split item must have leading/trailing whitespace stripped."""
+    text = "  Alpha  ·  Beta  ·  Gamma  ·  Delta  "
+    result = _split_inline_separators(text)
+    assert result is not None
+    for item in result:
+        assert item == item.strip()
+
+
+# --- Integration: extract_list_items_from_marker_shape with inline lists ----
+
+def _build_pptx_with_inline_separator_paragraph(
+    out_path: Path,
+    inline_text: str,
+    marker_name: str = "SMARTART-FROM-LIST:inline-list",
+) -> Path:
+    """Build a 1-slide .pptx whose marker shape contains a SINGLE PARAGRAPH
+    with an inline-separator list (not separate bullet paragraphs)."""
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    box = slide.shapes.add_textbox(Inches(0.5), Inches(1.5), Inches(9), Inches(4))
+    tf = box.text_frame
+    tf.text = inline_text  # single paragraph with inline separators
+    box.name = marker_name
+    prs.save(str(out_path))
+    return out_path
+
+
+def test_extract_splits_inline_middle_dot_paragraph(tmp_path):
+    """Round-trip: a marker shape with a single inline-· paragraph yields 5
+    items, not 1. Issue #56 reproduction test."""
+    inline = "Edge inference · Operator playbook · Customer overlap · GPU procurement · Registry seam"
+    pptx = _build_pptx_with_inline_separator_paragraph(tmp_path / "inline.pptx", inline)
+    prs = Presentation(str(pptx))
+    items = extract_list_items_from_marker_shape(
+        prs=prs, slide_index_1based=1,
+        marker_name="SMARTART-FROM-LIST:inline-list",
+    )
+    assert len(items) == 5
+    assert items[0] == "Edge inference"
+    assert items[4] == "Registry seam"
+
+
+def test_extract_does_not_split_prose_with_one_middle_dot(tmp_path):
+    """Negative: prose with a single · is NOT split into multiple items."""
+    prose = "The system uses a proprietary · encoding for all payloads"
+    pptx = _build_pptx_with_inline_separator_paragraph(tmp_path / "prose.pptx", prose)
+    prs = Presentation(str(pptx))
+    items = extract_list_items_from_marker_shape(
+        prs=prs, slide_index_1based=1,
+        marker_name="SMARTART-FROM-LIST:inline-list",
+    )
+    assert len(items) == 1
+    assert items[0] == prose
+
+
+def test_extract_does_not_split_prose_with_two_middle_dots(tmp_path):
+    """Negative: two · occurrences are below the threshold — still 1 item."""
+    prose = "A · B · C"  # only 2 occurrences — below the 3+ threshold
+    pptx = _build_pptx_with_inline_separator_paragraph(tmp_path / "prose2.pptx", prose)
+    prs = Presentation(str(pptx))
+    items = extract_list_items_from_marker_shape(
+        prs=prs, slide_index_1based=1,
+        marker_name="SMARTART-FROM-LIST:inline-list",
+    )
+    assert len(items) == 1
+
+
+def test_extract_mixes_normal_bullets_and_inline_paragraph(tmp_path):
+    """A shape with 2 normal bullet paragraphs + 1 inline paragraph expands
+    correctly: normal bullets stay as-is, inline paragraph splits."""
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    box = slide.shapes.add_textbox(Inches(0.5), Inches(1.5), Inches(9), Inches(4))
+    tf = box.text_frame
+    tf.text = "Normal bullet one"                          # paragraph 1 — normal
+    tf.add_paragraph().text = "Normal bullet two"         # paragraph 2 — normal
+    # paragraph 3 — inline list with 4 · separators
+    tf.add_paragraph().text = "A · B · C · D · E"
+    box.name = "SMARTART-FROM-LIST:mixed"
+    pptx_path = tmp_path / "mixed.pptx"
+    prs.save(str(pptx_path))
+
+    prs = Presentation(str(pptx_path))
+    items = extract_list_items_from_marker_shape(
+        prs=prs, slide_index_1based=1, marker_name="SMARTART-FROM-LIST:mixed",
+    )
+    # 2 normal + 5 from inline = 7 total
+    assert items[:2] == ["Normal bullet one", "Normal bullet two"]
+    assert items[2:] == ["A", "B", "C", "D", "E"]


### PR DESCRIPTION
## Problem

Finding #4 from Run 1 of the 2026-04-23 dogfood series, open across 10 runs. When the narrative-brief-architect persona produces a Section C list using inline `·` (U+00B7), ` • `, or ` | ` separators instead of bullet-line format, `/pptx` faithfully transcribes them as a single paragraph. The bridge's `extract_list_items_from_marker_shape` then reads the whole paragraph as one bullet, producing a 1-bullet SmartArt instead of a 5-bullet SmartArt.

Example: `"Edge inference · Operator playbook · Customer overlap · GPU procurement · Registry seam"` → was 1 item, now correctly yields 5.

## Two-layer fix

**Downstream — load-bearing split in the extractor** (`enrichment_ops/smartart_from_list.py`):

- New `_split_inline_separators(text)` helper: scans each paragraph for dominant inline separator (`·` → ` • ` → ` | `, preference order). If ≥3 occurrences found, splits and returns trimmed non-empty fragments. Returns `None` otherwise.
- `extract_list_items_from_marker_shape` calls this helper per paragraph. Normal bullet paragraphs are unaffected; inline-list paragraphs expand into sibling items. Mix of normal + inline paragraphs in a single marker shape is handled correctly.
- Debug log fires when splitting activates (operator can see it in the run log).

**Upstream — persona guidance + brief-save lint** (preventive):

- `agents/narrative-brief-architect.md`: new "SMARTART-FROM-LIST — bullet-line format only" section in Section C guidance explicitly discourages inline `·`/`•`/`|` lists and coaches bullet-line format. Notes that the bridge has a downstream recovery path but bullet-line is preferred.
- `src/creative_brief.py`: `lint_brief_for_extract_compatibility()` extended to scan SMARTART-FROM-LIST marker blocks for inline-separator lines (≥3 occurrences). Issues a soft warning (returns a string in the list, does not raise) so SKILL.md controls severity — matching the non-throwing pattern of the rest of the lint surface.

## Decisions

- **3+ threshold**: prose can contain one or two decorative `·` characters (mathematical, typographical). Three is strong evidence of an intent-to-list. Validated by the negative tests: 1-occurrence and 2-occurrence paragraphs are NOT split.
- **Silent split + debug log**: the bridge can always recover via splitting; surfacing a hard error at render time for a recoverable case would interrupt a /enrich-deck run unnecessarily.
- **Soft lint warning** (not hard-stop): matches the `lint_brief_for_extract_compatibility` pattern — returns a list of strings, never raises. SKILL.md decides whether to halt or surface as a note.
- **Preferred separator order**: `·` first (most common persona output), then ` • ` (spaced bullet), then ` | ` (spaced pipe, lower priority because pipe appears in tables and prose). A paragraph must reach the threshold on one separator before any lower-priority separator is checked — so the split is deterministic.

## Test coverage delta

+25 tests across two files (325 total, all green):

- `test_smartart_from_list.py`: 14 new tests covering `_split_inline_separators` unit behaviour (5-item round-trip, `•` and `|` separators, 1- and 2-occurrence negatives, empty-item filter, mixed-separator preference, whitespace trimming) + 4 integration tests via `extract_list_items_from_marker_shape` (inline paragraph, prose-with-one-dot negative, prose-with-two-dot negative, mixed normal-and-inline paragraphs).
- `test_lint_brief_for_extract_compatibility.py`: 6 new tests covering soft-warn on `·` and `|` lists, IMAGE block not linted, below-threshold not warned, bullet-line format passes, non-throwing return.

## Version bump

`jack-tar-superpower-bridge` 0.2.0 → 0.2.1. Marketplace entry synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)