### PR TITLE
feat(jack-tar-deckhand): v1.4.2 — full-bleed image-is-the-slide scale (#88)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,9 +31,9 @@
     },
     {
       "name": "jack-tar-deckhand",
-      "description": "Full presentation pipeline \u2014 brand, style, narrative, images, SmartArt, assembly, QA + academic-figure rendering (optional paperbanana CLI) + /iterate-slide single-slide critique-driven refinement",
+      "description": "Full presentation pipeline \u2014 brand, style, narrative, images, SmartArt, assembly, QA + academic-figure rendering (optional paperbanana CLI) + /iterate-slide single-slide critique-driven refinement + full_bleed image-is-the-slide strategy",
       "source": "./plugins/jack-tar-deckhand",
-      "version": "1.4.1"
+      "version": "1.4.2"
     },
     {
       "name": "jack-tar-superpower-bridge",

--- a/docs/superpowers/dogfooding/2026-05-20-full-bleed-scale.md
+++ b/docs/superpowers/dogfooding/2026-05-20-full-bleed-scale.md
@@ -1,0 +1,60 @@
+# 2026-05-20 — full_bleed scale dogfood (issue #88, v1.4.2)
+
+## Scope
+
+Verify the new `full_bleed` rendering strategy makes the image fill the slide with ZERO chrome — no title overlay, no body, no footer logo — while leaving every other strategy unchanged.
+
+## Method
+
+Synthetic 4-slide deck built from JSON contracts (no AI generation; reused `tests/fixtures/minimal_deck/images/slide-01-hero.png` as the picture for every image-bearing slide). One slide per representative strategy:
+
+| # | Strategy      | Expected behaviour |
+|---|---------------|--------------------|
+| 1 | `full_render` | Image + title overlay near the bottom + footer logo |
+| 2 | `composed`    | Standard chrome — title + bullets, no image |
+| 3 | `background`  | Image as backdrop + `left_panel` text overlay + footer logo |
+| 4 | `full_bleed`  | Image edge-to-edge, NO title, NO body, NO footer — image IS the slide |
+
+Pipeline:
+
+1. `tmp/full-bleed-dogfood/setup_deck.py` writes outline / style-guide / image-manifest / chart-manifest / speaker-notes / strategy-map.
+2. `node plugins/jack-tar-deckhand/src/assembler/build_deck.js --deck-dir tmp/full-bleed-dogfood/deck` produces `presentation.pptx`.
+3. `soffice --headless --convert-to pdf` followed by `pdftoppm -png -r 96` rasterises each slide to a PNG for review.
+4. `general-purpose` subagent (Sonnet) dispatched with the 4 PNG paths and explicit pass/fail criteria. Subagent read the PNGs into its own context and returned a text verdict — no direct PNG read in the orchestration session.
+
+## Spend
+
+$0.00 — image generation skipped, only existing fixture used. Sonnet subagent dispatch cost ~$0.01.
+
+## Subagent verdict
+
+```
+Slide 1 (full_render): PASS — Image fill with title overlay "Slide 1 — full_render"
+                              in white on a dark band near the bottom. Chrome matches
+                              full_render contract.
+Slide 2 (composed):    PASS — White content slide with red left rule and bottom rule,
+                              title "Slide 2 — composed", three bullets, no image.
+                              Matches composed contract.
+Slide 3 (background):  PASS — Image filling the canvas with a darker left_panel
+                              containing white title "Slide 3 — background" and three
+                              light-grey bullets. Matches background+left_panel
+                              contract.
+Slide 4 (FULL_BLEED):  PASS — Pure edge-to-edge image. ZERO text visible.
+                              No "Slide 4", no "NOTHING SHOULD APPEAR", no body
+                              bullets, no title bar, no footer logo, no chrome of any
+                              kind. [gate satisfied]
+Overall verdict: SHIP
+```
+
+## Findings to entrench
+
+1. **The `full_bleed` branch correctly strips ALL chrome** including footer logo. The contrast with `full_render` (which keeps a title overlay and the logo) confirms the two strategies are distinguishable to the eye, not just to the schema.
+2. **No backward-compat regression.** Slides 1–3 render identically to baseline; the new branch is purely additive on the dispatcher (an `if strategy === 'full_bleed'` clause that returns early).
+3. **The python-pptx template path was not exercised in the visual dogfood** — covered exclusively by the integration tests in `test_full_bleed_scale.py`. Acceptable for the merge gate because the path is small (one new helper `_apply_full_bleed` plus a four-line wiring branch) and the unit + integration tests inspect both the shape count and the OOXML spTree ordering after `_apply_full_bleed` runs. A template-mode dogfood is a candidate for the v1.4 end-to-end dogfood (PR #105).
+4. **No upstream review cost.** Because the image is a known fixture and the rendering strategies are deterministic, the subagent was acting as a contract verifier, not a quality scorer. The image-reviewer agent (Haiku, scoring rubric) was not the right tool here — `general-purpose` (Sonnet, text+image semantics) gave a precise verdict in one round.
+
+## Out of scope for this PR
+
+- Auto-classification of `full_bleed` (operator-opt-in only by design — see issue #88 plan and the verification tests in `test_outline_classifier_never_emits_full_bleed`).
+- Bridge-side `FULLBLEED:` marker kind in `placeholder.py` (would require coordinated work in the bridge's `enrichment.py`, separate ticket).
+- Final v1.4 end-to-end dogfood mixing #88 + #90 + #91 (PR #105 candidate).

--- a/plugins/jack-tar-deckhand/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-deckhand/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-deckhand",
-  "description": "Full presentation pipeline — brand, style, narrative, images, SmartArt, assembly, QA + academic-figure rendering (optional paperbanana CLI) + /iterate-slide single-slide critique-driven refinement",
-  "version": "1.4.1",
+  "description": "Full presentation pipeline — brand, style, narrative, images, SmartArt, assembly, QA + academic-figure rendering (optional paperbanana CLI) + /iterate-slide single-slide critique-driven refinement + full_bleed image-is-the-slide strategy",
+  "version": "1.4.2",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-deckhand/skills/deck-assembler/SKILL.md
+++ b/plugins/jack-tar-deckhand/skills/deck-assembler/SKILL.md
@@ -58,7 +58,7 @@ Default deck-dir is `./tmp/deck` if not specified.
    - Images from ImageManifest placed in correct zones
    - Chart images from ChartManifest for data_chart slides
    - Speaker notes from SpeakerNotes contract
-   - If strategy-map.json exists, routes slides to full_render (full-bleed AI image), backdrop_render (AI background + text overlay), or composed (standard) assembly paths
+   - If strategy-map.json exists, routes slides to full_render (full-bleed AI image with title overlay), full_bleed (image IS the slide — zero chrome, issue #88), backdrop_render (AI background + text overlay), or composed (standard) assembly paths
 5. Generates progressive build slides for bullets with build_animation cues
 6. Writes the assembled .pptx to the output directory
 7. Reports file size and any asset warnings

--- a/plugins/jack-tar-deckhand/skills/strategy-map/SKILL.md
+++ b/plugins/jack-tar-deckhand/skills/strategy-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: strategy-map
-description: Classify each slide's rendering strategy (full_render, background, backdrop, pragmatic_composition, composed) and generate image prompts via the prompt-engineer agent.
+description: Classify each slide's rendering strategy (full_render, full_bleed, background, backdrop, pragmatic_composition, composed) and generate image prompts via the prompt-engineer agent.
 argument-hint: [--deck-dir PATH] [--approval-mode review|one_shot]
 allowed-tools: Bash(python *), Read, Glob, Agent(prompt-engineer)
 ---
@@ -18,7 +18,8 @@ Classify rendering strategies for each slide and produce the StrategyMap contrac
 ## What It Does
 
 1. Reads the SlideOutline and classifies each slide into a rendering strategy:
-   - **full_render** — entire slide generated as one AI image (title, section divider, closing, sparse content)
+   - **full_render** — entire slide generated as one AI image with a programmatic title overlay and footer logo on top (title, section divider, closing, sparse content)
+   - **full_bleed** — _operator-opt-in only_ — image IS the slide, ZERO chrome: no title, no body, no footer logo (issue #88). Use for the infographic-narrative register where every slide is edge-to-edge. See "Opting into full_bleed" below.
    - **background** — atmospheric AI background + text in template zones (5 variants: left_panel, right_panel, bottom_bar, top_band, center_float)
    - **backdrop** — structured AI scene + vision post-analysis for text positioning (Claude Code vision-analyst agent)
    - **pragmatic_composition** — individual AI-generated elements assembled at exact positions with text labels
@@ -84,6 +85,24 @@ If overrides are provided, rebuild with the overrides dict and save again.
 ### Pragmatic composition for grid content
 
 When a slide has 4+ labeled elements in a grid layout, recommend `pragmatic_composition` over `backdrop`. Pragmatic composition gives precise control over element sizing and alignment since each image is independently generated and placed at exact coordinates. Backdrop relies on vision-detected positions from a single scene image, which produces inconsistent element sizes and misaligned text labels.
+
+### Opting into full_bleed (issue #88)
+
+The `full_bleed` strategy is **operator-opt-in only**. Neither the rule-based classifier nor the outline-driven classifier will assign it automatically — the Speaker must pass it via the `overrides` dict to `build_strategy_map` or via `upgrade_slide_strategy`.
+
+**When to reach for it.** Decks in the infographic-narrative register (see superpower-bridge `infographic-narrative.md` preset, related to issue #87) want every content slide rendered edge-to-edge — title and body baked into the picture itself, no template chrome, no footer logo. The image carries the entire slide's meaning. Examples: large-format conference keynote screens where each slide is a designed plate; long-scroll briefing decks; institutional reports rendered as full-image plates.
+
+**When NOT to reach for it.** Avoid for slides that need post-delivery editability (the picture is fixed; speakers can't tweak words in PowerPoint), and for slides whose value is the text itself. If you want a hero image plus a programmatic title overlay, that is `full_render`, not `full_bleed`.
+
+**Override example.**
+
+```python
+strategy_map = build_strategy_map(outline, overrides={3: "full_bleed", 5: "full_bleed"})
+```
+
+Overrides set `render_funnel` to `["ollama", "cloud_low", "cloud_full"]` so the slide actually gets a production-quality image rendered.
+
+**Edge case — no picture.** If image generation fails for a `full_bleed` slide the assembler emits a slide with a solid brand-primary background (no chrome). Speakers spot the gap during review rather than seeing a misleading title placeholder.
 
 ### body_layout option for background slides
 

--- a/plugins/jack-tar-deckhand/src/assembler/build_deck.js
+++ b/plugins/jack-tar-deckhand/src/assembler/build_deck.js
@@ -171,6 +171,10 @@ async function assembleDeck() {
         const strategy = slideStrategies[slideData.slide_number] || 'composed';
 
         // Strategy-first routing: keynote strategies override slide-type routing
+        if (strategy === 'full_bleed') {
+            buildFullBleedSlide(pptx, slideData, { palette, SLIDE_W, SLIDE_H, noteData, imageData });
+            continue;
+        }
         if (strategy === 'full_render') {
             buildFullRenderSlide(pptx, slideData, { palette, typo, slidePalette, layouts, SLIDE_W, SLIDE_H, MARGIN, logoPath, hasLogo, noteData, imageData });
             continue;
@@ -940,6 +944,42 @@ function buildFullRenderSlide(pptx, slideData, ctx) {
     addFooterLogo(slide, ctx);
 
     // Speaker notes
+    if (noteData) {
+        slide.addNotes(noteData.text);
+    }
+}
+
+/**
+ * Full-bleed slide: the image IS the slide.
+ * Zero chrome — no title, no body, no footer logo. Just an edge-to-edge
+ * picture + speaker notes. Distinct from full_render (which keeps a title
+ * overlay and footer logo). Issue #88 — infographic-narrative register.
+ *
+ * Edge case: when no picture is available, render a solid brand-primary
+ * background. Still no chrome — the speaker can spot the missing image
+ * during review without misleading them with placeholder text.
+ */
+function buildFullBleedSlide(pptx, slideData, ctx) {
+    const { palette, SLIDE_W, SLIDE_H, noteData, imageData } = ctx;
+
+    const slide = pptx.addSlide();
+
+    const imgPath = imageData ? resolveImagePath(imageData.file_path) : null;
+    if (imgPath && fs.existsSync(imgPath)) {
+        slide.addImage({
+            path: imgPath,
+            x: 0,
+            y: 0,
+            w: SLIDE_W,
+            h: SLIDE_H,
+            sizing: { type: 'cover', w: SLIDE_W, h: SLIDE_H },
+            altText: imageData.alt_text || slideData.headline || '',
+        });
+    } else {
+        const bgColor = palette.primary || '1B3A4B';
+        slide.background = { color: bgColor };
+    }
+
     if (noteData) {
         slide.addNotes(noteData.text);
     }

--- a/plugins/jack-tar-deckhand/src/assembler/build_deck_template.py
+++ b/plugins/jack-tar-deckhand/src/assembler/build_deck_template.py
@@ -12,6 +12,11 @@ from pptx import Presentation
 from pptx.enum.shapes import MSO_SHAPE
 from pptx.util import Inches
 
+# Tag under <p:spTree> in the PresentationML namespace. Picture shapes must
+# sit AFTER <p:nvGrpSpPr> and <p:grpSpPr> for PowerPoint to render the slide.
+_PML_NS = "{http://schemas.openxmlformats.org/presentationml/2006/main}"
+_SPTREE_HEAD_TAGS = (f"{_PML_NS}nvGrpSpPr", f"{_PML_NS}grpSpPr")
+
 
 def _resolve_layout(prs, profile, slide_type):
     """Find the python-pptx SlideLayout object for a given slide type."""
@@ -90,6 +95,42 @@ def _get_mapped_layout_name(profile, slide_type):
     return None
 
 
+def _apply_full_bleed(slide, image_path, slide_w, slide_h):
+    """Render a full_bleed slide: strip all shapes, add picture at canvas size.
+
+    Implements issue #88. Promotes the fullbleed_deck.py post-processor to
+    first-class assembler behaviour. Image goes edge-to-edge with zero
+    chrome — no title, no body, no footer placeholders.
+
+    Args:
+        slide: python-pptx Slide object (already added via prs.slides.add_slide).
+        image_path: Absolute path to the picture file, or None.
+        slide_w: Slide width in EMU (from prs.slide_width).
+        slide_h: Slide height in EMU (from prs.slide_height).
+
+    Edge case: when ``image_path`` is None or the file is missing, the slide
+    is left empty (every shape stripped). Speakers spot the gap during
+    review rather than seeing a misleading title placeholder.
+    """
+    for shape in list(slide.shapes):
+        el = shape._element
+        el.getparent().remove(el)
+
+    if not image_path or not os.path.isfile(image_path):
+        return
+
+    pic = slide.shapes.add_picture(image_path, 0, 0, width=slide_w, height=slide_h)
+
+    sp_tree = pic._element.getparent()
+    sp_tree.remove(pic._element)
+    children = list(sp_tree)
+    insert_at = 0
+    for i, ch in enumerate(children):
+        if ch.tag in _SPTREE_HEAD_TAGS:
+            insert_at = i + 1
+    sp_tree.insert(insert_at, pic._element)
+
+
 def _emit_smartart_placeholder(slide, slide_number, profile_layout):
     """Add a named rectangle placeholder for pptx_native SmartArt injection.
 
@@ -158,8 +199,21 @@ def build_deck(deck_dir, template_path, template_profile):
             if graphic.get('engine_used') == 'pptx_native':
                 pptx_native_slides.add(graphic['slide_number'])
 
+    # Build a set of slide numbers marked full_bleed (issue #88).
+    # speaker_override wins when present, mirroring the JS assembler.
+    full_bleed_slides = set()
+    strategy_map_path = os.path.join(deck_dir, 'strategy-map.json')
+    if os.path.isfile(strategy_map_path):
+        with open(strategy_map_path) as f:
+            strategy_map = json.load(f)
+        for entry in strategy_map.get('slides', []):
+            effective = entry.get('speaker_override') or entry.get('strategy')
+            if effective == 'full_bleed':
+                full_bleed_slides.add(entry['slide_number'])
+
     prs = Presentation(template_path)
     _strip_existing_slides(prs)
+    slide_w, slide_h = prs.slide_width, prs.slide_height
 
     for slide_data in outline.get('slides', []):
         slide_number = slide_data['slide_number']
@@ -169,6 +223,18 @@ def build_deck(deck_dir, template_path, template_profile):
 
         layout = _resolve_layout(prs, template_profile, slide_type)
         slide = prs.slides.add_slide(layout)
+
+        # full_bleed short-circuits all standard population. Picture only,
+        # zero chrome. Issue #88.
+        if slide_number in full_bleed_slides:
+            abs_image_path = None
+            if slide_number in image_lookup:
+                raw = image_lookup[slide_number]
+                abs_image_path = raw if os.path.isabs(raw) else os.path.join(deck_dir, raw)
+            _apply_full_bleed(slide, abs_image_path, slide_w, slide_h)
+            if slide_number in speaker_notes:
+                slide.notes_slide.notes_text_frame.text = speaker_notes[slide_number]
+            continue
 
         layout_name = _get_mapped_layout_name(template_profile, slide_type)
         profile_layout = _get_profile_layout(template_profile, layout_name)

--- a/plugins/jack-tar-deckhand/src/conductor.py
+++ b/plugins/jack-tar-deckhand/src/conductor.py
@@ -228,7 +228,7 @@ def upgrade_slide_strategy(deck_dir, slide_number, new_strategy):
     Args:
         deck_dir: Path to the deck working directory.
         slide_number: Which slide to upgrade.
-        new_strategy: 'full_render', 'backdrop_render', or 'composed'.
+        new_strategy: 'full_render', 'backdrop_render', 'full_bleed', or 'composed'.
 
     Returns:
         dict: The updated strategy map.
@@ -241,7 +241,7 @@ def upgrade_slide_strategy(deck_dir, slide_number, new_strategy):
     for entry in strategy_map.get('slides', []):
         if entry['slide_number'] == slide_number:
             entry['speaker_override'] = new_strategy
-            if new_strategy in ('full_render', 'backdrop_render'):
+            if new_strategy in ('full_render', 'backdrop_render', 'full_bleed'):
                 entry['render_funnel'] = ['ollama', 'cloud_low', 'cloud_full']
             else:
                 entry['render_funnel'] = ['ollama']

--- a/plugins/jack-tar-deckhand/src/schemas/strategy_map.schema.json
+++ b/plugins/jack-tar-deckhand/src/schemas/strategy_map.schema.json
@@ -20,7 +20,7 @@
           "slide_number": {"type": "integer", "minimum": 1},
           "strategy": {
             "type": "string",
-            "enum": ["full_render", "backdrop_render", "composed", "background", "backdrop", "pragmatic_composition", "smartart", "academic_figure"]
+            "enum": ["full_render", "backdrop_render", "composed", "background", "backdrop", "pragmatic_composition", "smartart", "academic_figure", "full_bleed"]
           },
           "rationale": {"type": "string"},
           "render_funnel": {
@@ -32,7 +32,7 @@
           },
           "speaker_override": {
             "type": ["string", "null"],
-            "enum": ["full_render", "backdrop_render", "composed", "background", "backdrop", "pragmatic_composition", "smartart", "academic_figure", null]
+            "enum": ["full_render", "backdrop_render", "composed", "background", "backdrop", "pragmatic_composition", "smartart", "academic_figure", "full_bleed", null]
           },
           "backdrop_variant": {
             "type": "string",

--- a/plugins/jack-tar-deckhand/src/slide_prompt_composer.py
+++ b/plugins/jack-tar-deckhand/src/slide_prompt_composer.py
@@ -135,7 +135,7 @@ def build_strategy_map(outline, approval_mode='review', overrides=None, template
         if slide_num in overrides:
             entry['speaker_override'] = overrides[slide_num]
             # Override also sets the render funnel for the new strategy
-            if overrides[slide_num] in ('full_render', 'backdrop_render', 'background', 'backdrop'):
+            if overrides[slide_num] in ('full_render', 'backdrop_render', 'background', 'backdrop', 'full_bleed'):
                 entry['render_funnel'] = ['ollama', 'cloud_low', 'cloud_full']
             else:
                 entry['render_funnel'] = ['ollama']

--- a/plugins/jack-tar-deckhand/tests/test_full_bleed_scale.py
+++ b/plugins/jack-tar-deckhand/tests/test_full_bleed_scale.py
@@ -1,0 +1,518 @@
+"""Tests for the full_bleed strategy (issue #88 — v1.4.2).
+
+The full_bleed strategy is "the image IS the slide" — picture fills the
+canvas with ZERO chrome (no title, no body, no footer logo). Distinct
+from full_render, which keeps a title overlay and footer logo.
+
+Coverage:
+
+- Schema accepts full_bleed in strategy and speaker_override enums.
+- Neither auto-classifier (rule-based ``strategy_classifier`` or the
+  outline-driven ``classify_slide_strategy``) can emit full_bleed. It
+  is operator-opt-in only.
+- ``build_strategy_map`` overrides + ``upgrade_slide_strategy`` propagate
+  full_bleed to a cloud-rendering funnel.
+- python-pptx ``_apply_full_bleed`` strips chrome, adds a picture at
+  canvas size, hoists it to the first drawable position in spTree.
+- Edge case: full_bleed without an image leaves an empty slide rather
+  than misleading placeholder chrome.
+- python-pptx ``build_deck`` end-to-end emits a full_bleed slide with
+  one PICTURE shape and nothing else.
+- Backward compatibility: existing strategies (full_render, composed)
+  remain unchanged when the strategy map contains no full_bleed entries.
+- JS assembler subprocess emits a full_bleed slide containing only the
+  picture (no title text shapes), gated on Node + pptxgenjs being
+  available so CI can skip when the JS toolchain is absent.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+from jsonschema import ValidationError, validate
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+from pptx.util import Inches, Pt
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = PLUGIN_ROOT.parent.parent
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from src.assembler.build_deck_template import (  # noqa: E402
+    _apply_full_bleed,
+    build_deck,
+)
+from src.conductor import init_pipeline, upgrade_slide_strategy  # noqa: E402
+from src.slide_prompt_composer import (  # noqa: E402
+    build_strategy_map,
+    classify_slide_strategy,
+)
+from src.strategy_classifier import classify_strategy  # noqa: E402
+
+SCHEMA_PATH = PLUGIN_ROOT / "src" / "schemas" / "strategy_map.schema.json"
+TEMPLATE_FIXTURE = PROJECT_ROOT / "tests" / "fixtures" / "templates" / "metamirror-template.pptx"
+HERO_IMAGE_FIXTURE = PROJECT_ROOT / "tests" / "fixtures" / "minimal_deck" / "images" / "slide-01-hero.png"
+PLUGIN_JS_ASSEMBLER = PLUGIN_ROOT / "src" / "assembler" / "build_deck.js"
+
+
+# --- Schema -----------------------------------------------------------------
+
+
+def _load_schema():
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+def _valid_strategy_map(strategy: str, speaker_override=None):
+    entry = {
+        "slide_number": 1,
+        "strategy": strategy,
+        "rationale": "test",
+        "render_funnel": ["ollama", "cloud_low", "cloud_full"],
+    }
+    if speaker_override is not None:
+        entry["speaker_override"] = speaker_override
+    return {"approval_mode": "review", "slides": [entry]}
+
+
+def test_schema_accepts_full_bleed_strategy():
+    validate(instance=_valid_strategy_map("full_bleed"), schema=_load_schema())
+
+
+def test_schema_accepts_full_bleed_speaker_override():
+    validate(
+        instance=_valid_strategy_map("composed", speaker_override="full_bleed"),
+        schema=_load_schema(),
+    )
+
+
+def test_schema_rejects_unknown_strategy():
+    with pytest.raises(ValidationError):
+        validate(instance=_valid_strategy_map("not_a_strategy"), schema=_load_schema())
+
+
+# --- Auto-classification safety --------------------------------------------
+
+
+def test_rule_classifier_never_emits_full_bleed_for_academic_text():
+    result = classify_strategy(
+        "Figure 3: Transformer architecture [12]. Algorithm 2 (gradient descent)."
+    )
+    assert result.strategy != "full_bleed"
+
+
+def test_rule_classifier_never_emits_full_bleed_for_business_text():
+    result = classify_strategy("Quarterly revenue grew 12% in Q4.")
+    assert result.strategy != "full_bleed"
+
+
+@pytest.mark.parametrize(
+    "slide",
+    [
+        {"slide_number": 1, "slide_type": "title", "headline": "X", "visual_type": "hero_image"},
+        {"slide_number": 2, "slide_type": "content", "headline": "Y", "body_points": ["a"], "visual_type": "hero_image"},
+        {"slide_number": 3, "slide_type": "content", "headline": "Z", "body_points": ["a", "b", "c", "d"], "visual_type": "hero_image"},
+        {"slide_number": 4, "slide_type": "closing", "headline": "End", "visual_type": "none"},
+        {"slide_number": 5, "slide_type": "data_chart", "headline": "Data", "visual_type": "chart"},
+    ],
+)
+def test_outline_classifier_never_emits_full_bleed(slide):
+    """full_bleed must be operator-opt-in only — never auto-classified."""
+    result = classify_slide_strategy(slide, template_mode=False)
+    assert result["strategy"] != "full_bleed"
+
+
+def test_outline_classifier_in_template_mode_never_emits_full_bleed():
+    full_bleed_layout = {
+        "placeholders": [
+            {"idx": 13, "type": "picture", "name": "Picture", "x": 0.0, "y": 0.0, "w": 13.33, "h": 7.5},
+        ]
+    }
+    result = classify_slide_strategy(
+        {"slide_number": 1, "slide_type": "title", "headline": "T", "visual_type": "hero_image"},
+        template_mode=True,
+        template_layout=full_bleed_layout,
+    )
+    assert result["strategy"] != "full_bleed"
+
+
+# --- Override propagation ---------------------------------------------------
+
+
+def test_build_strategy_map_override_to_full_bleed_assigns_cloud_funnel():
+    outline = {
+        "narrative_arc": "infographic-narrative",
+        "estimated_duration_minutes": 10,
+        "slides": [
+            {"slide_number": 1, "slide_type": "content", "headline": "H",
+             "body_points": ["a", "b"], "visual_type": "hero_image"},
+        ],
+    }
+    strategy_map = build_strategy_map(outline, overrides={1: "full_bleed"})
+    entry = strategy_map["slides"][0]
+    assert entry["speaker_override"] == "full_bleed"
+    assert entry["render_funnel"] == ["ollama", "cloud_low", "cloud_full"]
+
+
+def test_upgrade_slide_strategy_to_full_bleed(tmp_path):
+    deck_dir = tmp_path / "deck"
+    deck_dir.mkdir()
+    init_pipeline(str(deck_dir))
+    with open(deck_dir / "strategy-map.json", "w") as f:
+        json.dump(
+            {
+                "approval_mode": "review",
+                "slides": [
+                    {"slide_number": 1, "strategy": "composed", "rationale": "x",
+                     "render_funnel": ["ollama"], "speaker_override": None},
+                ],
+            },
+            f,
+        )
+    upgrade_slide_strategy(str(deck_dir), 1, "full_bleed")
+    with open(deck_dir / "strategy-map.json") as f:
+        result = json.load(f)
+    entry = result["slides"][0]
+    assert entry["speaker_override"] == "full_bleed"
+    assert entry["render_funnel"] == ["ollama", "cloud_low", "cloud_full"]
+
+
+# --- _apply_full_bleed unit tests ------------------------------------------
+
+
+def _make_template_slide_with_chrome(tmp_dir):
+    """Build a minimal one-slide presentation with title + body + a rect."""
+    prs = Presentation()
+    layout = prs.slide_layouts[1]  # Title and Content
+    slide = prs.slides.add_slide(layout)
+    if slide.shapes.title is not None:
+        slide.shapes.title.text = "Pre-existing title chrome"
+    box = slide.shapes.add_textbox(Inches(1), Inches(3), Inches(4), Inches(1))
+    box.text_frame.text = "Pre-existing body chrome"
+    out = tmp_dir / "fixture.pptx"
+    prs.save(out)
+    return out, prs.slide_width, prs.slide_height
+
+
+def test_apply_full_bleed_strips_all_shapes_and_adds_picture(tmp_path):
+    fixture_pptx, slide_w, slide_h = _make_template_slide_with_chrome(tmp_path)
+    prs = Presentation(fixture_pptx)
+    slide = prs.slides[0]
+    initial_shape_count = len(slide.shapes)
+    assert initial_shape_count >= 2  # title + body textbox
+
+    _apply_full_bleed(slide, str(HERO_IMAGE_FIXTURE), slide_w, slide_h)
+
+    assert len(slide.shapes) == 1
+    only = slide.shapes[0]
+    assert only.shape_type == MSO_SHAPE_TYPE.PICTURE
+    assert only.left == 0 and only.top == 0
+    assert only.width == slide_w and only.height == slide_h
+
+
+def test_apply_full_bleed_without_picture_leaves_empty_slide(tmp_path):
+    fixture_pptx, slide_w, slide_h = _make_template_slide_with_chrome(tmp_path)
+    prs = Presentation(fixture_pptx)
+    slide = prs.slides[0]
+
+    _apply_full_bleed(slide, None, slide_w, slide_h)
+
+    assert len(slide.shapes) == 0
+
+
+def test_apply_full_bleed_missing_image_file_leaves_empty_slide(tmp_path):
+    fixture_pptx, slide_w, slide_h = _make_template_slide_with_chrome(tmp_path)
+    prs = Presentation(fixture_pptx)
+    slide = prs.slides[0]
+
+    _apply_full_bleed(slide, str(tmp_path / "does-not-exist.png"), slide_w, slide_h)
+
+    assert len(slide.shapes) == 0
+
+
+def test_apply_full_bleed_picture_is_first_drawable_in_sp_tree(tmp_path):
+    fixture_pptx, slide_w, slide_h = _make_template_slide_with_chrome(tmp_path)
+    prs = Presentation(fixture_pptx)
+    slide = prs.slides[0]
+    _apply_full_bleed(slide, str(HERO_IMAGE_FIXTURE), slide_w, slide_h)
+
+    ns = "{http://schemas.openxmlformats.org/presentationml/2006/main}"
+    sp_tree = slide.shapes._spTree
+    drawables = [child for child in sp_tree if child.tag not in (f"{ns}nvGrpSpPr", f"{ns}grpSpPr")]
+    assert len(drawables) == 1
+    pic_tag = f"{ns}pic"
+    assert drawables[0].tag == pic_tag
+
+
+# --- python-pptx build_deck integration ------------------------------------
+
+
+def _write_minimal_template_inputs(deck_dir: Path, full_bleed_slide_nums):
+    """Build the contracts build_deck() needs, with one optional full_bleed slide."""
+    outline = {
+        "narrative_arc": "infographic-narrative",
+        "estimated_duration_minutes": 6,
+        "total_slides": 2,
+        "slides": [
+            {
+                "slide_number": 1,
+                "slide_type": "content",
+                "headline": "Composed slide retains chrome",
+                "body_points": ["alpha", "beta"],
+                "visual_type": "none",
+                "layout_template": "content",
+            },
+            {
+                "slide_number": 2,
+                "slide_type": "content",
+                "headline": "Full-bleed slide has no chrome",
+                "body_points": ["this should not appear"],
+                "visual_type": "hero_image",
+                "layout_template": "content",
+            },
+        ],
+    }
+    with open(deck_dir / "outline.json", "w") as f:
+        json.dump(outline, f)
+
+    image_manifest = {
+        "generated_at": "2026-05-20T00:00:00Z",
+        "image_backend": "ollama",
+        "images": [
+            {
+                "image_id": "slide-02-hero",
+                "slide_number": 2,
+                "file_path": str(HERO_IMAGE_FIXTURE),
+                "placement_zone": "background",
+                "dimensions": {"width": 1920, "height": 1080},
+                "source_prompt": "test",
+                "model_used": "test",
+                "alt_text": "Full bleed hero",
+                "status": "generated",
+                "retry_count": 0,
+                "generation_time_seconds": 1.0,
+            },
+        ],
+        "summary": {"total_images": 1, "generated_count": 1, "cached_count": 0, "placeholder_count": 0, "failed_count": 0, "total_generation_seconds": 1.0},
+    }
+    with open(deck_dir / "image-manifest.json", "w") as f:
+        json.dump(image_manifest, f)
+
+    if full_bleed_slide_nums:
+        strategy_map = {
+            "approval_mode": "review",
+            "slides": [
+                {"slide_number": 1, "strategy": "composed", "rationale": "keep chrome",
+                 "render_funnel": ["ollama"], "speaker_override": None},
+                {"slide_number": 2, "strategy": "full_bleed", "rationale": "infographic register",
+                 "render_funnel": ["ollama", "cloud_low", "cloud_full"], "speaker_override": None},
+            ],
+        }
+        with open(deck_dir / "strategy-map.json", "w") as f:
+            json.dump(strategy_map, f)
+
+
+def _stub_template_profile():
+    """Minimal TemplateProfile pointing at the fixture template."""
+    return {
+        "master_index": 0,
+        "layout_mapping": {
+            "content": {"layout_index": 1, "layout_name": "Title and Content"},
+            "title": {"layout_index": 0, "layout_name": "Title Slide"},
+        },
+        "unmapped_fallback": {"layout_index": 1, "layout_name": "Title and Content"},
+        "layouts": [
+            {
+                "name": "Title and Content",
+                "placeholders": [
+                    {"idx": 0, "type": "title", "name": "Title", "x": 0.5, "y": 0.3, "w": 12.0, "h": 1.0},
+                    {"idx": 1, "type": "content", "name": "Body", "x": 0.5, "y": 1.5, "w": 12.0, "h": 5.5},
+                ],
+            },
+            {
+                "name": "Title Slide",
+                "placeholders": [
+                    {"idx": 0, "type": "title", "name": "Title", "x": 0.5, "y": 3.0, "w": 12.0, "h": 1.5},
+                ],
+            },
+        ],
+    }
+
+
+@pytest.mark.skipif(not TEMPLATE_FIXTURE.exists(), reason="template fixture missing")
+def test_build_deck_template_emits_full_bleed_slide_with_only_picture(tmp_path):
+    deck_dir = tmp_path / "deck"
+    deck_dir.mkdir()
+    _write_minimal_template_inputs(deck_dir, full_bleed_slide_nums=[2])
+
+    output_path = build_deck(str(deck_dir), str(TEMPLATE_FIXTURE), _stub_template_profile())
+
+    prs = Presentation(output_path)
+    assert len(prs.slides) == 2
+
+    full_bleed_slide = prs.slides[1]
+    pictures = [s for s in full_bleed_slide.shapes if s.shape_type == MSO_SHAPE_TYPE.PICTURE]
+    non_pictures = [s for s in full_bleed_slide.shapes if s.shape_type != MSO_SHAPE_TYPE.PICTURE]
+    assert len(pictures) == 1
+    assert len(non_pictures) == 0
+    assert pictures[0].left == 0 and pictures[0].top == 0
+    assert pictures[0].width == prs.slide_width
+    assert pictures[0].height == prs.slide_height
+
+
+@pytest.mark.skipif(not TEMPLATE_FIXTURE.exists(), reason="template fixture missing")
+def test_build_deck_template_preserves_composed_slide_when_other_is_full_bleed(tmp_path):
+    """Backward-compat: composed slide chrome is untouched even when a sibling is full_bleed."""
+    deck_dir = tmp_path / "deck"
+    deck_dir.mkdir()
+    _write_minimal_template_inputs(deck_dir, full_bleed_slide_nums=[2])
+
+    output_path = build_deck(str(deck_dir), str(TEMPLATE_FIXTURE), _stub_template_profile())
+    prs = Presentation(output_path)
+
+    composed_slide = prs.slides[0]
+    has_title_text = any(
+        getattr(s, "has_text_frame", False) and "Composed slide retains chrome" in (s.text_frame.text or "")
+        for s in composed_slide.shapes
+    )
+    assert has_title_text, "composed slide should keep its title text"
+
+
+@pytest.mark.skipif(not TEMPLATE_FIXTURE.exists(), reason="template fixture missing")
+def test_build_deck_template_without_strategy_map_unchanged(tmp_path):
+    """Backward-compat: no strategy-map.json → no full_bleed behaviour kicks in."""
+    deck_dir = tmp_path / "deck"
+    deck_dir.mkdir()
+    _write_minimal_template_inputs(deck_dir, full_bleed_slide_nums=None)
+
+    output_path = build_deck(str(deck_dir), str(TEMPLATE_FIXTURE), _stub_template_profile())
+    prs = Presentation(output_path)
+    # Slide 2 should retain chrome since no strategy map said full_bleed.
+    slide_two_shapes = list(prs.slides[1].shapes)
+    assert len(slide_two_shapes) > 0
+
+
+# --- JS assembler subprocess integration -----------------------------------
+
+
+def _have_node_with_pptxgenjs() -> bool:
+    """True only if `node` is on PATH and pptxgenjs resolves from the plugin dir."""
+    if shutil.which("node") is None:
+        return False
+    check = subprocess.run(
+        ["node", "-e", "require('pptxgenjs')"],
+        cwd=str(PLUGIN_ROOT),
+        capture_output=True,
+        text=True,
+    )
+    return check.returncode == 0
+
+
+def _write_js_assembler_inputs(deck_dir: Path):
+    """Contracts the JS assembler reads, with a single full_bleed slide."""
+    outline = {
+        "narrative_arc": "infographic-narrative",
+        "estimated_duration_minutes": 4,
+        "total_slides": 2,
+        "slides": [
+            {"slide_number": 1, "slide_type": "title", "headline": "Composed Title",
+             "body_points": [], "visual_type": "hero_image", "layout_template": "title"},
+            {"slide_number": 2, "slide_type": "content", "headline": "This headline must not appear",
+             "body_points": ["this body must not appear"], "visual_type": "hero_image",
+             "layout_template": "content"},
+        ],
+    }
+    with open(deck_dir / "outline.json", "w") as f:
+        json.dump(outline, f)
+
+    style_guide = {
+        "palette": {"primary": "1B3A4B", "accent": "C0392B", "text_primary": "111111",
+                    "text_secondary": "555555", "background": "FFFFFF"},
+        "typography": {"heading_font": "Inter", "body_font": "Inter",
+                       "heading_sizes": {"slide_heading": 32}, "body_sizes": {"body": 18}},
+        "layouts": {},
+        "image_style_tokens": {},
+        "slide_palette": {},
+    }
+    with open(deck_dir / "style-guide.json", "w") as f:
+        json.dump(style_guide, f)
+
+    images_dir = deck_dir / "images"
+    images_dir.mkdir()
+    shutil.copy(HERO_IMAGE_FIXTURE, images_dir / "slide-02-hero.png")
+
+    image_manifest = {
+        "generated_at": "2026-05-20T00:00:00Z",
+        "image_backend": "ollama",
+        "images": [
+            {"image_id": "slide-02-hero", "slide_number": 2,
+             "file_path": "./images/slide-02-hero.png",
+             "placement_zone": "background", "dimensions": {"width": 1920, "height": 1080},
+             "source_prompt": "test", "model_used": "test", "alt_text": "hero",
+             "status": "generated", "retry_count": 0, "generation_time_seconds": 1.0},
+        ],
+        "summary": {"total_images": 1, "generated_count": 1, "cached_count": 0,
+                    "placeholder_count": 0, "failed_count": 0, "total_generation_seconds": 1.0},
+    }
+    with open(deck_dir / "image-manifest.json", "w") as f:
+        json.dump(image_manifest, f)
+
+    with open(deck_dir / "chart-manifest.json", "w") as f:
+        json.dump({"generated_at": "2026-05-20T00:00:00Z", "charts": [],
+                   "summary": {"total_charts": 0, "rendered_count": 0, "failed_count": 0}}, f)
+
+    with open(deck_dir / "speaker-notes.json", "w") as f:
+        json.dump({"generated_at": "2026-05-20T00:00:00Z", "talk_duration_minutes": 4,
+                   "notes": []}, f)
+
+    strategy_map = {
+        "approval_mode": "review",
+        "slides": [
+            {"slide_number": 1, "strategy": "composed", "rationale": "title",
+             "render_funnel": ["ollama"], "speaker_override": None},
+            {"slide_number": 2, "strategy": "full_bleed", "rationale": "infographic register",
+             "render_funnel": ["ollama", "cloud_low", "cloud_full"], "speaker_override": None},
+        ],
+    }
+    with open(deck_dir / "strategy-map.json", "w") as f:
+        json.dump(strategy_map, f)
+
+
+@pytest.mark.skipif(not _have_node_with_pptxgenjs(), reason="node + pptxgenjs not available")
+def test_js_assembler_emits_full_bleed_slide_with_no_title_text(tmp_path):
+    deck_dir = tmp_path / "deck"
+    deck_dir.mkdir()
+    (deck_dir / "output").mkdir()
+    _write_js_assembler_inputs(deck_dir)
+
+    result = subprocess.run(
+        ["node", str(PLUGIN_JS_ASSEMBLER), "--deck-dir", str(deck_dir)],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, f"JS assembler failed: {result.stderr}"
+
+    output_pptx = deck_dir / "output" / "presentation.pptx"
+    assert output_pptx.is_file()
+
+    prs = Presentation(output_pptx)
+    assert len(prs.slides) == 2
+
+    full_bleed_slide = prs.slides[1]
+    text_shapes = [
+        s for s in full_bleed_slide.shapes
+        if getattr(s, "has_text_frame", False) and (s.text_frame.text or "").strip()
+    ]
+    forbidden = "This headline must not appear"
+    forbidden_body = "this body must not appear"
+    for s in text_shapes:
+        assert forbidden not in s.text_frame.text
+        assert forbidden_body not in s.text_frame.text
+
+    pictures = [s for s in full_bleed_slide.shapes if s.shape_type == MSO_SHAPE_TYPE.PICTURE]
+    assert len(pictures) == 1


### PR DESCRIPTION
## Summary

Adds `full_bleed` to the deck-assembler strategy vocabulary: a slide where the picture fills the canvas edge-to-edge with **zero chrome** — no title overlay, no body, no footer logo. Distinct from `full_render`, which keeps a title overlay and the footer logo on top of the image.

Designed for the infographic-narrative register: decks where every content slide is meant to be a designed plate rather than a chrome-decorated template, or where post-delivery editability is not a goal.

Closes #88.

## What's IN this PR

- **Schema** — `full_bleed` added to the `strategy` enum and the `speaker_override` enum in `strategy_map.schema.json`.
- **PptxGenJS path** — new `buildFullBleedSlide` in `build_deck.js`. Adds the picture at `0,0 → SLIDE_W × SLIDE_H` with `cover` sizing. No title, no body, no footer logo. Edge case (no picture): solid brand-primary fill so the gap is visible at review time.
- **python-pptx template path** — new `_apply_full_bleed` in `build_deck_template.py`. Strips every shape on the slide, adds the picture at canvas dimensions, hoists it to first drawable in spTree. The template assembler now reads `strategy-map.json` (it did not before) so the branch only fires when an operator opts a slide in.
- **Operator-opt-in only** — neither auto-classifier emits `full_bleed`. The override paths (`build_strategy_map` overrides, `upgrade_slide_strategy`) accept it and allocate a `["ollama", "cloud_low", "cloud_full"]` render funnel.
- **Tests** — 21 new tests covering schema, classifier safety, override propagation, `_apply_full_bleed` unit (including edge cases), python-pptx `build_deck` integration, and a JS assembler subprocess integration (skipped when `node`/`pptxgenjs` is absent). Plugin suite: **183 → 204 tests green**.
- **Docs** — `strategy-map/SKILL.md` gets a new "Opting into full_bleed" section + the strategy table updated; `deck-assembler/SKILL.md` mentions the new routing path.
- **Dogfood** — `docs/superpowers/dogfooding/2026-05-20-full-bleed-scale.md` logs a 4-slide synthetic render mixing `full_render` / `composed` / `background` / `full_bleed`. Subagent visual review verdict: SHIP. Spend $0 (fixture-only).
- **Version bump** — plugin and marketplace to `1.4.2`.

## What's NOT IN this PR

- **#90** (composition primitives) and **#91** (text-density warning) — those touch the prompt-engineer agent and ship together on `feat/v1.4.3-prompt-engineer-primitives`.
- **CLAUDE.md current-status update** — per the established convention (the v1.4.1 PR shipped without it; PR #103 followed up with the docs branch), CLAUDE.md is updated post-merge.
- **Final v1.4 end-to-end dogfood** — PR #105 candidate, AFTER #90/#91 land.
- **Bridge-side `FULLBLEED:` marker kind** — the bridge marker typology (`placeholder.py` with BG / IMAGE / SMARTART / etc.) is unchanged. Wiring full-bleed into the bridge's `enrichment.py` is a separate ticket if/when desired.

## Plan clarifications (documented in commit bodies)

- The plan referenced a "scale enum" on the schema, but the existing equivalent is the `strategy` enum (which already carries `full_render`, `composed`, etc.). `full_bleed` lands there. The "BG / content-zone / side-accent" scale typology lives in the bridge's `placeholder.py`, not the deckhand schema.
- `full_render` already exists and is similar but NOT redundant — it keeps a title overlay + footer logo on top of the full-bleed image. `full_bleed` is genuinely new: zero chrome at all.
- `build_deck_template.py` did not previously read `strategy-map.json`. This change adds that read so the python-pptx path can honour `full_bleed`.

## Test plan

- [x] Plugin tests: `204 / 204 green` (183 baseline + 21 new) via `.venv/bin/pytest plugins/jack-tar-deckhand/tests/`
- [x] Synthetic 4-slide dogfood deck rendered; subagent verdict SHIP (slide 4 confirmed edge-to-edge image with zero chrome)
- [x] Backward compatibility verified: `test_build_deck_template_preserves_composed_slide_when_other_is_full_bleed` and `test_build_deck_template_without_strategy_map_unchanged`
- [ ] CI 9/9 green (await)

🤖 Generated with [Claude Code](https://claude.com/claude-code)