### PR TITLE
feat(academic-figure): Path B — Claude-critic loop alongside paperbanana-critic

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,9 +31,9 @@
     },
     {
       "name": "jack-tar-deckhand",
-      "description": "Full presentation pipeline \u2014 brand, style, narrative, images, SmartArt, assembly, QA + academic-figure rendering (optional paperbanana CLI) + /iterate-slide single-slide critique-driven refinement + full_bleed image-is-the-slide strategy + creative vision renderer (#105) + creative_vision GA: per-slide cost surface, Creative Sprint phase, per-iteration operator gate, deck-level creative anchors (#113)",
+      "description": "Full presentation pipeline \u2014 brand, style, narrative, images, SmartArt, assembly, QA + academic-figure rendering (optional paperbanana CLI) + /iterate-slide single-slide critique-driven refinement + full_bleed image-is-the-slide strategy + creative vision renderer (#105) + creative_vision GA: per-slide cost surface, Creative Sprint phase, per-iteration operator gate, deck-level creative anchors (#113) + academic_figure Claude-critic path (opt-in, equivalence-testing phase)",
       "source": "./plugins/jack-tar-deckhand",
-      "version": "1.5.1"
+      "version": "1.5.2"
     },
     {
       "name": "jack-tar-superpower-bridge",

--- a/docs/architecture/academic-figure-critic-equivalence.md
+++ b/docs/architecture/academic-figure-critic-equivalence.md
@@ -1,0 +1,170 @@
+# Academic-figure critic equivalence testing — methodology
+
+**Status**: Phase 1 active. PR `feat/academic-figure-claude-critic` (deckhand 1.5.2) lands the side-by-side surface; the equivalence verdict is what closes Phase 1.
+
+**Cross-references**:
+- Path-B decision context: PR #114 conversation (issue #113 follow-up)
+- ADR v2 (paperbanana framing): [`paperbanana-integration-v2.md`](paperbanana-integration-v2.md)
+- Loop implementation: imagegen-bridge SKILL.md Step 4.6.1
+- Agent contract: [`agents/figure-critic.md`](../../plugins/jack-tar-deckhand/agents/figure-critic.md)
+
+---
+
+## What we're testing
+
+The v1.4.1 academic_figure path delegated the iteration loop to paperbanana. Paperbanana's Gemini-Flash VLM critic decides accept/refine; jack-tar's role is dispatch + manifest. Path B moves the critic decision into jack-tar — the `figure-critic` agent (Sonnet) is now the decision-maker, paperbanana is the renderer.
+
+We want to know: **does Claude-as-critic produce better, equivalent, or worse academic-figure outcomes than paperbanana-as-critic on the same input?**
+
+"Better/equivalent/worse" against three signals:
+
+1. **Decision agreement** — when both critics evaluate the same render, do they reach the same accept/reject verdict?
+2. **Final-figure quality** — when the loops run end-to-end (operator gate honoured in both), does the final figure read as good to the operator?
+3. **Loop cost** — total Gemini calls + Sonnet calls + paperbanana runs per accepted figure.
+
+## Phase 1: side-by-side instrumentation (what this PR ships)
+
+This PR adds the surface for an operator to run both critics on the same slide and capture both verdicts side-by-side. The flow:
+
+1. Operator marks a slide `academic_figure.critic: "claude"` AND `academic_figure.log_paperbanana_verdict_for_comparison: true`.
+2. Orchestrator runs the claude-critic loop (Step 4.6.1).
+3. For each iteration, paperbanana renders one image. Paperbanana's own VLM critic ALSO runs (we can't disable it in 0.1.2 — see #213/#214 upstream). Jack-tar parses paperbanana's verdict from stdout.
+4. The figure-critic agent receives the image + the paperbanana verdict in its input blob, with explicit "do NOT defer to this" language.
+5. The figure-critic returns its own verdict + a boolean `agrees_with_paperbanana_verdict`.
+6. Both verdicts persist in the manifest. Operator makes the final decision at the gate.
+
+Over many runs, the operator accumulates a data set of `(image, claude_verdict, paperbanana_verdict, agrees, operator_decision)` tuples.
+
+## The equivalence bar (what closes Phase 1)
+
+We promote Claude-critic to default when **all three** of the following hold across a representative sample (target: ≥15 academic_figure slides, ≥5 distinct figure types):
+
+### Bar 1 — agreement statistic
+
+`agrees_with_paperbanana_verdict == true` on **≥75%** of iterations.
+
+- 100% agreement would mean Claude is a redundant copy of paperbanana's verdict — useless.
+- <50% agreement would suggest one critic is systematically wrong (or they're orthogonally good, both signal worth keeping).
+- 75-90% is the sweet spot: substantial agreement on easy cases + meaningful disagreement on hard cases where Claude's judgement is the differentiator.
+
+### Bar 2 — operator-decision alignment
+
+When Claude and paperbanana disagree, **the operator agrees with Claude ≥60%** of the time.
+
+This is the load-bearing signal. The operator's "go / no-go" at the gate is the ground truth; whichever critic the operator agrees with more often is the better critic.
+
+A 60% bar (vs 50% / equal) requires Claude to be the *better* critic on disagreements, not merely as-good-as. We're not promoting Claude to default for parity; we're promoting it because it's measurably better.
+
+### Bar 3 — final-figure-quality regression
+
+Final accepted figures from the claude-critic path are **≥ as good** as the paperbanana-critic path on a blinded operator review. Specifically: present the operator a randomised pair of final figures (one from each path) and ask "which is better, or are they tied?" — Claude-critic path wins or ties on **≥50%** of pairs.
+
+The blinded review controls for confirmation bias — the operator might subconsciously prefer the path they spent more interactive time with.
+
+### Phase 1 sample-size minimum
+
+- **≥15 academic_figure slides** that completed the claude-critic loop with side-by-side logging enabled.
+- **≥5 distinct figure types** (architecture_diagram, equation, plot, table, algorithm_pseudocode, flowchart, other) represented.
+- **At least one slide per figure type** with operator-flagged disagreement.
+
+If after 15 slides we don't have disagreement on every figure type, extend to 25 slides or accept that some types are converged-on (both critics agree → either is fine).
+
+## Phase 2: promote Claude-critic to default
+
+When Phase 1 closes positively:
+
+1. Strategy schema default changes: `academic_figure.critic` defaults to `"claude"` (previously `"paperbanana"`).
+2. SKILL.md Step 4.6 (legacy paperbanana-critic path) moves to a "deprecated path" footnote; Step 4.6.1 becomes the canonical flow.
+3. Plugin version bump to 1.6.0 (minor — behaviour default change).
+4. Operator can still opt back to paperbanana-critic with `critic: "paperbanana"` for the slow-deprecation grace period (1-2 minor versions).
+
+When Phase 1 closes negatively (Claude-critic loses to paperbanana-critic on bars 1-3):
+
+1. Add the data set + analysis to this document.
+2. Keep paperbanana-critic as the default.
+3. Investigate: is the figure-critic agent definition off? Is Sonnet under-prompted? Move to Sonnet 4.7 / 5.x?
+4. Either iterate on figure-critic.md, or close out Path B as a methodology dead end and pursue Path C (collapse academic_figure into creative_vision).
+
+## Phase 3: deprecate paperbanana entirely (Path C)
+
+A more radical step. If during Phase 1/2 the operator finds that the figure-critic's prompt could be enriched to subsume paperbanana's academic-figure-aware prompting, we could skip paperbanana for the render step too — calling cloud-image directly. Out of scope for the current PR.
+
+The Phase 3 bar: figure-critic + cloud-image (no paperbanana) produces final figures that are ≥ paperbanana-rendered figures on a blinded operator review across all 7 figure types.
+
+## What to log per iteration
+
+The manifest entry for each iteration in the claude-critic loop SHOULD carry these fields for Phase 1 analysis (jack-tar writes this directly into the slide's image-manifest entry):
+
+```json
+{
+  "slide_number": 5,
+  "iteration_index": 2,
+  "image_path": "tmp/deck/images/run_20260527_120000_abc123/iter_2.png",
+  "paperbanana_run_id": "run_20260527_120000_abc123",
+  "figure_critic_verdict": {
+    "verdict": "refine",
+    "per_axis_scores": {"methodology_fidelity": 75, "caption_alignment": 80, "legibility": 70, "figure_type_correctness": 78, "aesthetic_quality": 82},
+    "refinement_feedback": "Add the missing 'Attention' block between Encoder and Decoder; the methodology lists three blocks, the figure shows two.",
+    "agrees_with_paperbanana_verdict": false
+  },
+  "paperbanana_side_by_side_verdict": {
+    "verdict": "pass",
+    "raw_score": 88,
+    "captured_from_stdout": true
+  },
+  "operator_decision": "refine",
+  "cumulative_cost_usd": 0.134
+}
+```
+
+The `operator_decision` field is the ground truth. Disagreement happens when:
+- `figure_critic_verdict.agrees_with_paperbanana_verdict == false`
+- AND the operator's decision matches one critic, not the other
+
+That's the bar-2 signal.
+
+## Practical operator workflow
+
+To run the equivalence test on a slide:
+
+```json
+{
+  "slide_number": 7,
+  "strategy": "academic_figure",
+  "academic_figure": {
+    "critic": "claude",
+    "figure_type": "architecture_diagram",
+    "iteration_cap": 5,
+    "log_paperbanana_verdict_for_comparison": true
+  }
+}
+```
+
+Run the imagegen-bridge. The Step 4.6.1 loop fires. Operator gates every iteration. The manifest accumulates the side-by-side data.
+
+After 15+ slides across multiple figure types, run the analysis (a small script TODO — landed in Phase 1.5):
+
+```bash
+PYTHONPATH=plugins/jack-tar-deckhand .venv/bin/python -m src.academic_figure_equivalence_report \
+  --deck-dir tmp/deck \
+  --output equivalence-report.md
+```
+
+The report tabulates per-figure-type agreement statistics and operator-decision alignment, and computes the bar-1 / bar-2 / bar-3 thresholds.
+
+## Why this matters
+
+The honest read from the original Path-B decision (PR #114 discussion):
+
+> "The deepest reason our integration hard-codes Gemini isn't technical — it's that paperbanana was framed as a 'sibling orchestrator, external CLI tool' per the ADR v2 framing. We treat it as a black box that owns its loop... The question 'why can't the critic be Claude?' is actually asking whether that black-box framing is right."
+
+Path B is the experiment. Equivalence testing is how we know whether the experiment landed. If Claude-critic measurably beats paperbanana-critic on a representative sample of academic figures, we got the framing right. If it doesn't, we go back to the black-box framing and find a different lever.
+
+Either way, the side-by-side surface this PR ships is reusable: it's the methodology for evaluating "should orchestrator-Claude be the critic for X" on any future paperbanana-like tool integration. The same shape would apply if we asked the same question about, say, an LLM-as-judge for SmartArt selection or a vision-language critic for full-bleed creative slides.
+
+## Open questions for Phase 1 dogfood
+
+1. **Can we reliably parse paperbanana's verdict from stdout?** Paperbanana's CLI uses `rich.console` for output. PR #186 (resume visualizer output fix) suggests the stdout format is in flux upstream. The `Output: <path>` line we already parse for the image path is stable; verdict capture would need a similar grep target. If unstable, fall back to running paperbanana's critic inspect-only OR omitting side-by-side logging.
+2. **Does Sonnet over-refine?** Creative_vision dogfood evidence suggests Sonnet critics can be too eager to refine when an image is already shippable. Watch the agreement statistic on the paperbanana-pass + claude-refine quadrant — that's the failure mode.
+3. **What's the operator-cost?** Each iteration is one paperbanana render + one Sonnet figure-critic call + one operator gate. For a 4-iteration loop that's 4 + 4 + 4 = 12 interactions per slide. Higher than v1.4.1's 1-2 interactions. Acceptable for high-stakes figures (a paper's hero diagram) but expensive for routine ones.
+4. **Should the equivalence-testing flag default on for the first 15 slides?** Or operator-explicit-only? Default-on would build the data set faster; explicit-only respects operator agency. Recommend explicit-only — operators opt into the cost.

--- a/plugins/jack-tar-deckhand/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-deckhand/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-deckhand",
-  "description": "Full presentation pipeline — brand, style, narrative, images, SmartArt, assembly, QA + academic-figure rendering (optional paperbanana CLI) + /iterate-slide single-slide critique-driven refinement + full_bleed image-is-the-slide strategy + creative vision renderer (#105) + creative_vision GA: per-slide cost surface, Creative Sprint phase, per-iteration operator gate, deck-level creative anchors (#113)",
-  "version": "1.5.1",
+  "description": "Full presentation pipeline — brand, style, narrative, images, SmartArt, assembly, QA + academic-figure rendering (optional paperbanana CLI) + /iterate-slide single-slide critique-driven refinement + full_bleed image-is-the-slide strategy + creative vision renderer (#105) + creative_vision GA: per-slide cost surface, Creative Sprint phase, per-iteration operator gate, deck-level creative anchors (#113) + academic_figure Claude-critic path (opt-in, equivalence-testing phase — figure-critic agent + paperbanana renders one image per iteration, jack-tar owns the loop)",
+  "version": "1.5.2",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-deckhand/agents/figure-critic.md
+++ b/plugins/jack-tar-deckhand/agents/figure-critic.md
@@ -1,0 +1,190 @@
+---
+name: figure-critic
+description: "Academic-figure quality gate. Evaluates a rendered figure against its methodology source + caption. Returns per-axis scores + verdict (pass | refine | escalate | abort) that drives jack-tar's academic_figure iteration loop. Replaces paperbanana's internal VLM critic in the Claude-critic path (issue #113 follow-up, Path B)."
+model: sonnet
+---
+
+# Figure Critic
+
+## Role
+
+You are the **Figure Critic** — the load-bearing decision-maker for the `academic_figure` cascade loop when jack-tar runs the Claude-critic path. Your single job is to evaluate a rendered academic figure against its methodology source + caption + (optional) figure type, and return a structured verdict the orchestrator uses to decide what happens next.
+
+You read:
+- The rendered image (you must look at it)
+- The methodology text (the operator's verbatim source — the paper section / draft prose / equations / pseudocode the figure should depict)
+- The caption (one-line communicative intent — e.g. "Figure 3: System architecture")
+- The figure type hint (one of: `architecture_diagram` | `equation` | `plot` | `table` | `algorithm_pseudocode` | `flowchart` | `other`)
+- Run history: chronological per-axis scores from prior iterations
+- The current iteration index
+
+You return a verdict the orchestrator uses to decide what happens next: continue iterating, accept the figure, or abort. You do NOT generate or revise prompts. You evaluate only.
+
+---
+
+## Why this agent exists
+
+Paperbanana ships its own VLM critic (Gemini Flash by default — see upstream PR #214 for the deprecated-defaults bug). For most academic figures it is competent. But:
+
+- It is downstream of the orchestrator (jack-tar is the conductor; paperbanana is a subprocess; the critic is downstream of paperbanana). Decisions made there are opaque to jack-tar's manifest and operator-gate flow.
+- It is gemini-only on PyPI 0.1.2. PR #212 (LiteLLM VLM provider) is on `main` but not yet released.
+- Jack-tar already runs Claude as the orchestrator for `creative_vision` slides (`directors-critic`); academic figures should get the same operator-paced review cadence.
+
+This agent moves the critic decision into jack-tar's loop. Paperbanana keeps doing what it is good at — academic-figure-aware image rendering — and you decide whether the result is good enough.
+
+---
+
+## Inputs
+
+You receive the following in every call:
+
+1. **Methodology source text** — verbatim, clearly labelled. The paper section / draft prose / equations / pseudocode the figure must depict.
+2. **Caption** — one-line communicative intent (e.g. "Figure 3: System architecture").
+3. **Figure type** — one of: `architecture_diagram`, `equation`, `plot`, `table`, `algorithm_pseudocode`, `flowchart`, `other`. Operator-provided; tunes which axes matter most.
+4. **Rendered image path** — the file path. You MUST visually inspect it before scoring.
+5. **Prior scores history** — chronological list of per-axis score dicts. Empty on iteration 1.
+6. **Iteration index** — integer ≥ 1.
+7. **Iteration cap** — integer; the maximum iterations the operator has authorised.
+8. **(Optional) Side-by-side paperbanana verdict** — when present, this is the verdict paperbanana's own VLM critic returned for the same image. Include it in your assessment but **do NOT defer to it** — your judgment is what the orchestrator uses. The paperbanana verdict is logged so the operator can compare critics during the equivalence-testing phase (see `docs/architecture/academic-figure-critic-equivalence.md`).
+
+---
+
+## Output Contract
+
+Return a **single fenced ` ```json ``` block** conforming to the `FigureCriticVerdict` schema at `plugins/jack-tar-deckhand/src/schemas/figure_critic_verdict.schema.json`.
+
+**No prose outside the fence.** No preamble. No explanation. Only the JSON block.
+
+Required keys:
+
+| Key | Type | Constraints |
+|-----|------|-------------|
+| `verdict` | string | `pass` \| `refine` \| `escalate` \| `abort` |
+| `per_axis_scores` | object | 5 keys: `methodology_fidelity`, `caption_alignment`, `legibility`, `figure_type_correctness`, `aesthetic_quality` — each integer 0–100 |
+| `issues` | array | Each item: `{"axis": string, "detail": string}`. Empty array `[]` only when `verdict == "pass"`. |
+| `refinement_feedback` | string | When `verdict == "refine"`: concrete, actionable feedback to pass to `paperbanana generate --continue-run --feedback "..."`. Empty string when `verdict != "refine"`. |
+| `iteration_index` | integer | Echo the iteration index from input. |
+| `plateau_signal` | boolean | True when no axis has improved ≥ 5 points in 2+ consecutive iterations. |
+| `agrees_with_paperbanana_verdict` | boolean or null | When a paperbanana side-by-side verdict was provided in the input, true iff your verdict has the same accept/reject polarity. Null when no side-by-side was provided. |
+
+---
+
+## Per-Axis Scoring Rubric
+
+Score each axis independently against the **methodology source + caption**, not the prior image.
+
+### methodology_fidelity (0–100)
+
+Does the figure accurately depict what the methodology text describes?
+
+- **100**: Every element in the methodology text (named blocks, equations, arrows, data points, citations) is present and correctly rendered.
+- **80–99**: All elements present; at most one minor ambiguity (e.g., an arrow direction is slightly ambiguous but a reasonable reader would still get it right).
+- **60–79**: All elements present but at least one is misrendered (wrong block order, wrong arrow direction, wrong constant in an equation).
+- **40–59**: One element from the methodology is missing or replaced by a similar but wrong element.
+- **10–39**: Multiple elements missing or wrong.
+- **0–9**: The figure bears no resemblance to the methodology.
+
+### caption_alignment (0–100)
+
+Does the figure depict what its caption claims?
+
+- **100**: Caption and figure agree exactly. A reader could write the caption from the figure alone.
+- **80–99**: Caption and figure agree; minor framing difference (caption says "System architecture", figure shows the architecture but emphasises one component).
+- **60–79**: Caption and figure agree on the subject but the focus is wrong (caption emphasises X, figure emphasises Y).
+- **40–59**: Caption and figure disagree on at least one key claim.
+- **0–39**: Caption and figure are incompatible.
+
+### legibility (0–100)
+
+Can a reader actually read the figure on a presentation slide?
+
+- **100**: All text (labels, axis labels, equation symbols, citations) is clearly legible at slide scale. Lines are crisp. Symbols are unambiguous.
+- **80–99**: All critical text legible; secondary text (e.g., footnotes within the figure) slightly small but readable.
+- **60–79**: Most text legible; one or two labels garbled or too small (a reader would have to zoom in).
+- **40–59**: Critical labels are illegible OR equation symbols are wrong/garbled (e.g., `Σ` rendered as a similar-but-wrong glyph).
+- **0–39**: Figure is largely unreadable.
+
+### figure_type_correctness (0–100)
+
+Does the figure conform to the conventions of its declared figure type?
+
+- **architecture_diagram**: blocks + arrows + labelled connections. Score 100 if the topology is correct; lower if blocks are missing or arrows go the wrong way.
+- **equation**: rendered as a mathematical equation, not free prose. LaTeX-quality symbols. Score 100 if it could be transcribed back to LaTeX.
+- **plot**: axes with labels + tick marks + units; data line/bars/points; legend if multiple series. Score 100 if axis labels match the methodology's variable names.
+- **table**: cells aligned, headers present, values from the methodology. Score 100 if values match.
+- **algorithm_pseudocode**: numbered or indented steps, mathematical notation correct, control flow clear.
+- **flowchart**: nodes + decision diamonds + arrows. Score 100 if the flow matches the methodology's described process.
+- **other**: score against a sensible interpretation of the methodology.
+
+### aesthetic_quality (0–100)
+
+Slide-projection ready? No artefacts, no fingerprints of generation-AI failure modes?
+
+- **100**: Clean rendering, consistent line weights, good use of whitespace, no obvious AI-generation artefacts (no melted text, no spurious extra arrows, no garbled background).
+- **80–99**: One small artefact that wouldn't be noticed at a glance.
+- **60–79**: Visible artefacts but the figure still communicates.
+- **40–59**: Significant artefacts; presentation would be embarrassing.
+- **0–39**: Unshippable.
+
+---
+
+## Verdict Decision Logic
+
+Pick exactly one verdict per call.
+
+| Verdict | When |
+|---------|------|
+| `pass` | Every axis ≥ 80 AND no critical-method element is missing. Image is shippable as-is. |
+| `refine` | At least one axis < 80 AND the gap is addressable through prompt refinement (e.g., add a missing block, fix a label, redraw the arrow). Iteration count has not exceeded `iteration_cap`. Provide `refinement_feedback`. |
+| `escalate` | At least one axis < 80 AND the gap is NOT addressable through prompt refinement (e.g., the image generator can't render the LaTeX symbol at this resolution; methodology asks for something the model can't produce). The orchestrator may escalate to a higher-quality image provider or surface to the operator. |
+| `abort` | The methodology itself is malformed (e.g., references a figure that doesn't exist in the source text) OR iteration cap reached without convergence AND no axis is improving. The operator must intervene. |
+
+**Hard rule**: `verdict == "pass"` requires the minimum per-axis score to be ≥ 80. If your minimum score is < 80, your verdict MUST NOT be `pass`. The schema validator enforces this; do not try to fake it.
+
+`refinement_feedback` is what we pass directly to paperbanana's `--continue-run --feedback`. Write it as concrete imperatives ("Increase the size of the 'Encoder' block by 30%. Add a labelled arrow from 'Encoder' to 'Attention'. Remove the spurious 'Output' block that appears bottom-left."). Avoid vague feedback ("make it clearer"). Paperbanana's image regenerator uses this string verbatim.
+
+---
+
+## Iteration discipline
+
+You SEE the run history. Use it.
+
+- If `iteration_index` is 1 and any score is ≥ 80, lean toward `pass` if all five are ≥ 80, `refine` otherwise.
+- If `iteration_index` ≥ 3 and `plateau_signal` is true, lean toward `escalate` or `abort` — paperbanana's renderer is at its tier ceiling for this figure.
+- If `iteration_cap` is hit and no axis is ≥ 80, return `abort` with `plateau_signal: true`. The operator gets to choose: accept the best-so-far image, swap image provider, or rewrite the methodology.
+
+Set `plateau_signal: true` when no axis has improved ≥ 5 points in 2+ consecutive prior iterations. This signals that further iteration at the current path is unlikely to help.
+
+---
+
+## Equivalence-testing posture
+
+This agent is being run side-by-side with paperbanana's internal VLM critic during the equivalence-testing phase. You may be given the paperbanana verdict in your input.
+
+- **Do NOT defer to paperbanana's verdict.** Your judgment is what the orchestrator uses.
+- **Do log whether you agree.** Set `agrees_with_paperbanana_verdict: true` iff your accept/reject polarity matches (you both pass, or you both don't-pass — the specific refine/escalate/abort breakdown doesn't have to match).
+- The operator uses the agreement statistic across many runs to decide whether to deprecate the paperbanana critic.
+
+If you systematically disagree with paperbanana, that's signal. Don't smooth it over.
+
+---
+
+## Anti-patterns
+
+- **Don't grade against the prior image.** Score against the methodology + caption. The prior image is for context only.
+- **Don't accept a passing-looking figure with a missing methodology element.** Methodology fidelity is the load-bearing axis.
+- **Don't refine on tier limits.** If the model can't render readable LaTeX at the current image provider, escalate. Don't ask paperbanana to "try harder".
+- **Don't dump general advice into `refinement_feedback`.** It goes verbatim into paperbanana's regenerator. Concrete imperatives only.
+- **Don't pass with one axis below 80.** Schema enforces it; the manifest records it; the operator notices.
+
+---
+
+## Cross-references
+
+- Schema: `plugins/jack-tar-deckhand/src/schemas/figure_critic_verdict.schema.json`
+- Dispatch helper: `plugins/jack-tar-deckhand/src/academic_figure_critic.py`
+- Orchestrator branch: imagegen-bridge SKILL.md Step 4.6.1
+- Sibling agents: `directors-critic.md` (creative_vision), `image-reviewer.md` (generic per-image)
+- ADR: `docs/architecture/paperbanana-integration-v2.md`
+- Equivalence methodology: `docs/architecture/academic-figure-critic-equivalence.md`
+- Upstream paperbanana issues that motivated this work: #213 (pricing), #214 (deprecated defaults), #216 (PyPI staleness)

--- a/plugins/jack-tar-deckhand/skills/imagegen-bridge/SKILL.md
+++ b/plugins/jack-tar-deckhand/skills/imagegen-bridge/SKILL.md
@@ -212,6 +212,22 @@ not a Claude Code plugin or a cross-skill dispatch target. See
 `docs/architecture/paperbanana-integration-v2.md` for the framing
 rationale.
 
+**Two critic paths exist for academic_figure** (issue #113 Path B —
+equivalence-testing phase):
+
+- **paperbanana-critic (default)** — paperbanana owns the iteration loop;
+  its internal Gemini VLM critic decides accept/refine. The v1.4.1
+  behaviour. This is Step 4.6 below.
+- **claude-critic (opt-in)** — jack-tar owns the loop; paperbanana
+  renders one image per iteration (`--iterations 1`); the `figure-critic`
+  agent (Sonnet) decides accept/refine; refine path uses
+  `--continue-run --feedback`. Operator gates fire at every iteration
+  (F12 cadence). See **Step 4.6.1** below.
+
+Branch on the slide's `academic_figure.critic` field
+(`is_claude_critic_path(slide)` in `paperbanana_dispatch.py`). Default
+is `paperbanana` so existing decks are unchanged.
+
 The dispatch decision is built by `src/paperbanana_dispatch.py`. Use
 it from the bridge as the single source of truth — do NOT duplicate
 the availability check inline.
@@ -341,6 +357,196 @@ print(json.dumps(entry))
 > `jack-tar-deckhand:image-reviewer` subagent (Haiku, JSON verdict) or
 > the `general-purpose` subagent (Sonnet, higher accuracy). Both
 > subagents pull the image into THEIR context and return text.
+
+### Step 4.6.1: Academic Figure Dispatch — Claude-critic path (issue #113 Path B)
+
+When the slide's `academic_figure.critic` field is `"claude"` (opt-in
+during the equivalence-testing phase), jack-tar takes the iteration loop
+back from paperbanana:
+
+- **paperbanana** still renders one image per cascade step (via
+  `--iterations 1`). Paperbanana's academic-figure-aware prompting is
+  exactly what we want to keep.
+- **figure-critic** (Sonnet) decides whether to accept, refine,
+  escalate, or abort.
+- **operator gate** fires at every iteration regardless of cost (F12
+  elevated cadence, same as creative_vision slides).
+- **refine path** dispatches paperbanana again with `--continue-run
+  <run_id> --feedback "<figure-critic's refinement_feedback>"`.
+- **iteration cap** is the slide's `academic_figure.iteration_cap`
+  (default 4) — counted in jack-tar's loop, NOT paperbanana's.
+
+Branch into this path BEFORE invoking the v1.4.1 paperbanana-critic
+path:
+
+```python
+from src.paperbanana_dispatch import is_claude_critic_path
+if is_claude_critic_path(slide):
+    # run Step 4.6.1 loop
+else:
+    # run Step 4.6 (legacy paperbanana-critic) — unchanged
+```
+
+#### The loop
+
+For each `academic_figure` slide with `critic: claude`:
+
+**Step A — initial render**
+
+```python
+from src.paperbanana_dispatch import (
+    build_initial_dispatch_args_for_claude_critic,
+    get_iteration_cap,
+    get_figure_type,
+    should_log_paperbanana_verdict,
+)
+args = build_initial_dispatch_args_for_claude_critic(slide)
+iteration_cap = get_iteration_cap(slide)
+figure_type = get_figure_type(slide)
+log_paperbanana_verdict = should_log_paperbanana_verdict(slide)
+```
+
+Invoke `paperbanana generate` with these args (writing methodology to a
+tmp file, passing it via `--input <file>`, the rest via the CLI flags
+in Step 4.6). Parse the output path from paperbanana's stdout:
+
+```bash
+PB_FILE=$(echo "$PB_OUTPUT" | grep -oE 'Output: [^ ]+' | head -1 | cut -d' ' -f2)
+```
+
+The `--iterations 1` flag means paperbanana renders ONE image and
+returns. Paperbanana's VLM critic will still run once internally (we
+pay one VLM call) but we ignore its verdict; jack-tar makes the
+decision.
+
+**Step B — operator gate (F12 cadence — MANDATORY every iteration)**
+
+Open the rendered image for the operator (`open $PB_FILE` on macOS).
+State the current iteration index, cumulative slide spend, and what
+the figure-critic will be asked to assess. **Wait for explicit
+operator go-ahead** before invoking the figure-critic dispatch.
+
+This gate is the load-bearing economic AND quality checkpoint of the
+claude-critic loop. Per F12, the operator MUST see every render
+regardless of cost transition. Same rationale as creative_vision Step
+H.1.
+
+**Step C — figure-critic dispatch**
+
+```python
+from src.academic_figure_critic import build_critic_input, parse_critic_output, decide_next_action
+
+# Optional: capture paperbanana's verdict from its stdout for side-by-side
+# logging during the equivalence-testing phase
+pb_verdict = parse_paperbanana_verdict_from_stdout(PB_OUTPUT) if log_paperbanana_verdict else None
+
+blob = build_critic_input(
+    methodology_text=slide_methodology_text,
+    caption=slide_caption,
+    figure_type=figure_type,
+    image_path=PB_FILE,
+    prior_scores_history=manifest["iterations"],  # chronological score dicts
+    iteration_index=current_iter,
+    iteration_cap=iteration_cap,
+    paperbanana_side_by_side_verdict=pb_verdict,
+)
+```
+
+Dispatch the `figure-critic` agent (Sonnet) with that input. Parse the
+response via `parse_critic_output` — this performs:
+
+- JSON parse + schema validation (FigureCriticVerdict schema)
+- Semantic checks: `pass` requires every axis ≥ 80; `refine` requires
+  non-empty `refinement_feedback`; `pass`/`refine` polarity rules
+
+Schema or semantic failures raise `ValueError` with a concrete error
+message. Re-dispatch the agent with the error in feedback (the F1
+schema-validation retry pattern).
+
+**Step D — decide next action**
+
+```python
+action = decide_next_action(verdict, iteration_index=current_iter, iteration_cap=iteration_cap)
+```
+
+The state machine returns one of:
+
+- `accept` — finalise the slide. Use this image as the final output.
+- `refine` — call paperbanana again with `--continue-run --feedback`.
+  Increment iteration counter. Loop back to Step A (well, Step B —
+  paperbanana renders the refinement and we gate again).
+- `escalate` — the figure-critic judged that prompt refinement can't
+  fix this slide. Surface to operator; they may switch image provider
+  or accept the best-so-far.
+- `abort` — iteration cap reached without convergence OR critic
+  returned `abort` (methodology malformed). Surface to operator.
+
+**Step E — refine path (when action == refine)**
+
+```python
+from src.paperbanana_dispatch import build_continue_run_dispatch_args
+continue_args = build_continue_run_dispatch_args(
+    paperbanana_run_id=manifest["latest_run_id"],
+    feedback=action["refinement_feedback"],
+)
+```
+
+Invoke `paperbanana generate --continue-run <run_id> --feedback
+"<feedback>"` with these args. The feedback string flows in verbatim;
+the run_id ties the refinement to paperbanana's existing run directory.
+
+Loop back to Step B (operator gate fires for the refinement render
+too).
+
+**Step F — manifest**
+
+Each iteration appends to the slide's manifest:
+
+```python
+manifest["iterations"].append({
+    "iteration_index": current_iter,
+    "image_path": PB_FILE,
+    "paperbanana_run_id": run_id,
+    "figure_critic_verdict": verdict,
+    "paperbanana_side_by_side_verdict": pb_verdict,  # null when not logging
+    "operator_decision": "accept" | "refine" | "escalate" | "abort",
+    "cumulative_cost_usd": cumulative,
+})
+```
+
+The side-by-side paperbanana verdict (when logged) is the input to the
+equivalence-testing analysis — see
+`docs/architecture/academic-figure-critic-equivalence.md`.
+
+#### Bypass conditions
+
+- Slide has no `academic_figure` block, or `critic: paperbanana`. Run
+  Step 4.6 (legacy path) unchanged.
+- `paperbanana_available` is False. Fall back to the cloud-image path
+  (Step 4.6 already handles this — the claude-critic loop also depends
+  on paperbanana for the render step).
+
+#### Discipline-hook rule (in force)
+
+Never `Read` a generated PNG in the orchestration session. Always
+dispatch a subagent (figure-critic itself, image-reviewer, or
+general-purpose) to evaluate. The bypass `ALLOW_PNG_READ=1` does not
+apply here — the figure-critic IS the dispatch that reads the image.
+
+> Do not `Read` PNG / JPG / GIF / WEBP / BMP / TIFF files directly.
+> If you need to verify an image, dispatch the
+> `jack-tar-deckhand:image-reviewer` subagent (Haiku, JSON verdict) or
+> the `general-purpose` subagent (Sonnet, higher accuracy). Both
+> subagents pull the image into THEIR context and return text.
+
+#### Cross-references
+
+- Schema: `plugins/jack-tar-deckhand/src/schemas/figure_critic_verdict.schema.json`
+- Dispatch helpers: `plugins/jack-tar-deckhand/src/academic_figure_critic.py`
+- Paperbanana CLI helpers (claude-critic block): `plugins/jack-tar-deckhand/src/paperbanana_dispatch.py`
+- Agent definition: `plugins/jack-tar-deckhand/agents/figure-critic.md`
+- Equivalence-testing methodology: `docs/architecture/academic-figure-critic-equivalence.md`
+- Sibling cascade: Step 4.7 (creative_vision) — same operator-gate cadence; same critic-as-Claude pattern
 
 ### Step 4.7: Creative Vision Dispatch (multi-agent cascade loop)
 

--- a/plugins/jack-tar-deckhand/src/academic_figure_critic.py
+++ b/plugins/jack-tar-deckhand/src/academic_figure_critic.py
@@ -1,0 +1,261 @@
+"""Figure Critic agent dispatch helpers — academic_figure Claude-critic path.
+
+Issue #113 follow-up, Path B. When a slide is marked ``strategy: academic_figure``
+AND ``academic_figure_critic: "claude"``, jack-tar's imagegen-bridge runs the
+following loop INSTEAD of paperbanana's internal VLM-critic loop:
+
+    1. paperbanana renders ONE image (--iterations 1)
+    2. dispatch ``figure-critic`` (Sonnet) with this module's helpers
+    3. operator gate (F12 cadence — every iteration)
+    4. on refine: paperbanana --continue-run --feedback "<refinement_feedback>"
+    5. loop until pass / abort / iteration_cap
+
+This module owns the contract between the orchestrator and the agent dispatch:
+input-blob builder + response parser + schema validator + per-axis sanity
+checks. The schema validator catches malformed agent output at the boundary
+(parallel to the F1 schema-validation fix in ``creative_vision/brief.py``).
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from jsonschema import ValidationError, validate
+
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parent / "schemas" / "figure_critic_verdict.schema.json"
+)
+
+
+def _load_schema() -> dict:
+    with open(_SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+_VALID_FIGURE_TYPES = {
+    "architecture_diagram",
+    "equation",
+    "plot",
+    "table",
+    "algorithm_pseudocode",
+    "flowchart",
+    "other",
+}
+
+
+def build_critic_input(
+    methodology_text: str,
+    caption: str,
+    figure_type: str,
+    image_path: str,
+    prior_scores_history: list[dict],
+    iteration_index: int,
+    iteration_cap: int,
+    *,
+    paperbanana_side_by_side_verdict: dict | None = None,
+) -> str:
+    """Compose the input blob for the figure-critic agent dispatch.
+
+    Args:
+        methodology_text: Operator's verbatim methodology / source text the
+            figure should depict. NOT paraphrased.
+        caption: One-line communicative intent ("Figure 3: System architecture").
+        figure_type: One of the canonical types — see :data:`_VALID_FIGURE_TYPES`.
+            Tunes which scoring axes weigh most.
+        image_path: Path to the rendered image the agent will read.
+        prior_scores_history: Chronological per-iteration score dicts. Empty
+            on iteration 1.
+        iteration_index: 1-based. Echoed back in the verdict.
+        iteration_cap: Max iterations the operator authorised. The agent uses
+            this to decide whether `refine` is still allowed or `abort` is the
+            honest call.
+        paperbanana_side_by_side_verdict: Optional. When the operator is
+            running the equivalence-testing phase, the paperbanana VLM's own
+            verdict for the same image is included so the agent can record
+            whether its decision agrees. Does NOT influence the agent's
+            verdict; logged only.
+
+    Raises:
+        ValueError: When ``figure_type`` is not a canonical value. The agent
+            contract requires a known type; ambiguous input would yield
+            unpredictable scoring.
+    """
+    if figure_type not in _VALID_FIGURE_TYPES:
+        raise ValueError(
+            f"figure_type={figure_type!r} is not valid. "
+            f"Allowed: {sorted(_VALID_FIGURE_TYPES)}"
+        )
+
+    sections = [
+        "# Methodology source (VERBATIM):",
+        methodology_text.strip(),
+        "",
+        f"# Caption: {caption.strip()}",
+        f"# Figure type: {figure_type}",
+        "",
+        f"# Image to evaluate: {image_path}",
+        f"# Iteration index: {iteration_index}",
+        f"# Iteration cap: {iteration_cap}",
+        "",
+        "# Prior score history (chronological, most recent last):",
+        "```json",
+        json.dumps(prior_scores_history, indent=2),
+        "```",
+    ]
+
+    if paperbanana_side_by_side_verdict is not None:
+        sections += [
+            "",
+            "# Paperbanana side-by-side verdict (equivalence-testing only):",
+            "# (Do NOT defer to this. Your verdict is what the orchestrator uses.)",
+            "```json",
+            json.dumps(paperbanana_side_by_side_verdict, indent=2),
+            "```",
+        ]
+
+    sections += [
+        "",
+        "Return a single fenced ```json``` block conforming to the FigureCriticVerdict schema.",
+    ]
+    return "\n".join(sections)
+
+
+_FENCE_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+
+
+def parse_critic_output(agent_response: str) -> dict:
+    """Extract + validate the figure-critic verdict from the agent's response.
+
+    Validates against ``figure_critic_verdict.schema.json`` and applies semantic
+    checks that the schema can't express:
+
+    - ``verdict == "pass"`` requires every per-axis score >= 80.
+    - ``verdict != "pass"`` requires at least one issue.
+    - ``verdict == "refine"`` requires non-empty ``refinement_feedback``.
+    - ``verdict != "refine"`` requires empty ``refinement_feedback``.
+
+    Raises:
+        ValueError: When the response is missing the fence, malformed JSON,
+            fails schema validation, or violates any of the semantic checks.
+    """
+    m = _FENCE_RE.search(agent_response)
+    if m is None:
+        raise ValueError("figure-critic response missing ```json``` fence")
+    try:
+        payload = json.loads(m.group(1))
+    except json.JSONDecodeError as e:
+        raise ValueError(f"figure-critic JSON parse failed: {e}") from e
+
+    try:
+        validate(instance=payload, schema=_load_schema())
+    except ValidationError as e:
+        path = "/" + "/".join(str(p) for p in e.absolute_path)
+        raise ValueError(
+            f"figure-critic verdict failed schema at {path}: {e.message}"
+        ) from e
+
+    _validate_verdict_score_coherence(payload)
+    _validate_verdict_issues_coherence(payload)
+    _validate_refinement_feedback_coherence(payload)
+
+    return payload
+
+
+def _validate_verdict_score_coherence(payload: dict) -> None:
+    """Enforce: verdict='pass' requires every axis >= 80.
+
+    Mirrors the F3 fix proposed for directors-critic — the schema validator
+    can't express cross-field invariants, so this semantic check pairs with
+    schema validation.
+    """
+    verdict = payload["verdict"]
+    scores = payload["per_axis_scores"]
+    min_score = min(scores.values())
+    if verdict == "pass" and min_score < 80:
+        raise ValueError(
+            f"figure-critic verdict=pass but min axis score is {min_score} < 80; "
+            f"the schema requires every axis >= 80 for a pass verdict."
+        )
+
+
+def _validate_verdict_issues_coherence(payload: dict) -> None:
+    """Enforce: verdict != 'pass' must have at least one issue; pass must have none."""
+    verdict = payload["verdict"]
+    issues = payload["issues"]
+    if verdict == "pass" and issues:
+        raise ValueError(
+            "figure-critic verdict=pass but issues array is non-empty; "
+            "pass requires no issues."
+        )
+    if verdict != "pass" and not issues:
+        raise ValueError(
+            f"figure-critic verdict={verdict} but issues array is empty; "
+            f"non-pass verdicts require at least one issue naming the failing axis."
+        )
+
+
+def _validate_refinement_feedback_coherence(payload: dict) -> None:
+    """Enforce: refinement_feedback non-empty iff verdict=='refine'."""
+    verdict = payload["verdict"]
+    feedback = payload["refinement_feedback"]
+    if verdict == "refine" and not feedback.strip():
+        raise ValueError(
+            "figure-critic verdict=refine but refinement_feedback is empty; "
+            "refine requires concrete imperatives passed verbatim to paperbanana."
+        )
+    if verdict != "refine" and feedback.strip():
+        raise ValueError(
+            f"figure-critic verdict={verdict} but refinement_feedback is non-empty; "
+            f"refinement_feedback is only meaningful when verdict=='refine'."
+        )
+
+
+def decide_next_action(
+    verdict_payload: dict,
+    *,
+    iteration_index: int,
+    iteration_cap: int,
+) -> dict:
+    """Return the next action for the orchestrator based on the critic verdict.
+
+    This is the small state machine that translates a critic verdict into
+    "what should the orchestrator do next?" — equivalent to
+    ``creative_vision.orchestrator.decide_next_action`` but for the academic-
+    figure cascade.
+
+    Returns:
+        Dict with keys:
+        - ``action``: one of ``"accept"``, ``"refine"``, ``"escalate"``, ``"abort"``
+        - ``reason``: short string explaining the choice
+        - ``refinement_feedback``: present iff action == "refine"; the string
+          to pass to ``paperbanana generate --continue-run --feedback``
+    """
+    verdict = verdict_payload["verdict"]
+
+    if verdict == "pass":
+        return {"action": "accept", "reason": "all axes >= 80 (pass verdict)"}
+
+    if verdict == "abort":
+        return {"action": "abort", "reason": "critic returned abort verdict"}
+
+    if verdict == "escalate":
+        return {
+            "action": "escalate",
+            "reason": "critic returned escalate (gap not addressable by prompt refinement)",
+        }
+
+    # verdict == "refine"
+    if iteration_index >= iteration_cap:
+        return {
+            "action": "abort",
+            "reason": (
+                f"iteration_cap {iteration_cap} reached without convergence; "
+                f"critic still wanted to refine. Operator must intervene."
+            ),
+        }
+    return {
+        "action": "refine",
+        "reason": "critic returned refine; iteration cap not reached",
+        "refinement_feedback": verdict_payload["refinement_feedback"],
+    }

--- a/plugins/jack-tar-deckhand/src/paperbanana_dispatch.py
+++ b/plugins/jack-tar-deckhand/src/paperbanana_dispatch.py
@@ -354,3 +354,128 @@ def build_manifest_entry(
     if error is not None:
         entry["error"] = error
     return entry
+
+
+# ---------------------------------------------------------------------------
+# Claude-critic path helpers (issue #113 follow-up, Path B)
+#
+# When a slide is marked ``strategy: academic_figure`` AND
+# ``academic_figure.critic: "claude"``, jack-tar drives the iteration loop
+# instead of paperbanana's internal VLM critic. Paperbanana renders one
+# image per iteration (--iterations 1) and jack-tar dispatches the
+# ``figure-critic`` agent for the verdict + decides next action.
+#
+# The helpers below construct the paperbanana CLI args for each phase:
+# - is_claude_critic_path: predicate on the slide entry
+# - build_initial_dispatch_args_for_claude_critic: first render args
+# - build_continue_run_dispatch_args: --continue-run --feedback args
+# ---------------------------------------------------------------------------
+
+
+def is_claude_critic_path(slide: Mapping) -> bool:
+    """Return True when the slide opts into the Claude-critic academic_figure path.
+
+    The opt-in is via the slide's ``academic_figure.critic`` field. Defaults to
+    False (paperbanana-critic path — v1.4.1 behaviour) unless explicitly set
+    to ``"claude"``. Slides without an ``academic_figure`` block at all also
+    return False — they get the legacy default path.
+    """
+    if slide.get("strategy") != "academic_figure":
+        return False
+    cfg = slide.get("academic_figure")
+    if not isinstance(cfg, Mapping):
+        return False
+    return cfg.get("critic") == "claude"
+
+
+def build_initial_dispatch_args_for_claude_critic(slide: Mapping) -> dict:
+    """Build paperbanana CLI args for the first render in the Claude-critic loop.
+
+    Forces ``iterations=1`` regardless of any per-slide override so paperbanana
+    renders exactly one image per cascade step. Jack-tar's loop then dispatches
+    the figure-critic and (on refine) calls back with ``--continue-run``.
+
+    Note: paperbanana will still invoke its own VLM critic ONCE per render
+    (paperbanana has no render-only mode in 0.1.2 / current main). Jack-tar
+    ignores paperbanana's verdict; figure-critic owns the decision. When the
+    operator has enabled ``log_paperbanana_verdict_for_comparison``, the
+    bridge captures paperbanana's verdict from stdout for side-by-side
+    logging.
+    """
+    args = {
+        "source_context": _build_source_context_from_slide(slide),
+        "caption": _build_caption_from_slide(slide),
+        "aspect_ratio": "16:9",
+        "iterations": 1,
+    }
+    return args
+
+
+def build_continue_run_dispatch_args(
+    *,
+    paperbanana_run_id: str,
+    feedback: str,
+) -> dict:
+    """Build paperbanana CLI args for a continue-run refinement step.
+
+    Called by the orchestrator after figure-critic returns ``verdict: refine``
+    with ``refinement_feedback``. The feedback string flows into paperbanana
+    verbatim via ``--feedback``; the run_id ties the refinement to the
+    previously written run directory.
+
+    Always sets ``iterations: 1`` so paperbanana renders exactly one new image
+    per refinement step (loop control stays in jack-tar).
+
+    Raises:
+        ValueError: When ``paperbanana_run_id`` is empty or ``feedback`` is
+            blank. Both are required for a meaningful continue-run.
+    """
+    if not paperbanana_run_id.strip():
+        raise ValueError("paperbanana_run_id must be non-empty for --continue-run")
+    if not feedback.strip():
+        raise ValueError(
+            "feedback must be non-empty for --continue-run; figure-critic "
+            "is contractually required to provide refinement_feedback on a "
+            "refine verdict."
+        )
+    return {
+        "continue_run": paperbanana_run_id.strip(),
+        "feedback": feedback.strip(),
+        "iterations": 1,
+    }
+
+
+def get_iteration_cap(slide: Mapping) -> int:
+    """Return the iteration cap for the slide's Claude-critic loop.
+
+    Reads ``academic_figure.iteration_cap`` (default 4 per the schema). Used
+    by the orchestrator + figure-critic to decide when to abort.
+    """
+    cfg = slide.get("academic_figure")
+    if isinstance(cfg, Mapping) and isinstance(cfg.get("iteration_cap"), int):
+        return cfg["iteration_cap"]
+    return 4  # mirrors schema default
+
+
+def get_figure_type(slide: Mapping) -> str:
+    """Return the figure type hint for the slide. Defaults to 'other'."""
+    cfg = slide.get("academic_figure")
+    if isinstance(cfg, Mapping) and isinstance(cfg.get("figure_type"), str):
+        return cfg["figure_type"]
+    return "other"
+
+
+def should_log_paperbanana_verdict(slide: Mapping) -> bool:
+    """Return True when the slide opts into side-by-side critic comparison.
+
+    Only meaningful when ``critic: claude``. When True, the orchestrator
+    captures paperbanana's own VLM verdict from stdout (or runs paperbanana's
+    critic in inspect-only mode) so the manifest carries both critics'
+    verdicts. Used during the equivalence-testing phase.
+    """
+    if not is_claude_critic_path(slide):
+        return False
+    cfg = slide.get("academic_figure")
+    if isinstance(cfg, Mapping):
+        return bool(cfg.get("log_paperbanana_verdict_for_comparison", False))
+    return False

--- a/plugins/jack-tar-deckhand/src/schemas/figure_critic_verdict.schema.json
+++ b/plugins/jack-tar-deckhand/src/schemas/figure_critic_verdict.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://jack-tar.dev/schemas/figure-critic-verdict.json",
+  "title": "FigureCriticVerdict",
+  "description": "Verdict returned by Figure Critic after evaluating a rendered academic figure against its methodology source + caption. Drives the academic_figure iteration loop on the Claude-critic path (issue #113 follow-up, Path B).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "verdict",
+    "per_axis_scores",
+    "issues",
+    "refinement_feedback",
+    "iteration_index",
+    "plateau_signal",
+    "agrees_with_paperbanana_verdict"
+  ],
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "enum": ["pass", "refine", "escalate", "abort"],
+      "description": "Decision the orchestrator acts on. `pass` requires every per_axis_score >= 80."
+    },
+    "per_axis_scores": {
+      "type": "object",
+      "required": [
+        "methodology_fidelity",
+        "caption_alignment",
+        "legibility",
+        "figure_type_correctness",
+        "aesthetic_quality"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "methodology_fidelity": {"type": "integer", "minimum": 0, "maximum": 100},
+        "caption_alignment": {"type": "integer", "minimum": 0, "maximum": 100},
+        "legibility": {"type": "integer", "minimum": 0, "maximum": 100},
+        "figure_type_correctness": {"type": "integer", "minimum": 0, "maximum": 100},
+        "aesthetic_quality": {"type": "integer", "minimum": 0, "maximum": 100}
+      }
+    },
+    "issues": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["axis", "detail"],
+        "additionalProperties": false,
+        "properties": {
+          "axis": {"type": "string"},
+          "detail": {"type": "string"}
+        }
+      },
+      "description": "Empty array iff verdict == 'pass'. Otherwise at least one item naming the failing axis + the specific gap."
+    },
+    "refinement_feedback": {
+      "type": "string",
+      "description": "Concrete imperative feedback passed verbatim to `paperbanana generate --continue-run --feedback`. Empty string when verdict != 'refine'."
+    },
+    "iteration_index": {"type": "integer", "minimum": 1},
+    "plateau_signal": {
+      "type": "boolean",
+      "description": "True when no axis has improved >=5 points in 2+ consecutive prior iterations. Signal for the orchestrator to consider escalation or abort."
+    },
+    "agrees_with_paperbanana_verdict": {
+      "type": ["boolean", "null"],
+      "description": "When a paperbanana side-by-side verdict was provided in the dispatch input, true iff this verdict's accept/reject polarity matches. Null when no side-by-side was provided. Used during the equivalence-testing phase."
+    }
+  }
+}

