### PR TITLE
feat(jack-tar-superpower-bridge): CHART:slug marker kind (#55)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -37,9 +37,9 @@
     },
     {
       "name": "jack-tar-superpower-bridge",
-      "description": "Wraps document-skills:pptx with narrative pre-brief (/bridge-brief) and post-hoc visual enrichment (/enrich-deck) — combine /pptx structural strength with jack-tar visual capabilities (AI backgrounds, element images, editable SmartArt)",
+      "description": "Wraps document-skills:pptx with narrative pre-brief (/bridge-brief) and post-hoc visual enrichment (/enrich-deck) — combine /pptx structural strength with jack-tar visual capabilities (AI backgrounds, element images, editable SmartArt, native charts)",
       "source": "./plugins/jack-tar-superpower-bridge",
-      "version": "0.2.1"
+      "version": "0.2.2"
     }
   ]
 }

--- a/docs/superpowers/dogfooding/2026-05-12-chart-marker-validation.md
+++ b/docs/superpowers/dogfooding/2026-05-12-chart-marker-validation.md
@@ -1,0 +1,90 @@
+# 2026-05-12 — CHART marker validation (issue #55 / PR #82)
+
+Pre-merge dogfood verification gate for the new `CHART:slug` marker kind. CI green is necessary but not sufficient for a PR that introduces a new render path — this gate confirms the chart renders correctly in PowerPoint Mac before merge per `feedback_verification_before_merge.md`.
+
+## Method
+
+Single-slide round-trip through the bridge's chart marker path:
+
+1. **Author fixture** (`output/chart-marker-verification/build_fixture.js`) — single-slide .pptx via PptxGenJS with one `CHART:quarterly-figures` placeholder rect (dashed grey border, 10×4.5 inches at x=1.5, y=1.8). Centred marker label addText shape inside the rect.
+2. **Run enrichment** (`output/chart-marker-verification/run_enrichment.py`) — constructs an `EnrichmentItem(kind="chart")` with a realistic 4-quarter × 2-series column chart_spec, `palette_role="vital_and_mourning"`, BrandPalette primary `#1A4D7A`. Calls `apply_enrichment()` end-to-end.
+3. **Rasterise output** — LibreOffice headless → PDF → PNG at 130 dpi for automated review.
+4. **Automated review** — dispatched the image-reviewer / general-purpose agent (Sonnet, fresh context) against the rasterised slide with the full expected-behaviour checklist.
+5. **Manual visual gate** — operator opened the enriched .pptx in PowerPoint Mac for the final eye-check.
+
+## chart_spec used
+
+```python
+{
+    "type": "column",
+    "categories": ["Q1 2026", "Q2 2026", "Q3 2026", "Q4 2026"],
+    "series": [
+        {"name": "Revenue", "values": [12.5, 14.2, 15.8, 17.1]},
+        {"name": "Costs",   "values": [8.1, 8.4, 8.9, 9.2]},
+    ],
+    "title": "Quarterly revenue vs costs (USD millions)",
+    "x_axis_title": "Fiscal quarter",
+    "y_axis_title": "USD millions",
+    "show_legend": True,
+    "value_format": "#,##0.0",
+    "palette_role": "vital_and_mourning",
+}
+```
+
+BrandPalette: `primary_fill_hex=#1A4D7A`, `text_on_primary_hex=#FFFFFF`, `text_on_surface_hex=#1A1A1A`.
+
+## Results
+
+### Automated review verdict — PASS
+
+| Check | Result |
+|---|---|
+| Placeholder rect removed | ✓ |
+| Marker label text removed | ✓ |
+| Native column chart inserted | ✓ |
+| Chart type appears correct | ✓ |
+| 4 x-axis categories visible (Q1-Q4 2026) | ✓ |
+| 2 series visible (Revenue, Costs) | ✓ |
+| Chart title rendered correctly | ✓ |
+| X-axis title visible ("Fiscal quarter") | ✓ |
+| Y-axis title visible ("USD millions") | ✓ |
+| Legend visible | ✓ |
+| Series colours distinct (vital + mourning roles) | ✓ |
+| Slide title intact | ✓ |
+| Slide subtitle intact | ✓ |
+| Slide footer intact | ✓ |
+| Chart at expected coords | ✓ |
+
+No blocking issues.
+
+### Operator visual gate — PASS
+
+Operator opened `chart-verify-enriched.pptx` in PowerPoint Mac and confirmed the chart renders as expected. PDF saved for record.
+
+## Minor observations (not blocking)
+
+- **Per-bar data labels** appeared on the rendered chart. Not specified in the chart_spec but not harmful — likely a python-pptx default. Could be wired through a future `chart_spec["show_data_labels"]` flag if operators want explicit control.
+- **Costs series rendered very dark charcoal** — close to black at small sizes. The `vital_and_mourning` palette derivation produces a dark, desaturated tone for the de-emphasis series. Readable here against a light surface, but worth a future tweak if briefs need a warmer "mourning" tone (e.g. mauve-grey, ox-blood-de-saturated).
+
+Neither of these is a v1 blocker. Both are candidates for v0.2.3 / v0.3 polish if real-user dogfood surfaces dissatisfaction.
+
+## Verdict
+
+**PASS** — both gates (automated review + operator PowerPoint Mac visual confirmation). PR #82 cleared for merge.
+
+## Artefacts
+
+- `output/chart-marker-verification/build_fixture.js` — PptxGenJS fixture authoring
+- `output/chart-marker-verification/chart-verify-fixture.pptx` — pre-enrichment input
+- `output/chart-marker-verification/run_enrichment.py` — enrichment driver
+- `output/chart-marker-verification/chart-verify-enriched.pptx` — post-enrichment output
+- `output/chart-marker-verification/chart-verify-enriched.pdf` — LibreOffice-rasterised render
+- `output/chart-marker-verification/slide-1.png` — rasterised slide for the automated reviewer
+
+## References
+
+- Issue: [#55](https://github.com/SteveGJones/jack-tar-deckhand/issues/55)
+- PR: [#82](https://github.com/SteveGJones/jack-tar-deckhand/pull/82)
+- Plan: `docs/superpowers/plans/2026-05-12-bridge-chart-marker.md`
+- EPIC: [#57](https://github.com/SteveGJones/jack-tar-deckhand/issues/57)
+- Verification-before-merge rule: `~/.claude/projects/-Users-stevejones-Documents-Development-jack-tar-deckhand/memory/feedback_verification_before_merge.md`

--- a/plugins/jack-tar-superpower-bridge/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-superpower-bridge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-superpower-bridge",
   "description": "Wraps document-skills:pptx with a narrative pre-brief skill and a post-hoc visual enrichment skill — combine /pptx structural strength with jack-tar visual capabilities (AI backgrounds, element images, editable SmartArt)",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-superpower-bridge/agents/narrative-brief-architect.md
+++ b/plugins/jack-tar-superpower-bridge/agents/narrative-brief-architect.md
@@ -123,15 +123,21 @@ Format every text-bearing IMAGE subject brief like this:
 
 Note the explicit "EXACT spelled labels REQUIRED" header and the per-element labelling. When a marker has no fixed text content (atmospheric backgrounds, abstract textures, illustrative scenes without overlay), omit this section — its absence signals to the bridge that text-content fidelity is not load-bearing.
 
-### Native charts — chart-shaped subjects go here, NOT into IMAGE markers
+### CHART markers — canonical for chart-shaped subjects (issue #55)
 
-For any slide whose subject is a data series with axes and category labels — market sizing, capacity allocation, revenue projection, ROI, MTTR-by-class, time-series trends — **use a native PptxGenJS chart directly on the slide via `addChart()`. Do NOT place an IMAGE marker on a chart-shaped subject.** Generative AI cannot render faithful axis tick values, category labels, or data-series annotations at slide scale; the result will be visually styled but numerically corrupted (Run 4 Finding #15 — three of four IMAGE markers in that run produced garbled axis labels).
+For any slide whose subject is a data series with axes and category labels — market sizing, capacity allocation, revenue projection, ROI, MTTR-by-class, time-series trends — **use a `CHART:slug` placeholder marker. Do NOT place an IMAGE marker on a chart-shaped subject.** Generative AI cannot render faithful axis tick values, category labels, or data-series annotations at slide scale; the result will be visually styled but numerically corrupted (Run 4 Finding #15 — three of four IMAGE markers in that run produced garbled axis labels).
 
-Section C must include explicit redirect language. Run 5's wording is the canonical example:
+The bridge reads the `CHART:slug` objectName from the placeholder rect, replaces the rect with a native PowerPoint chart (bar, column, line, area, pie, doughnut, or scatter) at the same coordinates, and colours the series from the brief's brand palette. The operator supplies the chart data at `/enrich-deck` time via `chart_spec`.
 
-> For any slide whose subject is a data series with axes and category labels, use a native PptxGenJS chart directly on the slide. Do not place an IMAGE marker on a chart-shaped subject.
+Section C must identify chart-shaped subjects by name so the operator knows which `CHART:slug` to supply data for. Run 5's wording is the canonical example for the language redirect (updated for the CHART marker pattern):
 
-Then list 2–3 example chart subjects relevant to the deck's narrative (e.g., for a strategy deck: "capacity allocation over time, market sizing across the portfolio, ROI projection per bet"). The example list anchors /pptx to the right tool.
+> For chart-shaped subjects — capacity allocation over time, market sizing across the portfolio, ROI projection per bet — author a `CHART:slug` placeholder rect (not an IMAGE marker). The bridge will replace it with a native chart. Operator supplies chart type, categories, and series data at /enrich-deck time.
+
+Supported `chart_spec.type` values: `bar`, `column`, `line`, `area`, `pie`, `doughnut`, `scatter`.
+
+**Fallback — Section C language workaround (still valid):** when operators don't yet have the chart data at brief-authoring time, the existing Section C `addChart()` language workaround from Runs 5–10 remains valid. Use it to redirect `/pptx` away from IMAGE markers until the data is ready; the CHART marker is the preferred path once data is available.
+
+Then list 2–3 example chart subjects relevant to the deck's narrative (e.g., for a strategy deck: "capacity allocation over time, market sizing across the portfolio, ROI projection per bet"). The example list anchors `/pptx` to the right tool.
 
 ### BG marker — single structural pivot only
 
@@ -219,13 +225,16 @@ If the user has not stated confidentiality, ask explicitly. Do not default silen
 | Marker prefix | Purpose | Use when |
 |--------------|---------|----------|
 | **`SMARTART-FROM-LIST:`** *(preferred SmartArt pattern, sub-page default)* | The marker IS a bullet-list shape; bridge replaces it with a brand-coloured SmartArt at the same coordinates, preserving title + surrounding prose. Authored at sub-page coordinates per the scale typology in the Section C output. | The slide has a process / hierarchy / cycle / list as part of its content, alongside a title and possibly other supporting prose. |
-| `IMAGE:` *(sub-page default)* | AI-generated schematic illustration in a reserved rectangle. Sub-page placement (side accent / inline / banner) — NOT full-bleed hero. | The slide benefits from a schematic, institutional-register illustration alongside body prose. NOT for chart-shaped subjects (those are native charts, not IMAGE markers). |
+| `IMAGE:` *(sub-page default)* | AI-generated schematic illustration in a reserved rectangle. Sub-page placement (side accent / inline / banner) — NOT full-bleed hero. | The slide benefits from a schematic, institutional-register illustration alongside body prose. NOT for chart-shaped subjects (those are CHART markers, not IMAGE markers). |
+| `CHART:` *(canonical for chart-shaped subjects — issue #55)* | Placeholder rectangle replaced by a native PowerPoint chart (bar, column, line, area, pie, doughnut, scatter) at the marker's coordinates. Bridge renders the chart with brand palette colours; operator supplies the chart data at /enrich-deck time via `chart_spec`. | The slide subject is a data series with axes and category labels — X-vs-Y comparisons, time-series trends, market sizing, revenue projections, ROI curves, MTTR-by-class. Generative AI cannot render faithful axis values; use this marker, not `IMAGE:`. |
 | `BG:` *(single-pivot only)* | AI atmospheric background covering the whole slide | The deck has ONE structural register-shift pivot (diagnosis→intervention, tension→release, accumulation→reveal). Most decks have 0–1 BG markers. The deck's surface colour IS the atmosphere on every other slide. |
 | `SMARTART:` *(graphic-only-slide fallback)* | Placeholder rectangle replaced by a SmartArt rendered from a separate spec | The slide is a graphic-only divider where the SmartArt owns the entire content zone (no surrounding prose). Most decks won't need this. |
 
 **Authoring guidance for /pptx:** when Section A names a slide that contains an enumerable structure (3-step process, 4-quadrant matrix, hierarchy, cycle, etc.) AS PART of a slide that ALSO has a title and possibly supporting prose, write the bullet list naturally at sub-page coordinates and mark the list shape with `SMARTART-FROM-LIST:slug`. Only reach for `SMARTART:slug` when the entire content zone is a graphic with no surrounding prose. The bridge's Phase 3 analyser detects both kinds and routes accordingly.
 
-**Authoring guidance for chart subjects:** when Section A names a slide whose subject is a data series with axes and category labels (X-vs-Y, time-series, comparison, projection), author it as a native PptxGenJS `addChart()` call with real labels and real series data. Do NOT place an IMAGE marker on a chart-shaped subject. Reserve IMAGE markers for schematic, illustrative content with no axis values to corrupt.
+**Authoring guidance for chart subjects (issue #55):** when Section A names a slide whose subject is a data series with axes and category labels (X-vs-Y, time-series, comparison, projection), author a `CHART:slug` placeholder rect. The bridge renders a native PowerPoint chart at the marker's coordinates using the brief's brand palette; the operator supplies the chart data at `/enrich-deck` time. The `/pptx` superpower should author the placeholder rect with `objectName: "CHART:slug"` and an optional `addText` label — both are removed after enrichment. Run 4 evidence: three of four IMAGE markers on chart-shaped subjects produced garbled axis labels (Finding #15); `CHART:` is the structural fix.
+
+The Section C `addChart()` language workaround from Runs 5–10 remains valid as a fallback when chart data is not yet available at brief-authoring time — use it if you need to redirect `/pptx` away from IMAGE markers before the operator has the chart data ready. `CHART:` markers are the preferred path when the operator has the data at `/enrich-deck` time.
 
 ## Identifier grammar
 
@@ -234,6 +243,7 @@ After the colon: lowercase letters, digits, hyphens, underscores only. `IMAGE:ag
 The identifier semantics:
 - For `IMAGE:` and `BG:` — descriptive slug (`IMAGE:agent-architecture`, `BG:dramatic-opening`).
 - For `SMARTART-FROM-LIST:` and `SMARTART:` — hint at the *subject*, not the catalog layout id (`SMARTART-FROM-LIST:three-pillars`, NOT `SMARTART-FROM-LIST:process1`). Layout selection is a separate step the bridge does in Phase 3 from the bullet content + item count.
+- For `CHART:` — descriptive slug naming the chart subject (`CHART:revenue-vs-costs`, `CHART:capacity-over-time`, `CHART:mttr-by-class`). NOT the chart type — the type is declared in the operator-supplied `chart_spec` at /enrich-deck time.
 
 Marker identifiers must be unique deck-wide. The Phase 3 analyser flags duplicates; if you are tempted to repeat one, use a more specific slug.
 
@@ -244,7 +254,7 @@ Marker identifiers must be unique deck-wide. The Phase 3 analyser flags duplicat
 - Do NOT specify `name:` as the PptxGenJS shape-name property in exemplar code — MUST use `objectName:` (Spike 1 finding; the entire downstream pipeline depends on it).
 - Do NOT lead Section C with `SMARTART:` (full content zone) when describing bullet-list-content slides — `SMARTART-FROM-LIST:` is the preferred pattern because it preserves the slide's title and surrounding prose. Reserve `SMARTART:` for graphic-only divider slides.
 - Do NOT default SMARTART-FROM-LIST or IMAGE markers to full-content-zone width. Section C MUST include sub-page scale typology with explicit inch coordinates (Run 5 evidence — `/pptx` defaults to content-zone width when the brief doesn't specify scale).
-- Do NOT propose IMAGE markers for chart-shaped subjects (X-vs-Y data with axes / category labels). Section C MUST include native-chart-routing language redirecting these subjects to `addChart()`. Generative AI corrupts axis text at slide scale (Run 4 Finding #15 evidence).
+- Do NOT propose IMAGE markers for chart-shaped subjects (X-vs-Y data with axes / category labels). Section C MUST use `CHART:slug` markers for chart-shaped subjects (issue #55 canonical fix), or the `addChart()` language workaround as a fallback when chart data is not yet available. Generative AI corrupts axis text at slide scale (Run 4 Finding #15 evidence).
 - Do NOT omit `EXACT spelled labels REQUIRED` per-element listings from any text-bearing IMAGE marker's Section C subject brief. Without an explicit expected-text list, the image-reviewer (Haiku) confabulates spelling correctness and ships misspellings (Run 6 Finding #19 evidence: "INFORENCE" passed Phase A review).
 - Do NOT omit the palette table from Section B if the deck contains SmartArt slides. The "Structural / Primary fill" row pins the bridge's brand-palette injection (Contract 1).
 - Do NOT propose SMARTART-FROM-LIST bullets exceeding 24 chars without flagging — the bridge's default `process1` layout caps at 24 chars and longer items either get truncated or fail at apply time (Run 4/5/6 Finding #13 reaffirmed).

--- a/plugins/jack-tar-superpower-bridge/src/chart_palette.py
+++ b/plugins/jack-tar-superpower-bridge/src/chart_palette.py
@@ -1,0 +1,202 @@
+"""Chart series colour derivation from BrandPalette (issue #55).
+
+Derives a list of hex series colours for a native python-pptx chart, given
+the brief's BrandPalette, a palette role, and the number of series to colour.
+
+Three roles are supported:
+
+- ``"default"`` — a single-hue family derived from the primary fill by
+  stepping lightness in HSL space. First colour is the primary fill itself;
+  successive colours are lighter (higher lightness, same hue + saturation).
+  Works for any series count; the colour family reads as "variations on the
+  brand colour".
+
+- ``"vital_and_mourning"`` — exactly two colours: the primary fill (the
+  "vital" / emphasis series) and a desaturated, darkened derivative (the
+  "mourning" / de-emphasis series). Intended for 2-series charts where one
+  series is the focus and the other is context. If n_series != 2, the
+  function logs a warning and falls back to ``"default"``.
+
+- ``"data_categorical"`` — n_series distinct hues, evenly distributed around
+  the HSL colour wheel, all sharing the primary fill's saturation and
+  lightness. The first hue is the primary fill's own hue; subsequent hues
+  are rotated by ``360 / n_series`` degrees. Produces visually distinct
+  colours suitable for 3+ unrelated data series.
+
+Explicit override:
+
+  If the caller supplies ``explicit: list[str]``, it always wins regardless
+  of ``role``. The list is normalised (6-char uppercase hex without ``#``).
+  If ``len(explicit) < n_series`` the last colour is repeated to pad; if
+  ``len(explicit) > n_series`` the list is truncated. This lets operators
+  specify exact hex values for each series when brand-governance matters.
+
+Soft failure:
+
+  If n_series > 6 for any role, a warning is logged (to stderr) and a
+  best-effort palette is returned — derive_chart_palette never raises for a
+  large n_series.
+"""
+from __future__ import annotations
+
+import colorsys
+import re
+import sys
+import warnings
+
+from src.colors_xml_builder import BrandPalette
+
+_HEX_NORM_RE = re.compile(r"^#?([0-9A-Fa-f]{6})$")
+_N_SERIES_WARN_THRESHOLD = 6
+
+
+def _hex_to_rgb(hex_str: str) -> tuple[float, float, float]:
+    """Return (r, g, b) each in [0, 1] from a 6-char hex string (no leading #)."""
+    h = hex_str.lstrip("#")
+    r = int(h[0:2], 16) / 255.0
+    g = int(h[2:4], 16) / 255.0
+    b = int(h[4:6], 16) / 255.0
+    return r, g, b
+
+
+def _rgb_to_hex(r: float, g: float, b: float) -> str:
+    """Return an uppercase 6-char hex string from (r, g, b) each in [0, 1]."""
+    ri = max(0, min(255, round(r * 255)))
+    gi = max(0, min(255, round(g * 255)))
+    bi = max(0, min(255, round(b * 255)))
+    return f"{ri:02X}{gi:02X}{bi:02X}"
+
+
+def _normalise_hex(value: str) -> str:
+    """Normalise a hex colour to 6-char uppercase without leading ``#``."""
+    m = _HEX_NORM_RE.match(value.strip())
+    if m is None:
+        raise ValueError(
+            f"Invalid hex colour for explicit series_colours: {value!r}. "
+            "Expected a 6-character hex string (with or without leading '#')."
+        )
+    return m.group(1).upper()
+
+
+def _default_palette(primary_hex: str, n: int) -> list[str]:
+    """Lightness-stepped single-hue family from primary_hex.
+
+    Series 0 is the primary fill colour exactly (no round-trip conversion).
+    Subsequent series step toward a lighter shade by increasing HSL lightness.
+    """
+    r, g, b = _hex_to_rgb(primary_hex)
+    h, base_l, s = colorsys.rgb_to_hls(r, g, b)
+    # colorsys.rgb_to_hls returns (h, l, s) — note L is index 1.
+    result: list[str] = []
+    for i in range(n):
+        if i == 0:
+            # Return the primary fill exactly — no round-trip rounding.
+            result.append(primary_hex)
+            continue
+        # Step lightness toward 0.85 (near-white) across the series count.
+        if n == 1:
+            step_l = base_l
+        else:
+            max_l = min(0.85, base_l + 0.40)
+            step_l = base_l + (max_l - base_l) * (i / (n - 1))
+        # Clamp to [0.1, 0.92] to avoid near-black or near-white extremes.
+        step_l = max(0.10, min(0.92, step_l))
+        rr, gg, bb = colorsys.hls_to_rgb(h, step_l, s)
+        result.append(_rgb_to_hex(rr, gg, bb))
+    return result
+
+
+def _vital_and_mourning_palette(primary_hex: str) -> list[str]:
+    """Two-colour pair: primary fill (vital) + desaturated+darkened (mourning)."""
+    r, g, b = _hex_to_rgb(primary_hex)
+    h, l, s = colorsys.rgb_to_hls(r, g, b)
+    # colorsys.rgb_to_hls returns (h, l, s).
+    # Mourning: reduce saturation to ~20% of original, darken by 25%.
+    mourning_s = s * 0.20
+    mourning_l = max(0.10, l * 0.75)
+    mr, mg, mb = colorsys.hls_to_rgb(h, mourning_l, mourning_s)
+    return [primary_hex, _rgb_to_hex(mr, mg, mb)]
+
+
+def _data_categorical_palette(primary_hex: str, n: int) -> list[str]:
+    """n evenly-spaced hues around the colour wheel, sharing primary's S and L."""
+    r, g, b = _hex_to_rgb(primary_hex)
+    h, l, s = colorsys.rgb_to_hls(r, g, b)
+    # colorsys.rgb_to_hls returns (h, l, s).
+    result: list[str] = []
+    for i in range(n):
+        rotated_h = (h + i / n) % 1.0
+        rr, gg, bb = colorsys.hls_to_rgb(rotated_h, l, s)
+        result.append(_rgb_to_hex(rr, gg, bb))
+    return result
+
+
+def derive_chart_palette(
+    brand: BrandPalette,
+    role: str,
+    n_series: int,
+    explicit: list[str] | None = None,
+) -> list[str]:
+    """Return a list of ``n_series`` hex strings for chart series colouring.
+
+    Parameters
+    ----------
+    brand:
+        The brief's BrandPalette. ``primary_fill_hex`` is the anchor colour.
+    role:
+        One of ``"default"``, ``"vital_and_mourning"``, or
+        ``"data_categorical"``. Unrecognised values are treated as
+        ``"default"`` with a warning.
+    n_series:
+        Number of series colours required. Must be >= 1. Values > 6 trigger a
+        soft warning but produce a best-effort result.
+    explicit:
+        When supplied, overrides role-based derivation entirely. Each entry
+        must be a 6-char hex string (with or without leading ``#``). The list
+        is padded (last colour repeated) or truncated to match ``n_series``.
+
+    Returns
+    -------
+    list[str]
+        Exactly ``n_series`` uppercase 6-char hex strings without leading
+        ``#``.
+    """
+    if n_series < 1:
+        raise ValueError(f"n_series must be >= 1, got {n_series!r}")
+
+    # Explicit override — normalise and pad/truncate to n_series.
+    if explicit is not None:
+        normalised = [_normalise_hex(c) for c in explicit]
+        if len(normalised) < n_series:
+            # Pad by repeating the last colour.
+            normalised = normalised + [normalised[-1]] * (n_series - len(normalised))
+        return normalised[:n_series]
+
+    if n_series > _N_SERIES_WARN_THRESHOLD:
+        warnings.warn(
+            f"derive_chart_palette: n_series={n_series} exceeds recommended "
+            f"maximum ({_N_SERIES_WARN_THRESHOLD}). Producing best-effort palette; "
+            "consider supplying explicit series_colours for large series counts.",
+            stacklevel=2,
+        )
+
+    primary = brand.primary_fill_hex  # already normalised uppercase no-#
+
+    if role == "vital_and_mourning":
+        if n_series != 2:
+            warnings.warn(
+                f"derive_chart_palette: role='vital_and_mourning' is designed for "
+                f"exactly 2 series but n_series={n_series}. Falling back to 'default'.",
+                stacklevel=2,
+            )
+            return _default_palette(primary, n_series)
+        return _vital_and_mourning_palette(primary)
+    elif role == "data_categorical":
+        return _data_categorical_palette(primary, n_series)
+    else:
+        if role != "default":
+            warnings.warn(
+                f"derive_chart_palette: unrecognised role {role!r}; using 'default'.",
+                stacklevel=2,
+            )
+        return _default_palette(primary, n_series)

--- a/plugins/jack-tar-superpower-bridge/src/enrichment.py
+++ b/plugins/jack-tar-superpower-bridge/src/enrichment.py
@@ -30,6 +30,7 @@ from pptx.oxml.ns import qn
 
 from src.colors_xml_builder import BrandPalette, patch_carrier_palette
 from src.enrichment_ops.background import apply_background_in_memory
+from src.enrichment_ops.chart import apply_chart_enrichment
 from src.enrichment_ops.element_image import replace_image_marker_in_memory
 from src.enrichment_ops.smartart import inject_smartart_into_file
 from src.enrichment_ops.smartart_from_list import (
@@ -40,7 +41,7 @@ from src.security import resolve_within_allowlist
 from src.smartart_bridge import render_carrier, select_layout_for_slide
 
 
-VALID_KINDS = {"background", "image", "smartart", "smartart_from_list"}
+VALID_KINDS = {"background", "image", "smartart", "smartart_from_list", "chart"}
 VALID_ACTIONS = {"apply", "apply_clear_overlap", "skip"}
 
 
@@ -51,11 +52,12 @@ class EnrichmentApplyError(RuntimeError):
 @dataclass
 class EnrichmentItem:
     slide_index: int
-    kind: str                    # background | image | smartart | smartart_from_list
-    marker_name: str             # full marker string (e.g. "IMAGE:foo")
-    asset_path: Path | None      # image path for background/image; None for smartart
+    kind: str                    # background | image | smartart | smartart_from_list | chart
+    marker_name: str             # full marker string (e.g. "IMAGE:foo", "CHART:bar")
+    asset_path: Path | None      # image path for background/image; None for smartart/chart
     action: str = "apply"        # apply | apply_clear_overlap | skip
     smartart_spec: dict[str, Any] | None = None  # required when kind="smartart" and action!="skip"
+    chart_spec: dict[str, Any] | None = None  # required when kind="chart" and action!="skip"
     overlap_shape_names: list[str] = field(default_factory=list)
     # Run 8 Finding #26 — picture-SmartArt image binding. When kind ==
     # "smartart_from_list" AND this list is non-empty, the bridge routes the
@@ -319,6 +321,24 @@ def apply_enrichment(
                 # label survives enrichment as a stranded floater.
                 _drop_residual_marker_label_shapes(
                     prs, item.slide_index, item.marker_name,
+                )
+            elif item.kind == "chart":
+                # Issue #55 — CHART:slug marker kind.
+                # chart_spec is operator-supplied on EnrichmentItem at
+                # /enrich-deck time (pattern (a) from the plan). The marker
+                # rect + any sibling addText label are removed inside
+                # apply_chart_enrichment via the same cleanup logic as BG /
+                # SMARTART / SMARTART-FROM-LIST (v0.2 #23 pattern).
+                if item.chart_spec is None:
+                    raise EnrichmentApplyError(
+                        f"chart item missing chart_spec: {item}"
+                    )
+                apply_chart_enrichment(
+                    prs=prs,
+                    slide_index_1based=item.slide_index,
+                    marker_name=item.marker_name,
+                    chart_spec=item.chart_spec,
+                    brand_palette=brand_palette,
                 )
             else:
                 raise EnrichmentApplyError(f"unknown enrichment kind {item.kind!r}")

--- a/plugins/jack-tar-superpower-bridge/src/enrichment_ops/chart.py
+++ b/plugins/jack-tar-superpower-bridge/src/enrichment_ops/chart.py
@@ -1,0 +1,336 @@
+"""Op — replace a named CHART:* marker shape with a native python-pptx chart.
+
+Issue #55 — CHART:slug marker kind for the superpower bridge.
+
+Design decisions (locked at plan time):
+  1. python-pptx ``slide.shapes.add_chart()`` — all-Python, no Node round-trip.
+  2. ``chart_spec`` supplied by operator on EnrichmentItem at /enrich-deck time.
+  3. Seven v1 chart types: bar, column, line, area, pie, doughnut, scatter.
+  4. Series colours derived via ``derive_chart_palette()`` from BrandPalette.
+  5. Marker rect + sibling addText label removed via existing v0.2 #23 helpers.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from pptx.chart.data import CategoryChartData, XyChartData
+from pptx.enum.chart import XL_CHART_TYPE
+from pptx.oxml.ns import qn
+
+from src.chart_palette import derive_chart_palette
+from src.colors_xml_builder import BrandPalette
+
+log = logging.getLogger(__name__)
+
+# Map from chart_spec["type"] string to python-pptx XL_CHART_TYPE member.
+# v1 scope: bar, column, line, area, pie, doughnut, scatter.
+_CHART_TYPE_MAP: dict[str, Any] = {
+    "bar": XL_CHART_TYPE.BAR_CLUSTERED,
+    "column": XL_CHART_TYPE.COLUMN_CLUSTERED,
+    "line": XL_CHART_TYPE.LINE,
+    "area": XL_CHART_TYPE.AREA,
+    "pie": XL_CHART_TYPE.PIE,
+    "doughnut": XL_CHART_TYPE.DOUGHNUT,
+    "scatter": XL_CHART_TYPE.XY_SCATTER,
+}
+
+# Default palette role when chart_spec omits "palette_role".
+_DEFAULT_PALETTE_ROLE = "default"
+
+
+def _validate_chart_spec(spec: dict[str, Any], marker_name: str) -> None:
+    """Raise ValueError if required fields are missing or malformed.
+
+    Uses ValueError (not EnrichmentApplyError) to avoid a circular import:
+    enrichment_ops.chart is imported by enrichment, so importing
+    EnrichmentApplyError back from enrichment would create a cycle.
+    The transactional orchestrator in enrichment.py wraps all exceptions
+    as EnrichmentApplyError automatically.
+    """
+    missing = []
+    for field in ("type", "categories", "series"):
+        if field not in spec:
+            missing.append(field)
+    if missing:
+        raise ValueError(
+            f"chart_spec for {marker_name!r} is missing required "
+            f"field(s): {', '.join(missing)}. Required fields: "
+            f"type (str), categories (list), series (list of {{name, values}})."
+        )
+
+    chart_type = spec["type"]
+    if chart_type not in _CHART_TYPE_MAP:
+        valid = ", ".join(sorted(_CHART_TYPE_MAP))
+        raise ValueError(
+            f"chart_spec for {marker_name!r} has unsupported type {chart_type!r}. "
+            f"Valid v1 types: {valid}."
+        )
+
+    if not isinstance(spec["categories"], list) or len(spec["categories"]) == 0:
+        raise ValueError(
+            f"chart_spec for {marker_name!r}: 'categories' must be a non-empty list."
+        )
+
+    series = spec["series"]
+    if not isinstance(series, list) or len(series) == 0:
+        raise ValueError(
+            f"chart_spec for {marker_name!r}: 'series' must be a non-empty list."
+        )
+    for i, s in enumerate(series):
+        if not isinstance(s, dict) or "name" not in s or "values" not in s:
+            raise ValueError(
+                f"chart_spec for {marker_name!r}: series[{i}] must be a dict "
+                f"with 'name' (str) and 'values' (list) keys."
+            )
+        if not isinstance(s["values"], list) or len(s["values"]) == 0:
+            raise ValueError(
+                f"chart_spec for {marker_name!r}: series[{i}]['values'] "
+                f"must be a non-empty list."
+            )
+
+
+def _find_marker_shape(prs, slide_index_1based: int, marker_name: str):
+    """Return the shape whose name matches marker_name on the given slide.
+
+    Returns None if the marker is not found — caller raises EnrichmentApplyError.
+    """
+    slide = prs.slides[slide_index_1based - 1]
+    for shape in slide.shapes:
+        if shape.name == marker_name:
+            return shape, slide
+    return None, slide
+
+
+def _apply_series_colours(chart, hex_colours: list[str]) -> None:
+    """Apply series fill colours to a python-pptx Chart object.
+
+    Sets a solid fill (RGB) on each series's ``format.fill``. Series that
+    don't have a corresponding colour in the list are left at their default.
+    Colours are 6-char uppercase hex strings without leading ``#``.
+    """
+    from pptx.dml.color import RGBColor
+
+    for i, series in enumerate(chart.series):
+        if i >= len(hex_colours):
+            break
+        hex_str = hex_colours[i]
+        r = int(hex_str[0:2], 16)
+        g = int(hex_str[2:4], 16)
+        b = int(hex_str[4:6], 16)
+        series.format.fill.solid()
+        series.format.fill.fore_color.rgb = RGBColor(r, g, b)
+
+
+def _apply_chart_formatting(chart, spec: dict[str, Any]) -> None:
+    """Apply optional formatting fields from chart_spec to the chart object."""
+    # Chart title
+    title_text = spec.get("title")
+    if title_text:
+        chart.has_title = True
+        chart.chart_title.text_frame.text = str(title_text)
+    else:
+        chart.has_title = False
+
+    # Legend
+    show_legend = spec.get("show_legend")
+    if show_legend is None:
+        # Default: show for multi-series, hide for single-series
+        show_legend = len(spec.get("series", [])) > 1
+    chart.has_legend = bool(show_legend)
+
+    # Value format on data labels — apply if specified
+    value_format = spec.get("value_format")
+    if value_format:
+        try:
+            chart.plots[0].has_data_labels = True
+            chart.plots[0].data_labels.number_format = str(value_format)
+            chart.plots[0].data_labels.number_format_is_linked = False
+        except Exception as exc:
+            log.warning(
+                "Could not apply value_format %r to chart: %s", value_format, exc
+            )
+
+    # Axis titles (category / value axes — not available on pie/doughnut)
+    x_title = spec.get("x_axis_title")
+    y_title = spec.get("y_axis_title")
+    chart_type = spec.get("type", "")
+    if chart_type not in ("pie", "doughnut"):
+        if x_title:
+            try:
+                chart.category_axis.has_title = True
+                chart.category_axis.axis_title.text_frame.text = str(x_title)
+            except Exception as exc:
+                log.warning("Could not set x_axis_title: %s", exc)
+        if y_title:
+            try:
+                chart.value_axis.has_title = True
+                chart.value_axis.axis_title.text_frame.text = str(y_title)
+            except Exception as exc:
+                log.warning("Could not set y_axis_title: %s", exc)
+
+
+def apply_chart_enrichment(
+    prs,
+    slide_index_1based: int,
+    marker_name: str,
+    chart_spec: dict[str, Any],
+    brand_palette: BrandPalette | None = None,
+) -> None:
+    """Replace the named CHART marker shape with a native python-pptx chart.
+
+    Steps:
+      1. Validate chart_spec — raise EnrichmentApplyError on missing required fields.
+      2. Find the marker shape and capture its coordinates.
+      3. Drop the marker shape element and any sibling addText label.
+      4. Build CategoryChartData (or XyChartData for scatter).
+      5. Derive series colours from brand_palette (or default).
+      6. Insert chart via slide.shapes.add_chart().
+      7. Apply series colours and optional formatting.
+
+    Parameters
+    ----------
+    prs:
+        python-pptx Presentation object (in-memory, caller owns save).
+    slide_index_1based:
+        1-based slide index.
+    marker_name:
+        Full marker string, e.g. ``"CHART:revenue-vs-costs"``.
+    chart_spec:
+        Dict with required fields: type, categories, series. Optional:
+        title, x_axis_title, y_axis_title, show_legend, value_format,
+        palette_role, series_colours.
+    brand_palette:
+        BrandPalette for series colour derivation. When None, falls back to
+        a neutral grey-blue palette derived from a default primary colour.
+    """
+    _validate_chart_spec(chart_spec, marker_name)
+
+    shape, slide = _find_marker_shape(prs, slide_index_1based, marker_name)
+    if shape is None:
+        raise LookupError(
+            f"CHART marker shape {marker_name!r} not found on slide "
+            f"{slide_index_1based}."
+        )
+
+    # Capture marker geometry before removing the shape.
+    left = shape.left
+    top = shape.top
+    width = shape.width
+    height = shape.height
+
+    # Remove the marker placeholder rect.
+    sp_elem = shape._element
+    sp_elem.getparent().remove(sp_elem)
+
+    # Remove any sibling addText label whose visible text equals marker_name
+    # (the v0.2 #23 cleanup pattern, generalised from BG/SMARTART to CHART).
+    _drop_residual_marker_label_shapes_local(prs, slide_index_1based, marker_name)
+
+    # Build chart data.
+    chart_type_key = chart_spec["type"]
+    chart_type = _CHART_TYPE_MAP[chart_type_key]
+    categories = chart_spec["categories"]
+    series = chart_spec["series"]
+    n_series = len(series)
+
+    if chart_type_key == "scatter":
+        chart_data = XyChartData()
+        for s in series:
+            series_data = chart_data.add_series(str(s["name"]))
+            vals = s["values"]
+            # Scatter expects (x, y) pairs. If values is a flat list of
+            # scalars, pair them with categories (converted to float if possible).
+            if vals and not isinstance(vals[0], (list, tuple)):
+                for cat, val in zip(categories, vals):
+                    try:
+                        x_val = float(cat)
+                    except (TypeError, ValueError):
+                        x_val = float(categories.index(cat))
+                    series_data.add_data_point(x_val, float(val) if val is not None else 0.0)
+            else:
+                for pair in vals:
+                    series_data.add_data_point(float(pair[0]), float(pair[1]))
+    else:
+        chart_data = CategoryChartData()
+        chart_data.categories = [str(c) for c in categories]
+        for s in series:
+            chart_data.add_series(
+                str(s["name"]),
+                [v if v is not None else 0 for v in s["values"]],
+            )
+
+    # Derive series colours.
+    palette_role = chart_spec.get("palette_role", _DEFAULT_PALETTE_ROLE)
+    explicit_colours = chart_spec.get("series_colours")
+
+    if brand_palette is not None:
+        hex_colours = derive_chart_palette(
+            brand=brand_palette,
+            role=palette_role,
+            n_series=n_series,
+            explicit=explicit_colours,
+        )
+    elif explicit_colours:
+        from src.chart_palette import _normalise_hex
+        normalised = [_normalise_hex(c) for c in explicit_colours]
+        if len(normalised) < n_series:
+            normalised = normalised + [normalised[-1]] * (n_series - len(normalised))
+        hex_colours = normalised[:n_series]
+    else:
+        # Fallback: neutral slate-blue family when no palette is available.
+        hex_colours = ["4472C4", "5B9BD5", "70AD47", "ED7D31", "FFC000", "FF0000"][:n_series]
+        if n_series > len(hex_colours):
+            hex_colours = (hex_colours * (n_series // len(hex_colours) + 1))[:n_series]
+
+    # Insert native chart at marker coordinates.
+    graphic_frame = slide.shapes.add_chart(chart_type, left, top, width, height, chart_data)
+    chart = graphic_frame.chart
+
+    # Apply series colours.
+    _apply_series_colours(chart, hex_colours)
+
+    # Apply optional formatting (title, legend, axis titles, value format).
+    _apply_chart_formatting(chart, chart_spec)
+
+    log.info(
+        "apply_chart_enrichment: inserted %s chart at slide %d (%s)",
+        chart_type_key, slide_index_1based, marker_name,
+    )
+
+
+def _drop_residual_marker_label_shapes_local(
+    prs, slide_index_1based: int, marker_name: str,
+) -> None:
+    """Drop addText label shapes whose visible text equals marker_name.
+
+    This is the same logic as the top-level
+    ``_drop_residual_marker_label_shapes`` in enrichment.py, duplicated here
+    to avoid a circular import (enrichment_ops.chart → enrichment would
+    cycle). The two implementations must stay in sync.
+
+    The marker shape itself has already been removed by the time this is
+    called, so the cNvPr-name-mismatch guard is a belt-and-braces check
+    for any edge-case where name re-use occurs.
+    """
+    a_t_qn = "{http://schemas.openxmlformats.org/drawingml/2006/main}t"
+    slide = prs.slides[slide_index_1based - 1]
+    cSld = slide.element.find(qn("p:cSld"))
+    spTree = cSld.find(qn("p:spTree"))
+    if spTree is None:
+        return
+    for sp in list(spTree):
+        nvSpPr = sp.find(qn("p:nvSpPr"))
+        if nvSpPr is None:
+            continue
+        cNvPr = nvSpPr.find(qn("p:cNvPr"))
+        shape_name = cNvPr.get("name") if cNvPr is not None else None
+        if shape_name == marker_name:
+            continue
+        parts: list[str] = []
+        for t_elem in sp.iter(a_t_qn):
+            if t_elem.text:
+                parts.append(t_elem.text)
+        visible_text = "".join(parts).strip()
+        if visible_text == marker_name:
+            spTree.remove(sp)

--- a/plugins/jack-tar-superpower-bridge/src/placeholder.py
+++ b/plugins/jack-tar-superpower-bridge/src/placeholder.py
@@ -1,8 +1,9 @@
 """Marker grammar, parsing, and uniqueness checks.
 
-Grammar: ^(IMAGE|SMARTART-FROM-LIST|SMARTART|BG):[a-z0-9_-]+$  (lowercase
-identifier after the colon). Kind names are uppercase / hyphenated; the
-identifier accepts lowercase letters, digits, hyphens, and underscores.
+Grammar: ^(IMAGE|SMARTART-FROM-LIST|SMARTART|CHART|BG):[a-z0-9_-]+$
+(lowercase identifier after the colon). Kind names are uppercase /
+hyphenated; the identifier accepts lowercase letters, digits, hyphens, and
+underscores.
 
 Marker kinds:
 
@@ -19,6 +20,14 @@ Marker kinds:
   list shape with the SmartArt graphic at the same position. Title and
   supporting prose on the slide are untouched. Graceful degradation: if
   enrichment is skipped, the bullet list remains on the slide.
+- ``CHART``  *(issue #55)* — a placeholder rectangle is replaced by a native
+  python-pptx chart at the same coordinates. Chart type, categories, series
+  data, and optional formatting come from a ``chart_spec`` dict supplied on
+  the ``EnrichmentItem`` at /enrich-deck time. Brand palette is derived via
+  ``derive_chart_palette()`` from the brief's ``BrandPalette``. Canonical
+  for chart-shaped subjects (X-vs-Y, time series, projection, comparison
+  bars); the Section C ``addChart()`` language workaround remains valid as a
+  fallback when chart data is not yet available at brief-authoring time.
 
 Per spec Section 3.1 — duplicate marker identifiers are a brief-authoring
 error and must be surfaced to the user before enrichment proceeds.
@@ -32,7 +41,7 @@ from src.slide_facts import Marker, SlideFacts
 
 # SMARTART-FROM-LIST appears before SMARTART so the regex engine matches the
 # more-specific (longer) kind first when both could prefix-match.
-MARKER_RE = re.compile(r"^(IMAGE|SMARTART-FROM-LIST|SMARTART|BG):([a-z0-9_-]+)$")
+MARKER_RE = re.compile(r"^(IMAGE|SMARTART-FROM-LIST|SMARTART|CHART|BG):([a-z0-9_-]+)$")
 
 
 def parse_marker(name: str) -> tuple[str, str] | None:

--- a/plugins/jack-tar-superpower-bridge/src/slide_facts.py
+++ b/plugins/jack-tar-superpower-bridge/src/slide_facts.py
@@ -12,9 +12,10 @@ from typing import Any
 # Marker kinds use the OOXML/brief-grammar form (uppercase, hyphenated).
 # SMARTART-FROM-LIST is Contract 2 / Finding #9 — the marker IS a text shape
 # with bullet content rather than a placeholder rectangle.
-VALID_MARKER_KINDS = {"IMAGE", "SMARTART", "SMARTART-FROM-LIST", "BG"}
+# CHART is issue #55 — placeholder rect replaced by a native python-pptx chart.
+VALID_MARKER_KINDS = {"IMAGE", "SMARTART", "SMARTART-FROM-LIST", "BG", "CHART"}
 # Enrichment kinds use the snake_case form internally.
-VALID_ENRICHMENT_KINDS = {"background", "image", "smartart", "smartart_from_list"}
+VALID_ENRICHMENT_KINDS = {"background", "image", "smartart", "smartart_from_list", "chart"}
 VALID_ENRICHMENT_ACTIONS = {"apply", "apply_clear_overlap", "skip"}
 
 

--- a/plugins/jack-tar-superpower-bridge/tests/test_chart_marker.py
+++ b/plugins/jack-tar-superpower-bridge/tests/test_chart_marker.py
@@ -1,0 +1,589 @@
+"""Tests for the CHART:slug marker kind (issue #55).
+
+Coverage:
+  - Phase 1: marker grammar — parse_marker accepts CHART:slug, rejects uppercase
+  - Phase 2: EnrichmentItem.kind="chart" dispatch + apply path
+  - Phase 3: chart_palette derivation
+  - Phase 5: analyser picks up CHART markers via MARKER_RE + end-to-end fixture test
+"""
+from __future__ import annotations
+
+import io
+import warnings
+from pathlib import Path
+
+import pytest
+from pptx import Presentation
+from pptx.util import Inches, Pt
+
+# ---------------------------------------------------------------------------
+# Phase 1 — Marker grammar
+# ---------------------------------------------------------------------------
+
+
+def test_parse_marker_chart_slug_returns_kind_and_identifier():
+    from src.placeholder import parse_marker
+    result = parse_marker("CHART:revenue-vs-costs")
+    assert result == ("CHART", "revenue-vs-costs")
+
+
+def test_parse_marker_chart_slug_with_underscore():
+    from src.placeholder import parse_marker
+    result = parse_marker("CHART:capacity_over_time")
+    assert result == ("CHART", "capacity_over_time")
+
+
+def test_parse_marker_chart_rejects_uppercase_identifier():
+    from src.placeholder import parse_marker
+    assert parse_marker("CHART:RevenueVsCosts") is None
+
+
+def test_parse_marker_chart_rejects_empty_identifier():
+    from src.placeholder import parse_marker
+    assert parse_marker("CHART:") is None
+
+
+def test_chart_marker_is_distinct_from_image_marker():
+    from src.placeholder import parse_marker
+    chart_kind, _ = parse_marker("CHART:foo")
+    image_kind, _ = parse_marker("IMAGE:foo")
+    assert chart_kind != image_kind
+    assert chart_kind == "CHART"
+
+
+def test_marker_re_accepts_chart_prefix():
+    from src.placeholder import MARKER_RE
+    m = MARKER_RE.match("CHART:mttr-by-class")
+    assert m is not None
+    assert m.group(1) == "CHART"
+    assert m.group(2) == "mttr-by-class"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Chart palette derivation
+# ---------------------------------------------------------------------------
+
+
+def _palette(primary="14213D", on_primary="F5F0E8", on_surface="2C2C2C"):
+    from src.colors_xml_builder import BrandPalette
+    return BrandPalette(primary, on_primary, on_surface)
+
+
+def test_derive_chart_palette_default_returns_n_colours():
+    from src.chart_palette import derive_chart_palette
+    pal = _palette()
+    result = derive_chart_palette(pal, "default", 4)
+    assert len(result) == 4
+    assert all(isinstance(c, str) and len(c) == 6 for c in result)
+
+
+def test_derive_chart_palette_default_first_colour_is_primary():
+    from src.chart_palette import derive_chart_palette
+    pal = _palette(primary="14213D")
+    result = derive_chart_palette(pal, "default", 3)
+    # First colour must equal the primary fill (uppercase, no #).
+    assert result[0] == "14213D"
+
+
+def test_derive_chart_palette_explicit_wins_over_role():
+    from src.chart_palette import derive_chart_palette
+    pal = _palette()
+    explicit = ["#FF0000", "#00FF00", "#0000FF"]
+    result = derive_chart_palette(pal, "data_categorical", 3, explicit=explicit)
+    assert result == ["FF0000", "00FF00", "0000FF"]
+
+
+def test_derive_chart_palette_explicit_padded_to_n_series():
+    from src.chart_palette import derive_chart_palette
+    pal = _palette()
+    result = derive_chart_palette(pal, "default", 4, explicit=["AABBCC"])
+    assert len(result) == 4
+    assert result == ["AABBCC", "AABBCC", "AABBCC", "AABBCC"]
+
+
+def test_derive_chart_palette_explicit_truncated_to_n_series():
+    from src.chart_palette import derive_chart_palette
+    pal = _palette()
+    result = derive_chart_palette(pal, "default", 2, explicit=["FF0000", "00FF00", "0000FF"])
+    assert result == ["FF0000", "00FF00"]
+
+
+def test_derive_chart_palette_vital_and_mourning_two_colours():
+    from src.chart_palette import derive_chart_palette
+    pal = _palette(primary="8B0000")
+    result = derive_chart_palette(pal, "vital_and_mourning", 2)
+    assert len(result) == 2
+    assert result[0] == "8B0000"  # vital — primary unchanged
+    # mourning must be a different (desaturated/darkened) colour
+    assert result[1] != result[0]
+
+
+def test_derive_chart_palette_vital_and_mourning_wrong_n_warns_and_falls_back():
+    from src.chart_palette import derive_chart_palette
+    pal = _palette()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = derive_chart_palette(pal, "vital_and_mourning", 3)
+    assert len(result) == 3
+    assert any("vital_and_mourning" in str(warning.message) for warning in w)
+
+
+def test_derive_chart_palette_data_categorical_distinct_hues():
+    from src.chart_palette import derive_chart_palette
+    pal = _palette(primary="4472C4")
+    result = derive_chart_palette(pal, "data_categorical", 4)
+    assert len(result) == 4
+    # All should be distinct (hue rotation guarantees this for n >= 2)
+    assert len(set(result)) == 4
+
+
+def test_derive_chart_palette_unknown_role_warns_and_uses_default():
+    from src.chart_palette import derive_chart_palette
+    pal = _palette()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = derive_chart_palette(pal, "nonexistent_role", 3)
+    assert len(result) == 3
+    assert any("nonexistent_role" in str(warning.message) for warning in w)
+
+
+def test_derive_chart_palette_large_n_warns_soft_fail():
+    from src.chart_palette import derive_chart_palette
+    pal = _palette()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = derive_chart_palette(pal, "default", 9)
+    assert len(result) == 9
+    assert any("n_series=9" in str(warning.message) for warning in w)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a minimal .pptx with a CHART marker rect
+# ---------------------------------------------------------------------------
+
+
+def _make_pptx_with_chart_marker(output_path: Path, marker_name: str,
+                                  x_in=1.0, y_in=1.5, w_in=9.0, h_in=5.0,
+                                  with_label: bool = True) -> None:
+    """Create a minimal .pptx with one CHART placeholder rect (and optional label)."""
+    from pptx.util import Inches
+    prs = Presentation()
+    slide_layout = prs.slide_layouts[6]  # blank layout
+    slide = prs.slides.add_slide(slide_layout)
+
+    # The marker placeholder rect
+    shapes = slide.shapes
+    marker_rect = shapes.add_shape(
+        1,  # MSO_SHAPE_TYPE.RECTANGLE = 1 in python-pptx; use the int directly
+        Inches(x_in), Inches(y_in), Inches(w_in), Inches(h_in),
+    )
+    marker_rect.name = marker_name
+
+    if with_label:
+        # Sibling addText label (simulates build.js authoring pattern)
+        label = shapes.add_textbox(
+            Inches(x_in), Inches(y_in + h_in / 2 - 0.15),
+            Inches(w_in), Inches(0.3),
+        )
+        label.name = f"label-for-{marker_name}"
+        label.text_frame.text = marker_name
+
+    prs.save(str(output_path))
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — EnrichmentItem chart dispatch + apply path
+# ---------------------------------------------------------------------------
+
+
+def _minimal_chart_spec(chart_type: str = "column") -> dict:
+    return {
+        "type": chart_type,
+        "categories": ["Q1", "Q2", "Q3", "Q4"],
+        "series": [
+            {"name": "Revenue", "values": [12.5, 14.2, 15.8, 17.1]},
+        ],
+    }
+
+
+def test_enrichment_item_chart_kind_constructs():
+    from src.enrichment import EnrichmentItem
+    item = EnrichmentItem(
+        slide_index=1,
+        kind="chart",
+        marker_name="CHART:revenue-vs-costs",
+        asset_path=None,
+        chart_spec=_minimal_chart_spec(),
+    )
+    assert item.kind == "chart"
+    assert item.chart_spec is not None
+    assert item.chart_spec["type"] == "column"
+
+
+def test_apply_chart_enrichment_missing_type_raises(tmp_path):
+    """chart_ops raises ValueError (wrapped by orchestrator as EnrichmentApplyError)."""
+    from src.enrichment_ops.chart import apply_chart_enrichment
+    pptx_path = tmp_path / "deck.pptx"
+    _make_pptx_with_chart_marker(pptx_path, "CHART:test")
+    prs = Presentation(str(pptx_path))
+    with pytest.raises(ValueError, match="missing required field"):
+        apply_chart_enrichment(
+            prs=prs,
+            slide_index_1based=1,
+            marker_name="CHART:test",
+            chart_spec={"categories": ["A"], "series": [{"name": "S", "values": [1]}]},
+        )
+
+
+def test_apply_chart_enrichment_missing_categories_raises(tmp_path):
+    from src.enrichment_ops.chart import apply_chart_enrichment
+    pptx_path = tmp_path / "deck.pptx"
+    _make_pptx_with_chart_marker(pptx_path, "CHART:test")
+    prs = Presentation(str(pptx_path))
+    with pytest.raises(ValueError, match="missing required field"):
+        apply_chart_enrichment(
+            prs=prs,
+            slide_index_1based=1,
+            marker_name="CHART:test",
+            chart_spec={"type": "bar", "series": [{"name": "S", "values": [1]}]},
+        )
+
+
+def test_apply_chart_enrichment_missing_series_raises(tmp_path):
+    from src.enrichment_ops.chart import apply_chart_enrichment
+    pptx_path = tmp_path / "deck.pptx"
+    _make_pptx_with_chart_marker(pptx_path, "CHART:test")
+    prs = Presentation(str(pptx_path))
+    with pytest.raises(ValueError, match="missing required field"):
+        apply_chart_enrichment(
+            prs=prs,
+            slide_index_1based=1,
+            marker_name="CHART:test",
+            chart_spec={"type": "column", "categories": ["A"]},
+        )
+
+
+def test_apply_chart_enrichment_invalid_type_raises(tmp_path):
+    from src.enrichment_ops.chart import apply_chart_enrichment
+    pptx_path = tmp_path / "deck.pptx"
+    _make_pptx_with_chart_marker(pptx_path, "CHART:test")
+    prs = Presentation(str(pptx_path))
+    with pytest.raises(ValueError, match="unsupported type"):
+        apply_chart_enrichment(
+            prs=prs,
+            slide_index_1based=1,
+            marker_name="CHART:test",
+            chart_spec={
+                "type": "heatmap",
+                "categories": ["A"],
+                "series": [{"name": "S", "values": [1]}],
+            },
+        )
+
+
+def test_apply_chart_enrichment_missing_marker_raises(tmp_path):
+    """Raises LookupError (wrapped by orchestrator as EnrichmentApplyError)."""
+    from src.enrichment_ops.chart import apply_chart_enrichment
+    pptx_path = tmp_path / "deck.pptx"
+    _make_pptx_with_chart_marker(pptx_path, "CHART:other-slug")
+    prs = Presentation(str(pptx_path))
+    with pytest.raises(LookupError, match="not found"):
+        apply_chart_enrichment(
+            prs=prs,
+            slide_index_1based=1,
+            marker_name="CHART:does-not-exist",
+            chart_spec=_minimal_chart_spec(),
+        )
+
+
+def _get_slide_shape_names(prs, slide_index_0based: int) -> list[str]:
+    slide = prs.slides[slide_index_0based]
+    return [s.name for s in slide.shapes]
+
+
+def _count_graphic_frames(prs, slide_index_0based: int) -> int:
+    """Count graphic frame shapes (charts are graphic frames) on a slide."""
+    from pptx.enum.shapes import MSO_SHAPE_TYPE
+    slide = prs.slides[slide_index_0based]
+    return sum(1 for s in slide.shapes if s.shape_type == 3)  # FREEFORM=5, CHART=3 in MSO_SHAPE_TYPE? No — use has_chart
+
+
+def _has_chart(prs, slide_index_0based: int) -> bool:
+    """Return True if any shape on the slide is a chart."""
+    slide = prs.slides[slide_index_0based]
+    for s in slide.shapes:
+        try:
+            _ = s.chart
+            return True
+        except Exception:
+            pass
+    return False
+
+
+def test_apply_chart_enrichment_inserts_chart_and_removes_marker(tmp_path):
+    from src.enrichment_ops.chart import apply_chart_enrichment
+    pptx_path = tmp_path / "deck.pptx"
+    marker_name = "CHART:revenue-vs-costs"
+    _make_pptx_with_chart_marker(pptx_path, marker_name, with_label=True)
+
+    prs = Presentation(str(pptx_path))
+
+    # Before: marker rect present
+    assert marker_name in _get_slide_shape_names(prs, 0)
+
+    apply_chart_enrichment(
+        prs=prs,
+        slide_index_1based=1,
+        marker_name=marker_name,
+        chart_spec=_minimal_chart_spec("column"),
+    )
+
+    # After: marker rect removed
+    names_after = _get_slide_shape_names(prs, 0)
+    assert marker_name not in names_after
+
+    # Chart inserted
+    assert _has_chart(prs, 0)
+
+
+def test_apply_chart_enrichment_removes_sibling_label(tmp_path):
+    from src.enrichment_ops.chart import apply_chart_enrichment
+    pptx_path = tmp_path / "deck.pptx"
+    marker_name = "CHART:capacity-over-time"
+    _make_pptx_with_chart_marker(pptx_path, marker_name, with_label=True)
+
+    prs = Presentation(str(pptx_path))
+    # Verify label is there before
+    slide = prs.slides[0]
+    label_texts = []
+    for s in slide.shapes:
+        try:
+            t = s.text_frame.text.strip()
+            if t == marker_name:
+                label_texts.append(t)
+        except Exception:
+            pass
+    assert label_texts, "Expected a sibling label before enrichment"
+
+    apply_chart_enrichment(
+        prs=prs,
+        slide_index_1based=1,
+        marker_name=marker_name,
+        chart_spec=_minimal_chart_spec("bar"),
+    )
+
+    # Label should be gone
+    slide = prs.slides[0]
+    for s in slide.shapes:
+        try:
+            t = s.text_frame.text.strip()
+            assert t != marker_name, "Sibling label should have been removed"
+        except Exception:
+            pass
+
+
+def test_apply_chart_enrichment_all_v1_chart_types_render(tmp_path):
+    """Verify all 7 v1 chart types can be applied without error."""
+    from src.enrichment_ops.chart import apply_chart_enrichment
+    chart_types = ["bar", "column", "line", "area", "pie", "doughnut", "scatter"]
+
+    for chart_type in chart_types:
+        pptx_path = tmp_path / f"deck-{chart_type}.pptx"
+        marker_name = f"CHART:{chart_type}-test"
+        _make_pptx_with_chart_marker(pptx_path, marker_name, with_label=False)
+        prs = Presentation(str(pptx_path))
+
+        spec = {
+            "type": chart_type,
+            "categories": ["A", "B", "C"],
+            "series": [{"name": "S1", "values": [1.0, 2.0, 3.0]}],
+        }
+        if chart_type == "scatter":
+            spec["categories"] = [1.0, 2.0, 3.0]
+
+        apply_chart_enrichment(
+            prs=prs,
+            slide_index_1based=1,
+            marker_name=marker_name,
+            chart_spec=spec,
+        )
+        assert _has_chart(prs, 0), f"Chart type {chart_type!r} did not insert a chart"
+
+
+def test_apply_chart_enrichment_with_brand_palette_uses_palette_colour(tmp_path):
+    """When brand_palette is supplied, series colour derives from it."""
+    from src.enrichment_ops.chart import apply_chart_enrichment
+    from src.colors_xml_builder import BrandPalette
+    pptx_path = tmp_path / "deck.pptx"
+    marker_name = "CHART:revenue"
+    _make_pptx_with_chart_marker(pptx_path, marker_name, with_label=False)
+    prs = Presentation(str(pptx_path))
+
+    palette = BrandPalette("8B0000", "F5F0E8", "2C2C2C")
+    apply_chart_enrichment(
+        prs=prs,
+        slide_index_1based=1,
+        marker_name=marker_name,
+        chart_spec=_minimal_chart_spec("column"),
+        brand_palette=palette,
+    )
+    assert _has_chart(prs, 0)
+
+
+def test_apply_chart_enrichment_explicit_series_colours_used(tmp_path):
+    """Explicit series_colours override palette derivation."""
+    from src.enrichment_ops.chart import apply_chart_enrichment
+    from src.colors_xml_builder import BrandPalette
+    from pptx.dml.color import RGBColor
+
+    pptx_path = tmp_path / "deck.pptx"
+    marker_name = "CHART:data"
+    _make_pptx_with_chart_marker(pptx_path, marker_name, with_label=False)
+    prs = Presentation(str(pptx_path))
+
+    palette = BrandPalette("14213D", "F5F0E8", "2C2C2C")
+    spec = {
+        "type": "bar",
+        "categories": ["X", "Y"],
+        "series": [
+            {"name": "A", "values": [10, 20]},
+            {"name": "B", "values": [30, 40]},
+        ],
+        "series_colours": ["FF0000", "00FF00"],
+    }
+    apply_chart_enrichment(
+        prs=prs,
+        slide_index_1based=1,
+        marker_name=marker_name,
+        chart_spec=spec,
+        brand_palette=palette,
+    )
+
+    # Verify the chart is present
+    assert _has_chart(prs, 0)
+    slide = prs.slides[0]
+    chart_shape = next(s for s in slide.shapes if _shape_has_chart(s))
+    chart = chart_shape.chart
+    # Series 0 should be red (FF0000)
+    series_0_fill = chart.series[0].format.fill
+    assert series_0_fill.fore_color.rgb == RGBColor(0xFF, 0x00, 0x00)
+
+
+def _shape_has_chart(shape) -> bool:
+    try:
+        _ = shape.chart
+        return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — OOXML analyser picks up CHART markers
+# ---------------------------------------------------------------------------
+
+
+def test_analyser_detects_chart_marker_via_marker_re():
+    """The OOXML primary analyser uses MARKER_RE, which now includes CHART."""
+    from src.placeholder import MARKER_RE
+    # CHART markers follow the same objectName pattern as IMAGE/BG/SMARTART.
+    test_cases = [
+        ("CHART:revenue-vs-costs", True),
+        ("CHART:capacity_over_time", True),
+        ("CHART:mttr-by-class", True),
+        ("CHART:UPPERCASE", False),
+        ("CHART:", False),
+    ]
+    for name, should_match in test_cases:
+        matched = MARKER_RE.match(name) is not None
+        assert matched == should_match, (
+            f"MARKER_RE.match({name!r}) expected {should_match}, got {matched}"
+        )
+
+
+def test_pptx_parser_detects_chart_marker_in_fixture(tmp_path):
+    """The OOXML primary analyser extracts CHART markers from a real .pptx fixture."""
+    from src.analyser.pptx_parser import parse_pptx
+
+    pptx_path = tmp_path / "chart_deck.pptx"
+    marker_name = "CHART:extinction-rate"
+    _make_pptx_with_chart_marker(pptx_path, marker_name, with_label=False)
+
+    result = parse_pptx(pptx_path)
+    assert len(result) >= 1
+    chart_markers = [
+        m for slide in result for m in slide.markers if m.kind == "CHART"
+    ]
+    assert len(chart_markers) == 1
+    assert chart_markers[0].identifier == "extinction-rate"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end — fixture .pptx with CHART marker → apply_enrichment → chart present
+# ---------------------------------------------------------------------------
+
+
+def test_end_to_end_apply_enrichment_chart_kind(tmp_path):
+    """apply_enrichment with kind='chart' inserts a native chart and removes the marker."""
+    from src.enrichment import EnrichmentPlan, EnrichmentItem, apply_enrichment
+
+    source = tmp_path / "source.pptx"
+    output = tmp_path / "output.pptx"
+    marker_name = "CHART:revenue-vs-costs"
+    _make_pptx_with_chart_marker(source, marker_name, with_label=True)
+
+    items = [
+        EnrichmentItem(
+            slide_index=1,
+            kind="chart",
+            marker_name=marker_name,
+            asset_path=None,
+            action="apply",
+            chart_spec={
+                "type": "column",
+                "categories": ["Q1", "Q2", "Q3", "Q4"],
+                "series": [
+                    {"name": "Revenue", "values": [12.5, 14.2, 15.8, 17.1]},
+                    {"name": "Costs", "values": [8.1, 8.4, 8.9, 9.2]},
+                ],
+                "title": "Quarterly revenue vs costs",
+                "show_legend": True,
+            },
+        ),
+    ]
+    plan = EnrichmentPlan(source_pptx=source, output_pptx=output, items=items)
+    apply_enrichment(plan, allowed_image_roots=[tmp_path])
+
+    assert output.exists()
+    prs_out = Presentation(str(output))
+    # Marker removed
+    names = _get_slide_shape_names(prs_out, 0)
+    assert marker_name not in names
+    # Chart present
+    assert _has_chart(prs_out, 0)
+
+
+def test_end_to_end_chart_missing_spec_raises(tmp_path):
+    """apply_enrichment raises EnrichmentApplyError when chart_spec is None."""
+    from src.enrichment import EnrichmentPlan, EnrichmentItem, apply_enrichment, EnrichmentApplyError
+
+    source = tmp_path / "source.pptx"
+    output = tmp_path / "output.pptx"
+    marker_name = "CHART:test"
+    _make_pptx_with_chart_marker(source, marker_name, with_label=False)
+
+    items = [
+        EnrichmentItem(
+            slide_index=1,
+            kind="chart",
+            marker_name=marker_name,
+            asset_path=None,
+            action="apply",
+            chart_spec=None,
+        ),
+    ]
+    plan = EnrichmentPlan(source_pptx=source, output_pptx=output, items=items)
+    with pytest.raises(EnrichmentApplyError, match="missing chart_spec"):
+        apply_enrichment(plan, allowed_image_roots=[tmp_path])
+
+    # No partial output on failure
+    assert not output.exists()


### PR DESCRIPTION
## Summary

Implements `CHART:slug` as a first-class marker kind for the superpower bridge (issue #55, Finding #15 from Runs 4–10). Replaces the fragile Section C `addChart()` language workaround with a structural grammar enforcement.

- **Marker grammar**: `CHART:slug` now parses alongside `IMAGE:` / `BG:` / `SMARTART:` / `SMARTART-FROM-LIST:`
- **Native chart insertion**: `apply_chart_enrichment()` uses python-pptx's `slide.shapes.add_chart()` — no Node round-trip, no rasterisation. Editable in PowerPoint after delivery.
- **7 v1 chart types**: bar, column, line, area, pie, doughnut, scatter
- **Brand palette integration**: `derive_chart_palette()` in `chart_palette.py` — three roles (`default`, `vital_and_mourning`, `data_categorical`) plus explicit `series_colours` override
- **Full marker cleanup**: marker rect + sibling addText label removed via the v0.2 #23 pattern (same as BG / SMARTART / SMARTART-FROM-LIST)
- **Persona doc updated**: `CHART:slug` is now canonical for chart-shaped subjects; `addChart()` language workaround noted as valid fallback

## Design decisions (all locked at plan time)

1. **`palette_role` enum + `series_colours` explicit override** — both supported; explicit always wins
2. **`chart_spec` sourcing — pattern (a)**: operator supplies spec at `/enrich-deck` time on `EnrichmentItem`; brief declares the marker slug only
3. **python-pptx `slide.shapes.add_chart()`** — all-Python, no Node round-trip, no OOXML handwriting
4. **v1 chart types**: `bar`, `column`, `line`, `area`, `pie`, `doughnut`, `scatter` — no stacked variants
5. **Section C `addChart()` language workaround kept as fallback** in persona doc — canonical for when chart data is not yet available at brief-authoring time

## Phase-by-phase summary

| Phase | Change |
|---|---|
| **1 — marker grammar** | `placeholder.py`: `MARKER_RE` now includes `CHART`; `slide_facts.py`: `VALID_MARKER_KINDS` and `VALID_ENRICHMENT_KINDS` extended |
| **2 — EnrichmentItem chart route** | `enrichment.py`: `chart_spec` field on `EnrichmentItem`; `chart` dispatch branch in `apply_enrichment`; new `enrichment_ops/chart.py` |
| **3 — chart palette** | New `src/chart_palette.py`: `derive_chart_palette()` with HSL-based derivation for all three roles |
| **4 — persona doc** | `narrative-brief-architect.md`: `CHART:slug` added to marker typology table + Section C guidance + identifier grammar + prohibited actions |
| **5 — analyser + tests** | 31 new tests in `test_chart_marker.py`: grammar, palette derivation, apply path (all 7 types), pptx_parser detection, two end-to-end fixture tests |
| **6 — dogfood validation** | **DEFERRED** — operator manual step post-merge (PowerPoint Mac gate; requires running `/pptx` with a CHART marker brief and opening in PowerPoint) |
| **7 — version + marketplace** | `plugin.json`: `0.2.1 → 0.2.2`; `marketplace.json`: synced |

## Test coverage delta

- Before: 325 bridge tests
- After: 356 bridge tests (+31)
- All 356 pass: `pytest -q` → `356 passed in 3.59s`

## Circular import note

`enrichment_ops/chart.py` raises `ValueError` / `LookupError` (not `EnrichmentApplyError`) to avoid a circular import (`enrichment` → `enrichment_ops.chart` → `enrichment`). The transactional orchestrator in `enrichment.py` wraps all exceptions as `EnrichmentApplyError` in its `except` clause — same behaviour for callers.

## Manual operator step required post-merge

**Phase 6 dogfood** — run a brief with one `CHART:slug` marker through `/pptx` + `/enrich-deck`, open in PowerPoint Mac, confirm:
- Native chart present at marker coordinates
- Chart is editable (double-click opens chart data editor)
- Brand palette series colours applied
- Marker rect and label removed

Document the run as `docs/superpowers/dogfooding/2026-05-12-chart-marker-validation.md`.

## References

- Issue: #55
- Plan: `docs/superpowers/plans/2026-05-12-bridge-chart-marker.md`
- Sibling: PR #81 (issue #56 — inline separator fix, already merged)
- Parent EPIC: #57 (Bridge v0.2 polish backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)