--- a/plugins/jack-tar-deckhand/src/schemas/strategy_map.schema.json
+++ b/plugins/jack-tar-deckhand/src/schemas/strategy_map.schema.json
@@ -105,6 +105,37 @@
               }
             }
           },
+          "academic_figure": {
+            "type": "object",
+            "description": "Optional block for slides with strategy='academic_figure'. When omitted, the legacy paperbanana-owned-loop path runs unchanged. When `critic: claude` is set, jack-tar's Claude-critic loop runs instead — paperbanana renders one image, figure-critic decides next action, operator gates every iteration (issue #113 follow-up, Path B).",
+            "additionalProperties": false,
+            "properties": {
+              "critic": {
+                "type": "string",
+                "enum": ["paperbanana", "claude"],
+                "default": "paperbanana",
+                "description": "Which critic decides whether the rendered figure is acceptable. `paperbanana` keeps the v1.4.1 behaviour (paperbanana's internal VLM critic owns the loop). `claude` invokes the figure-critic agent and runs the loop in jack-tar — paperbanana renders one image per iteration via --iterations 1, claude decides, refine path uses --continue-run --feedback. During the equivalence-testing phase the operator may toggle this per-slide to compare critics side by side."
+              },
+              "figure_type": {
+                "type": "string",
+                "enum": ["architecture_diagram", "equation", "plot", "table", "algorithm_pseudocode", "flowchart", "other"],
+                "default": "other",
+                "description": "Figure type hint passed to figure-critic. Tunes which scoring axes weigh most. Optional; defaults to 'other' which scores against a sensible interpretation of the methodology."
+              },
+              "iteration_cap": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 10,
+                "default": 4,
+                "description": "Max iterations the orchestrator runs before aborting. Counted across paperbanana renders. Operator-tunable per slide; defaults to 4 (matches paperbanana's --iterations default in v1.4.1)."
+              },
+              "log_paperbanana_verdict_for_comparison": {
+                "type": "boolean",
+                "default": false,
+                "description": "When true AND `critic: claude`, jack-tar additionally captures paperbanana's own VLM verdict on each iteration (running paperbanana's critic in inspect-only mode, no decision authority) so the manifest carries both critics' verdicts side-by-side for equivalence analysis. Costs one extra VLM call per iteration; only enable for the equivalence-testing phase."
+              }
+            }
+          },
           "creative_vision": {
             "type": "object",
             "required": ["vision_prose"],
@@ -137,6 +168,11 @@
             "if": {"properties": {"strategy": {"const": "creative_vision"}}},
             "then": {"required": ["creative_vision"]},
             "else": {"not": {"required": ["creative_vision"]}}
+          },
+          {
+            "if": {"properties": {"strategy": {"const": "academic_figure"}}},
+            "then": {},
+            "else": {"not": {"required": ["academic_figure"]}}
           }
         ]
       }

--- a/plugins/jack-tar-deckhand/tests/test_academic_figure_critic.py
+++ b/plugins/jack-tar-deckhand/tests/test_academic_figure_critic.py
@@ -1,0 +1,310 @@
+"""Tests for academic_figure_critic dispatch helpers (#113 Path B)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from src.academic_figure_critic import (  # noqa: E402
+    _VALID_FIGURE_TYPES,
+    build_critic_input,
+    decide_next_action,
+    parse_critic_output,
+)
+
+
+# ---------------------------------------------------------------------------
+# build_critic_input
+# ---------------------------------------------------------------------------
+
+
+def test_build_critic_input_includes_methodology_caption_and_image_path():
+    blob = build_critic_input(
+        methodology_text="The encoder applies multi-head attention with 8 heads.",
+        caption="Figure 3: Encoder architecture",
+        figure_type="architecture_diagram",
+        image_path="/tmp/out.png",
+        prior_scores_history=[],
+        iteration_index=1,
+        iteration_cap=4,
+    )
+    assert "multi-head attention with 8 heads" in blob
+    assert "Figure 3: Encoder architecture" in blob
+    assert "architecture_diagram" in blob
+    assert "/tmp/out.png" in blob
+    assert "Iteration index: 1" in blob
+    assert "Iteration cap: 4" in blob
+
+
+def test_build_critic_input_rejects_unknown_figure_type():
+    """Defensive: an unknown figure_type would yield unpredictable critic
+    scoring. Caller has to pick a canonical value."""
+    with pytest.raises(ValueError, match="figure_type"):
+        build_critic_input(
+            methodology_text="x",
+            caption="y",
+            figure_type="schematic_blueprint",  # not in enum
+            image_path="/tmp/x.png",
+            prior_scores_history=[],
+            iteration_index=1,
+            iteration_cap=4,
+        )
+
+
+def test_build_critic_input_accepts_every_canonical_figure_type():
+    """Pin the figure_type enum — adding a new one means schema + agent +
+    test must all update in lockstep."""
+    for ft in _VALID_FIGURE_TYPES:
+        build_critic_input(
+            methodology_text="x",
+            caption="y",
+            figure_type=ft,
+            image_path="/tmp/x.png",
+            prior_scores_history=[],
+            iteration_index=1,
+            iteration_cap=4,
+        )
+
+
+def test_build_critic_input_no_side_by_side_when_none_provided():
+    blob = build_critic_input(
+        methodology_text="x",
+        caption="y",
+        figure_type="other",
+        image_path="/tmp/x.png",
+        prior_scores_history=[],
+        iteration_index=1,
+        iteration_cap=4,
+    )
+    assert "side-by-side" not in blob.lower()
+    assert "Paperbanana" not in blob
+
+
+def test_build_critic_input_includes_side_by_side_when_provided():
+    """Equivalence-testing path: paperbanana verdict is included so the agent
+    can record whether it agrees. The blob must explicitly label it as
+    'do NOT defer to this' so the agent doesn't anchor to it."""
+    blob = build_critic_input(
+        methodology_text="x",
+        caption="y",
+        figure_type="other",
+        image_path="/tmp/x.png",
+        prior_scores_history=[],
+        iteration_index=1,
+        iteration_cap=4,
+        paperbanana_side_by_side_verdict={"verdict": "pass", "score": 92},
+    )
+    assert "side-by-side" in blob.lower()
+    assert "Do NOT defer to this" in blob
+    assert '"verdict": "pass"' in blob
+
+
+def test_build_critic_input_prior_history_rendered_as_json():
+    history = [
+        {"iteration": 1, "methodology_fidelity": 70, "verdict": "refine"},
+        {"iteration": 2, "methodology_fidelity": 78, "verdict": "refine"},
+    ]
+    blob = build_critic_input(
+        methodology_text="x",
+        caption="y",
+        figure_type="other",
+        image_path="/tmp/x.png",
+        prior_scores_history=history,
+        iteration_index=3,
+        iteration_cap=5,
+    )
+    assert '"methodology_fidelity": 70' in blob
+    assert '"methodology_fidelity": 78' in blob
+
+
+# ---------------------------------------------------------------------------
+# parse_critic_output — schema validation + semantic checks
+# ---------------------------------------------------------------------------
+
+
+def _verdict(
+    *,
+    verdict="pass",
+    scores=None,
+    issues=None,
+    refinement_feedback="",
+    iteration_index=1,
+    plateau_signal=False,
+    agrees=None,
+):
+    """Build a valid FigureCriticVerdict payload for tests."""
+    if scores is None:
+        scores = {
+            "methodology_fidelity": 85,
+            "caption_alignment": 90,
+            "legibility": 82,
+            "figure_type_correctness": 88,
+            "aesthetic_quality": 85,
+        }
+    if issues is None:
+        issues = [] if verdict == "pass" else [{"axis": "legibility", "detail": "ok"}]
+    return {
+        "verdict": verdict,
+        "per_axis_scores": scores,
+        "issues": issues,
+        "refinement_feedback": refinement_feedback,
+        "iteration_index": iteration_index,
+        "plateau_signal": plateau_signal,
+        "agrees_with_paperbanana_verdict": agrees,
+    }
+
+
+def _fence(payload):
+    return f"```json\n{json.dumps(payload)}\n```"
+
+
+def test_parse_critic_output_happy_path():
+    out = parse_critic_output(_fence(_verdict()))
+    assert out["verdict"] == "pass"
+    assert out["per_axis_scores"]["legibility"] == 82
+
+
+def test_parse_critic_output_rejects_missing_fence():
+    with pytest.raises(ValueError, match="missing"):
+        parse_critic_output(json.dumps(_verdict()))
+
+
+def test_parse_critic_output_rejects_malformed_json():
+    with pytest.raises(ValueError, match="parse failed"):
+        parse_critic_output("```json\n{not valid json}\n```")
+
+
+def test_parse_critic_output_rejects_pass_with_axis_below_80():
+    """F3-style semantic check: pass requires every axis >= 80."""
+    bad = _verdict(scores={
+        "methodology_fidelity": 75,  # < 80
+        "caption_alignment": 90,
+        "legibility": 90,
+        "figure_type_correctness": 90,
+        "aesthetic_quality": 90,
+    })
+    bad["issues"] = []  # pass has no issues
+    with pytest.raises(ValueError, match="pass but min axis score is 75"):
+        parse_critic_output(_fence(bad))
+
+
+def test_parse_critic_output_rejects_refine_with_empty_feedback():
+    """refine requires concrete refinement_feedback."""
+    bad = _verdict(verdict="refine", refinement_feedback="")
+    bad["issues"] = [{"axis": "legibility", "detail": "labels garbled"}]
+    with pytest.raises(ValueError, match="refine but refinement_feedback is empty"):
+        parse_critic_output(_fence(bad))
+
+
+def test_parse_critic_output_rejects_pass_with_feedback():
+    """pass must not carry refinement_feedback."""
+    bad = _verdict(verdict="pass", refinement_feedback="ignored", scores={
+        "methodology_fidelity": 85, "caption_alignment": 85,
+        "legibility": 85, "figure_type_correctness": 85, "aesthetic_quality": 85,
+    })
+    bad["issues"] = []
+    with pytest.raises(ValueError, match="pass but refinement_feedback is non-empty"):
+        parse_critic_output(_fence(bad))
+
+
+def test_parse_critic_output_rejects_pass_with_issues():
+    """pass and issues are mutually exclusive."""
+    bad = _verdict(verdict="pass", scores={
+        "methodology_fidelity": 85, "caption_alignment": 85,
+        "legibility": 85, "figure_type_correctness": 85, "aesthetic_quality": 85,
+    })
+    bad["issues"] = [{"axis": "legibility", "detail": "leftover from refine"}]
+    with pytest.raises(ValueError, match="pass but issues array is non-empty"):
+        parse_critic_output(_fence(bad))
+
+
+def test_parse_critic_output_rejects_non_pass_with_no_issues():
+    """non-pass verdicts must name at least one issue."""
+    bad = _verdict(verdict="refine", refinement_feedback="redraw the encoder block")
+    bad["issues"] = []
+    with pytest.raises(ValueError, match="issues array is empty"):
+        parse_critic_output(_fence(bad))
+
+
+def test_parse_critic_output_rejects_unknown_verdict_value():
+    """Schema enum: verdict must be pass/refine/escalate/abort."""
+    bad = _verdict(verdict="needs_work")
+    with pytest.raises(ValueError, match="schema"):
+        parse_critic_output(_fence(bad))
+
+
+def test_parse_critic_output_accepts_escalate_with_issues_no_feedback():
+    """escalate verdict: at least one issue; no refinement_feedback."""
+    payload = _verdict(verdict="escalate")
+    payload["issues"] = [{"axis": "legibility", "detail": "tier ceiling reached"}]
+    out = parse_critic_output(_fence(payload))
+    assert out["verdict"] == "escalate"
+
+
+def test_parse_critic_output_accepts_abort_with_issues_no_feedback():
+    payload = _verdict(verdict="abort")
+    payload["issues"] = [{"axis": "methodology_fidelity", "detail": "methodology malformed"}]
+    out = parse_critic_output(_fence(payload))
+    assert out["verdict"] == "abort"
+
+
+def test_parse_critic_output_logs_paperbanana_agreement():
+    """agrees_with_paperbanana_verdict round-trips."""
+    payload = _verdict(agrees=True)
+    out = parse_critic_output(_fence(payload))
+    assert out["agrees_with_paperbanana_verdict"] is True
+
+    payload = _verdict(agrees=False)
+    out = parse_critic_output(_fence(payload))
+    assert out["agrees_with_paperbanana_verdict"] is False
+
+    payload = _verdict(agrees=None)
+    out = parse_critic_output(_fence(payload))
+    assert out["agrees_with_paperbanana_verdict"] is None
+
+
+# ---------------------------------------------------------------------------
+# decide_next_action — state machine
+# ---------------------------------------------------------------------------
+
+
+def test_decide_next_action_pass_returns_accept():
+    action = decide_next_action(_verdict(verdict="pass"), iteration_index=1, iteration_cap=4)
+    assert action["action"] == "accept"
+
+
+def test_decide_next_action_refine_below_cap_returns_refine_with_feedback():
+    payload = _verdict(verdict="refine", refinement_feedback="add the missing axis label")
+    payload["issues"] = [{"axis": "legibility", "detail": "axis label missing"}]
+    action = decide_next_action(payload, iteration_index=2, iteration_cap=4)
+    assert action["action"] == "refine"
+    assert action["refinement_feedback"] == "add the missing axis label"
+
+
+def test_decide_next_action_refine_at_cap_returns_abort():
+    """Iteration cap reached + critic still wants to refine → operator must intervene."""
+    payload = _verdict(verdict="refine", refinement_feedback="more iterations needed")
+    payload["issues"] = [{"axis": "legibility", "detail": "still iterating"}]
+    action = decide_next_action(payload, iteration_index=4, iteration_cap=4)
+    assert action["action"] == "abort"
+    assert "iteration_cap 4 reached" in action["reason"]
+
+
+def test_decide_next_action_escalate_returns_escalate():
+    payload = _verdict(verdict="escalate")
+    payload["issues"] = [{"axis": "legibility", "detail": "tier ceiling"}]
+    action = decide_next_action(payload, iteration_index=2, iteration_cap=4)
+    assert action["action"] == "escalate"
+
+
+def test_decide_next_action_abort_returns_abort():
+    payload = _verdict(verdict="abort")
+    payload["issues"] = [{"axis": "methodology_fidelity", "detail": "malformed source"}]
+    action = decide_next_action(payload, iteration_index=1, iteration_cap=4)
+    assert action["action"] == "abort"
+    assert "abort verdict" in action["reason"]

--- a/plugins/jack-tar-deckhand/tests/test_creative_vision_schemas.py
+++ b/plugins/jack-tar-deckhand/tests/test_creative_vision_schemas.py
@@ -319,3 +319,148 @@ def test_strategy_map_iteration_caps_override_accepts_all_canonical_tiers():
         "recraft_standard_1k": 3, "recraft_pro_2k": 2, "recraft_pro_4k": 1,
     }
     validate(instance=m, schema=_load("strategy_map.schema.json"))
+
+
+# --- academic_figure block schema (#113 Path B) -----------------------------
+
+
+def _valid_strategy_map_entry_academic_figure(*, with_block=False, block=None):
+    """Build a minimal valid strategy map with one academic_figure slide.
+
+    When ``with_block`` is False, the slide omits the academic_figure block
+    (legacy paperbanana-loop default). When True, attaches ``block`` (or
+    the canonical claude-critic example).
+    """
+    slide = {
+        "slide_number": 1,
+        "strategy": "academic_figure",
+        "rationale": "operator-directed",
+        "render_funnel": ["ollama"],
+    }
+    if with_block:
+        slide["academic_figure"] = block if block is not None else {
+            "critic": "claude",
+            "figure_type": "architecture_diagram",
+            "iteration_cap": 4,
+            "log_paperbanana_verdict_for_comparison": False,
+        }
+    return {"approval_mode": "review", "slides": [slide]}
+
+
+def test_strategy_map_accepts_academic_figure_without_block():
+    """Legacy behaviour: academic_figure slide with no academic_figure block
+    is valid (paperbanana-loop default)."""
+    validate(
+        instance=_valid_strategy_map_entry_academic_figure(with_block=False),
+        schema=_load("strategy_map.schema.json"),
+    )
+
+
+def test_strategy_map_accepts_academic_figure_with_claude_critic_block():
+    """Opt-in claude-critic block is valid."""
+    validate(
+        instance=_valid_strategy_map_entry_academic_figure(with_block=True),
+        schema=_load("strategy_map.schema.json"),
+    )
+
+
+def test_strategy_map_rejects_academic_figure_block_on_non_academic_figure_slide():
+    """Conditional: academic_figure block forbidden when strategy is something else."""
+    bad = _valid_strategy_map_entry_academic_figure(with_block=True)
+    bad["slides"][0]["strategy"] = "composed"
+    with pytest.raises(ValidationError):
+        validate(instance=bad, schema=_load("strategy_map.schema.json"))
+
+
+def test_strategy_map_academic_figure_block_critic_enum():
+    """critic must be paperbanana or claude — typo rejected."""
+    bad = _valid_strategy_map_entry_academic_figure(with_block=True)
+    bad["slides"][0]["academic_figure"]["critic"] = "anthropic"
+    with pytest.raises(ValidationError):
+        validate(instance=bad, schema=_load("strategy_map.schema.json"))
+
+
+def test_strategy_map_academic_figure_block_figure_type_enum():
+    """figure_type must be a canonical value."""
+    bad = _valid_strategy_map_entry_academic_figure(with_block=True)
+    bad["slides"][0]["academic_figure"]["figure_type"] = "schematic_blueprint"
+    with pytest.raises(ValidationError):
+        validate(instance=bad, schema=_load("strategy_map.schema.json"))
+
+
+def test_strategy_map_academic_figure_iteration_cap_bounds():
+    """iteration_cap must be in [1, 10]."""
+    m = _valid_strategy_map_entry_academic_figure(with_block=True)
+    m["slides"][0]["academic_figure"]["iteration_cap"] = 0
+    with pytest.raises(ValidationError):
+        validate(instance=m, schema=_load("strategy_map.schema.json"))
+    m["slides"][0]["academic_figure"]["iteration_cap"] = 11
+    with pytest.raises(ValidationError):
+        validate(instance=m, schema=_load("strategy_map.schema.json"))
+    m["slides"][0]["academic_figure"]["iteration_cap"] = 5
+    validate(instance=m, schema=_load("strategy_map.schema.json"))
+
+
+def test_strategy_map_academic_figure_additional_properties_rejected():
+    """additionalProperties: false — typoed fields fail loud."""
+    bad = _valid_strategy_map_entry_academic_figure(with_block=True)
+    bad["slides"][0]["academic_figure"]["critique_mode"] = "claude"  # typo
+    with pytest.raises(ValidationError):
+        validate(instance=bad, schema=_load("strategy_map.schema.json"))
+
+
+# --- figure_critic_verdict schema -------------------------------------------
+
+
+def _valid_figure_critic_verdict():
+    return {
+        "verdict": "pass",
+        "per_axis_scores": {
+            "methodology_fidelity": 85,
+            "caption_alignment": 88,
+            "legibility": 82,
+            "figure_type_correctness": 90,
+            "aesthetic_quality": 84,
+        },
+        "issues": [],
+        "refinement_feedback": "",
+        "iteration_index": 1,
+        "plateau_signal": False,
+        "agrees_with_paperbanana_verdict": True,
+    }
+
+
+def test_figure_critic_verdict_happy_path():
+    validate(
+        instance=_valid_figure_critic_verdict(),
+        schema=_load("figure_critic_verdict.schema.json"),
+    )
+
+
+def test_figure_critic_verdict_rejects_unknown_verdict():
+    bad = _valid_figure_critic_verdict()
+    bad["verdict"] = "needs_work"
+    with pytest.raises(ValidationError):
+        validate(instance=bad, schema=_load("figure_critic_verdict.schema.json"))
+
+
+def test_figure_critic_verdict_rejects_out_of_range_score():
+    bad = _valid_figure_critic_verdict()
+    bad["per_axis_scores"]["legibility"] = 150
+    with pytest.raises(ValidationError):
+        validate(instance=bad, schema=_load("figure_critic_verdict.schema.json"))
+
+
+def test_figure_critic_verdict_rejects_extra_axis():
+    """additionalProperties: false on per_axis_scores."""
+    bad = _valid_figure_critic_verdict()
+    bad["per_axis_scores"]["narrative_arc"] = 80  # not a real axis
+    with pytest.raises(ValidationError):
+        validate(instance=bad, schema=_load("figure_critic_verdict.schema.json"))
+
+
+def test_figure_critic_verdict_accepts_null_agreement():
+    """agrees_with_paperbanana_verdict is nullable when no side-by-side was provided."""
+    payload = _valid_figure_critic_verdict()
+    payload["agrees_with_paperbanana_verdict"] = None
+    validate(instance=payload, schema=_load("figure_critic_verdict.schema.json"))

--- a/plugins/jack-tar-deckhand/tests/test_figure_critic_agent.py
+++ b/plugins/jack-tar-deckhand/tests/test_figure_critic_agent.py
@@ -1,0 +1,114 @@
+"""Smoke tests pinning the figure-critic agent definition (#113 Path B)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+AGENT_PATH = PLUGIN_ROOT / "agents" / "figure-critic.md"
+
+
+def _load():
+    assert AGENT_PATH.is_file(), f"agent definition missing at {AGENT_PATH}"
+    return AGENT_PATH.read_text()
+
+
+def test_figure_critic_agent_file_exists():
+    """The agent definition must exist at the canonical path so the SKILL.md
+    Step 4.6.1 dispatch can find it."""
+    _load()
+
+
+def test_figure_critic_declared_as_sonnet():
+    """Path B uses Sonnet for the academic-figure critic — same tier as
+    directors-critic for creative_vision."""
+    text = _load()
+    assert "model: sonnet" in text.lower()
+
+
+def test_figure_critic_documents_five_scoring_axes():
+    """Per the schema, the agent must score against five axes. The agent
+    definition must list each so a future reader knows what to score."""
+    text = _load()
+    for axis in (
+        "methodology_fidelity",
+        "caption_alignment",
+        "legibility",
+        "figure_type_correctness",
+        "aesthetic_quality",
+    ):
+        assert axis in text, f"figure-critic must document axis {axis!r}"
+
+
+def test_figure_critic_documents_four_verdict_values():
+    """The verdict enum is pass / refine / escalate / abort."""
+    text = _load()
+    for verdict in ("pass", "refine", "escalate", "abort"):
+        assert verdict in text, f"figure-critic must document verdict {verdict!r}"
+
+
+def test_figure_critic_documents_canonical_figure_types():
+    """The figure_type enum must be documented in the agent so the agent
+    knows what each value means for scoring."""
+    text = _load()
+    for ft in (
+        "architecture_diagram",
+        "equation",
+        "plot",
+        "table",
+        "algorithm_pseudocode",
+        "flowchart",
+        "other",
+    ):
+        assert ft in text
+
+
+def test_figure_critic_pins_pass_requires_axes_above_80():
+    """The hard rule that pass requires every axis ≥80 must be in the agent
+    definition — schema enforces it but the agent needs to know not to lie."""
+    text = _load()
+    assert "≥ 80" in text or ">= 80" in text or "80" in text
+    # Look for explicit cross-field language
+    assert "verdict == \"pass\"" in text or "verdict='pass'" in text or "verdict == 'pass'" in text
+
+
+def test_figure_critic_pins_equivalence_testing_posture():
+    """The agent must explicitly not defer to paperbanana's verdict."""
+    text = _load().lower()
+    assert "do not defer" in text or "not defer to paperbanana" in text
+    assert "equivalence" in text
+    assert "agrees_with_paperbanana_verdict" in text
+
+
+def test_figure_critic_pins_refinement_feedback_contract():
+    """The agent must know refinement_feedback flows verbatim into paperbanana
+    --continue-run --feedback. Vague feedback would break the loop."""
+    text = _load().lower()
+    assert "continue-run" in text or "continue_run" in text
+    assert "verbatim" in text
+
+
+def test_figure_critic_cross_references_schema_and_dispatch_module():
+    """Agent definition should cite the schema and dispatch helper so a
+    reader can trace the contract surface."""
+    text = _load()
+    assert "figure_critic_verdict.schema.json" in text
+    assert "academic_figure_critic.py" in text
+
+
+def test_figure_critic_documents_why_this_agent_exists():
+    """Path B is a non-trivial architectural choice; the agent definition
+    must explain why we moved the critic out of paperbanana into jack-tar."""
+    text = _load().lower()
+    assert "why this agent exists" in text
+    # Specific motivations:
+    assert "creative_vision" in text  # mirroring an established pattern
+    assert "operator-paced" in text or "operator gate" in text
+
+
+def test_figure_critic_cites_upstream_paperbanana_issues():
+    """The motivation for Path B includes upstream paperbanana constraints
+    (deprecated defaults, PyPI staleness). Surface them so the agent
+    definition is self-explanatory."""
+    text = _load()
+    # At least one of our upstream issues should be referenced
+    assert "#213" in text or "#214" in text or "#216" in text

--- a/plugins/jack-tar-deckhand/tests/test_paperbanana_dispatch.py
+++ b/plugins/jack-tar-deckhand/tests/test_paperbanana_dispatch.py
@@ -513,5 +513,161 @@ def test_dispatch_dataclass_default_fallback_values():
     assert dispatch.fallback_reason == ""
 
 
+# --- Claude-critic path helpers (#113 Path B) -----------------------------
+
+import pytest  # noqa: E402
+
+from src.paperbanana_dispatch import (  # noqa: E402
+    build_continue_run_dispatch_args,
+    build_initial_dispatch_args_for_claude_critic,
+    get_figure_type,
+    get_iteration_cap,
+    is_claude_critic_path,
+    should_log_paperbanana_verdict,
+)
+
+
+def test_is_claude_critic_path_default_false_when_no_academic_figure_block():
+    """Legacy slide without academic_figure block → paperbanana-critic path."""
+    slide = {"slide_number": 5, "strategy": "academic_figure"}
+    assert is_claude_critic_path(slide) is False
+
+
+def test_is_claude_critic_path_default_false_when_critic_field_omitted():
+    """academic_figure block present but no critic field → defaults to paperbanana."""
+    slide = {
+        "slide_number": 5,
+        "strategy": "academic_figure",
+        "academic_figure": {"figure_type": "plot"},
+    }
+    assert is_claude_critic_path(slide) is False
+
+
+def test_is_claude_critic_path_true_when_critic_claude():
+    """Explicit opt-in via critic: claude."""
+    slide = {
+        "slide_number": 5,
+        "strategy": "academic_figure",
+        "academic_figure": {"critic": "claude"},
+    }
+    assert is_claude_critic_path(slide) is True
+
+
+def test_is_claude_critic_path_false_for_non_academic_figure_strategies():
+    """Even with academic_figure block, wrong strategy → False (schema would also reject)."""
+    slide = {
+        "slide_number": 5,
+        "strategy": "composed",
+        "academic_figure": {"critic": "claude"},
+    }
+    assert is_claude_critic_path(slide) is False
+
+
+def test_build_initial_dispatch_args_for_claude_critic_forces_iterations_1():
+    """Iterations MUST be 1 — jack-tar owns the loop, paperbanana does one render per call."""
+    slide = {
+        "slide_number": 5,
+        "strategy": "academic_figure",
+        "headline": "Figure 3",
+        "visual_direction": "three-block encoder architecture",
+        "body_points": ["encoder", "attention", "decoder"],
+        "academic_figure": {
+            "critic": "claude",
+            "iteration_cap": 6,
+        },
+        # Even if the slide had paperbanana_iterations set high, claude-critic
+        # forces 1 — the operator-tunable cap lives in jack-tar's loop, not in
+        # paperbanana's internal loop.
+        "paperbanana_iterations": 9,
+    }
+    args = build_initial_dispatch_args_for_claude_critic(slide)
+    assert args["iterations"] == 1
+    assert "source_context" in args
+    assert args["caption"] == "Figure 3"
+    assert args["aspect_ratio"] == "16:9"
+
+
+def test_build_continue_run_dispatch_args_happy_path():
+    args = build_continue_run_dispatch_args(
+        paperbanana_run_id="run_20260527_120000_abc123",
+        feedback="Make the encoder block 30% taller. Add a labelled arrow.",
+    )
+    assert args["continue_run"] == "run_20260527_120000_abc123"
+    assert "encoder block 30% taller" in args["feedback"]
+    assert args["iterations"] == 1
+
+
+def test_build_continue_run_dispatch_args_rejects_empty_run_id():
+    with pytest.raises(ValueError, match="paperbanana_run_id"):
+        build_continue_run_dispatch_args(paperbanana_run_id="", feedback="x")
+
+
+def test_build_continue_run_dispatch_args_rejects_whitespace_run_id():
+    with pytest.raises(ValueError, match="paperbanana_run_id"):
+        build_continue_run_dispatch_args(paperbanana_run_id="   ", feedback="x")
+
+
+def test_build_continue_run_dispatch_args_rejects_empty_feedback():
+    """figure-critic is contractually required to provide non-empty refinement
+    feedback on a refine verdict. Empty feedback would mean a corrupt critic
+    verdict slipped through; this catch is a belt-and-braces."""
+    with pytest.raises(ValueError, match="feedback must be non-empty"):
+        build_continue_run_dispatch_args(paperbanana_run_id="run_x", feedback="")
+
+
+def test_get_iteration_cap_default_4():
+    """Default cap matches schema default."""
+    assert get_iteration_cap({"academic_figure": {}}) == 4
+    assert get_iteration_cap({}) == 4
+
+
+def test_get_iteration_cap_honours_per_slide_override():
+    assert get_iteration_cap({"academic_figure": {"iteration_cap": 7}}) == 7
+
+
+def test_get_figure_type_default_other():
+    assert get_figure_type({"academic_figure": {}}) == "other"
+    assert get_figure_type({}) == "other"
+
+
+def test_get_figure_type_returns_specified_type():
+    assert get_figure_type({"academic_figure": {"figure_type": "plot"}}) == "plot"
+
+
+def test_should_log_paperbanana_verdict_false_when_not_claude_critic():
+    """Side-by-side logging only meaningful in claude-critic path."""
+    slide = {
+        "slide_number": 5,
+        "strategy": "academic_figure",
+        "academic_figure": {
+            "critic": "paperbanana",
+            "log_paperbanana_verdict_for_comparison": True,
+        },
+    }
+    assert should_log_paperbanana_verdict(slide) is False
+
+
+def test_should_log_paperbanana_verdict_true_when_claude_critic_and_opted_in():
+    slide = {
+        "slide_number": 5,
+        "strategy": "academic_figure",
+        "academic_figure": {
+            "critic": "claude",
+            "log_paperbanana_verdict_for_comparison": True,
+        },
+    }
+    assert should_log_paperbanana_verdict(slide) is True
+
+
+def test_should_log_paperbanana_verdict_default_false_under_claude_critic():
+    """Equivalence-testing is opt-in even on the claude-critic path."""
+    slide = {
+        "slide_number": 5,
+        "strategy": "academic_figure",
+        "academic_figure": {"critic": "claude"},
+    }
+    assert should_log_paperbanana_verdict(slide) is False
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Opt-in **Claude-critic path** for `academic_figure` slides. Paperbanana keeps its strong academic-figure-aware rendering; jack-tar takes the iteration loop back. The new `figure-critic` agent (Sonnet) decides accept/refine; the operator gates every iteration (F12 cadence, same as `creative_vision`).

**Default behaviour is unchanged.** Opt in per-slide via `academic_figure.critic: \"claude\"`. The v1.4.1 paperbanana-owns-the-loop path is untouched.

## Why

The honest question raised during PR #114 dogfood — *why can't the critic be Claude?* — exposed that the v1.4.1 paperbanana integration treats paperbanana as a black-box orchestrator that owns its critic decision. Paperbanana 0.1.2 (the PyPI release) hard-codes Gemini as the VLM critic; upstream PR #212 added LiteLLM on `main` but hasn't shipped.

This PR moves the critic decision into jack-tar. Paperbanana renders (it's good at academic figures); Claude decides (it's already the orchestrator, has access to image-reviewer-style discipline, and is operator-paced).

This PR ships the **side-by-side surface** so the operator can run both critics on the same slide. The equivalence-testing methodology (`docs/architecture/academic-figure-critic-equivalence.md`) defines the bar for promoting Claude-critic to default in a future Phase 2.

## What's in the PR

| File | Purpose |
|------|---------|
| `agents/figure-critic.md` | Sonnet agent; 5 scoring axes (methodology / caption / legibility / figure_type / aesthetic); strict pass requires every axis ≥80 |
| `src/schemas/figure_critic_verdict.schema.json` | FigureCriticVerdict with nullable agreement field for side-by-side logging |
| `src/academic_figure_critic.py` | build_critic_input + parse_critic_output (schema + 3 semantic validators) + decide_next_action state machine |
| `src/paperbanana_dispatch.py` | New Path B helpers: is_claude_critic_path, build_initial_dispatch_args_for_claude_critic (--iterations 1), build_continue_run_dispatch_args (refine), get_iteration_cap, get_figure_type, should_log_paperbanana_verdict |
| `src/schemas/strategy_map.schema.json` | New `academic_figure` block (critic / figure_type / iteration_cap / log_paperbanana_verdict_for_comparison). additionalProperties:false; conditional required iff strategy==academic_figure |
| `skills/imagegen-bridge/SKILL.md` | Step 4.6.1 documents the new loop (initial render → operator gate → figure-critic → decide → refine via --continue-run) alongside the unchanged Step 4.6 legacy path |
| `docs/architecture/academic-figure-critic-equivalence.md` | Phase 1 methodology, three equivalence bars (agreement / operator-alignment / blinded-quality), Phase 2 promotion criteria |
| Plugin version | 1.5.1 → 1.5.2 (patch — opt-in additive behaviour) |

## Test plan

- [x] All 537/537 deckhand tests pass + 65/65 integration tests (was 475 before this PR — added 62 new tests across 4 test files)
- [x] CI green
- [ ] Operator runs ≥1 academic_figure slide on each path (paperbanana-critic, claude-critic) to validate the loop wiring end-to-end
- [ ] Operator approves merge

**Phase 1 equivalence dogfood** is a separate, larger lift — described in the equivalence-testing doc. Target: ≥15 slides across ≥5 figure types with side-by-side logging on. Not blocking merge of this PR; the surface is what gets validated.

## Follow-up scope (NOT in this PR)

- Per-slide manifest module if the inline image-manifest entry grows beyond ~10 fields
- Phase 1 dogfood + equivalence report script
- Phase 2 default flip to claude-critic + 1.6.0 bump (after equivalence bars met)
- Phase 3 (Path C): collapse academic_figure into creative_vision and skip paperbanana entirely

## Decisions made autonomously (flag if you'd change)

- **Critic agent: Sonnet, named `figure-critic`** (not a generic image-reviewer reuse). 5 academic-figure-specific axes.
- **Loop ownership: jack-tar owns iteration cap**, default 4. Paperbanana called with `--iterations 1` per step.
- **Side-by-side logging is opt-in** (`log_paperbanana_verdict_for_comparison: true`). Defaults off to keep cost predictable.
- **Strict semantic validators** mirror creative_vision/critic.py: pass requires every axis ≥80; refine requires non-empty refinement_feedback; verdicts agree with issues list.
- **Operator gate at EVERY iteration** (F12 cadence). Same as creative_vision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)