### PR TITLE
feat(narrative): standalone outline + notes without a style-guide

### DIFF
--- a/plugins/jack-tar-deckhand/skills/narrative-architect/SKILL.md
+++ b/plugins/jack-tar-deckhand/skills/narrative-architect/SKILL.md
@@ -12,7 +12,7 @@ Transform a TalkBrief into a structured SlideOutline. Works in two stages: colla
 ## Prerequisites
 
 - `./tmp/deck/talk-brief.json` must exist
-- `./tmp/deck/style-guide.json` must exist (produced by slide-stylist)
+- `./tmp/deck/style-guide.json` is **optional**. When present (produced by slide-stylist), its layout and pacing cues are used. When absent, narrative-architect runs in **standalone mode** (see below), synthesising a tone-keyed default style.
 
 ## Usage
 
@@ -22,6 +22,20 @@ Invoked by the Deck Conductor after slide-stylist. Can also be invoked directly:
 /narrative-architect
 /narrative-architect --deck-dir ./tmp/deck
 ```
+
+### Standalone mode (no style-guide)
+
+The generators (narrative-architect → speaker-notes-writer) can run from a TalkBrief alone, skipping brand-manager and slide-stylist — useful for outline-only drafts and self-presenting, visual-light decks.
+
+```python
+from src.narrative_standalone import generate_outline_from_brief_only
+from src.content_validation import generate_speaker_notes_from_outline
+
+outline = generate_outline_from_brief_only(deck_dir)          # reads talk-brief.json
+notes = generate_speaker_notes_from_outline(outline, tone="technical")
+```
+
+When `style-guide.json` is absent, `generate_outline_from_brief_only` synthesises a tone-keyed default before building the outline (technical → dense/90s, executive → spacious/120s, narrative → moderate/75s; other tones fall back to `narrative`).
 
 ## What It Does
 

--- a/plugins/jack-tar-deckhand/src/content_validation.py
+++ b/plugins/jack-tar-deckhand/src/content_validation.py
@@ -95,3 +95,101 @@ def check_outline_layout_references(outline, style_guide):
                 f'"{lt}" which does not exist in StyleGuide'
             )
     return issues
+
+
+# ---------------------------------------------------------------------------
+# Standalone shims — used by src.narrative_standalone (objective 4)
+# These enable outline + notes generation without brand-manager or slide-stylist.
+# ---------------------------------------------------------------------------
+
+def build_outline_from_brief(brief: dict, style_guide: dict) -> dict:
+    """Build a minimal but schema-valid SlideOutline from a TalkBrief.
+
+    Produces a title slide, one content slide per key_takeaway, and a closing
+    slide. The result passes validate_outline_schema().
+
+    Args:
+        brief: A TalkBrief dict (talk-brief.json).
+        style_guide: A StyleGuide dict or synthesized style defaults.
+
+    Returns:
+        A SlideOutline-compatible dict.
+    """
+    topic = brief.get("topic", "Untitled Talk")
+    takeaways = brief.get("key_takeaways", [])
+    duration = brief.get("duration_minutes", 30)
+    tone = brief.get("tone", "narrative")
+
+    slides = [
+        {
+            "slide_number": 1,
+            "slide_type": "title",
+            "headline": topic,
+            "body_points": [],
+            "narrative_beat": "opening",
+        }
+    ]
+
+    for i, takeaway in enumerate(takeaways, start=2):
+        slides.append(
+            {
+                "slide_number": i,
+                "slide_type": "content",
+                "headline": takeaway,
+                "body_points": [],
+                "narrative_beat": "body",
+            }
+        )
+
+    slides.append(
+        {
+            "slide_number": len(slides) + 1,
+            "slide_type": "closing",
+            "headline": "Thank you",
+            "body_points": [],
+            "narrative_beat": "closing",
+        }
+    )
+
+    return {
+        "narrative_arc": f"{tone}-standalone",
+        "estimated_duration_minutes": duration,
+        "total_slides": len(slides),
+        "slides": slides,
+        "metadata": {"source": "standalone"},
+    }
+
+
+def generate_speaker_notes_from_outline(outline: dict, tone: str = "narrative") -> dict:
+    """Generate minimal speaker notes for every slide in an outline.
+
+    Produces one note per slide conforming to speaker_notes.schema.json:
+    top-level key is 'notes', each item requires 'slide_number' and 'text',
+    with 'estimated_seconds' derived from the tone's default cadence and a
+    structured 'cues' list.
+
+    Args:
+        outline: A SlideOutline dict.
+        tone: Tone string used to derive per-slide cadence.
+
+    Returns:
+        A dict conforming to speaker_notes.schema.json with a 'notes' key.
+    """
+    cadence = {"technical": 90, "executive": 120, "professional": 120}.get(tone, 75)
+    all_slides = outline.get("slides", [])
+    last_index = len(all_slides) - 1
+    notes_items = [
+        {
+            "slide_number": s["slide_number"],
+            "text": f"Speak to: {s.get('headline', 'slide')}",
+            "estimated_seconds": cadence,
+            "cues": [
+                {
+                    "type": "transition",
+                    "text": "closing" if i == last_index else "next",
+                }
+            ],
+        }
+        for i, s in enumerate(all_slides)
+    ]
+    return {"notes": notes_items}

--- a/plugins/jack-tar-deckhand/src/narrative_standalone.py
+++ b/plugins/jack-tar-deckhand/src/narrative_standalone.py
@@ -1,0 +1,55 @@
+"""Narrative standalone — generate a SlideOutline from a TalkBrief without a StyleGuide.
+
+This module enables the narrative-architect → speaker-notes-writer path without
+first running brand-manager or slide-stylist. Speakers who only need the generators
+(objective 4) can call generate_outline_from_brief_only(deck_dir) and get a valid
+SlideOutline using tone-keyed default styles.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.deckcontext import read_contract
+from src.content_validation import build_outline_from_brief
+
+# Tone-keyed default style profiles synthesized when style-guide.json is absent.
+# These mirror the three primary audience profiles; other tones fall back to "narrative".
+DEFAULT_STYLES: dict[str, dict[str, Any]] = {
+    "technical": {"pace": "dense", "slide_cadence_seconds": 90},
+    "executive": {"pace": "spacious", "slide_cadence_seconds": 120},
+    "professional": {"pace": "spacious", "slide_cadence_seconds": 120},
+    "narrative": {"pace": "moderate", "slide_cadence_seconds": 75},
+    "conversational": {"pace": "moderate", "slide_cadence_seconds": 75},
+    "inspirational": {"pace": "moderate", "slide_cadence_seconds": 75},
+    "provocative": {"pace": "moderate", "slide_cadence_seconds": 75},
+    "storytelling": {"pace": "moderate", "slide_cadence_seconds": 75},
+}
+
+
+def generate_outline_from_brief_only(deck_dir: str) -> dict[str, Any]:
+    """Build a SlideOutline from a TalkBrief alone, synthesizing a style if needed.
+
+    Reads talk-brief.json and (optionally) style-guide.json from deck_dir.
+    If style-guide.json is absent, a tone-keyed default is synthesized.
+
+    Args:
+        deck_dir: Path to the deck working directory containing talk-brief.json.
+
+    Returns:
+        A dict conforming to the SlideOutline schema.
+
+    Raises:
+        FileNotFoundError: If talk-brief.json is not present in deck_dir.
+    """
+    brief = read_contract(deck_dir, "talk-brief")
+    if brief is None:
+        raise FileNotFoundError(f"talk-brief.json not found in {deck_dir}")
+
+    style_guide = read_contract(deck_dir, "style-guide")
+    if style_guide is None:
+        tone = brief.get("tone", "narrative")
+        style_guide = DEFAULT_STYLES.get(tone, DEFAULT_STYLES["narrative"]).copy()
+        style_guide["_synthesized"] = True
+
+    return build_outline_from_brief(brief, style_guide)

--- a/plugins/jack-tar-deckhand/tests/test_narrative_standalone.py
+++ b/plugins/jack-tar-deckhand/tests/test_narrative_standalone.py
@@ -1,0 +1,83 @@
+"""Tests for narrative-standalone path — outline and notes generation without style-guide."""
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+SPEAKER_NOTES_SCHEMA = json.loads(
+    (PLUGIN_ROOT / "src/schemas/speaker_notes.schema.json").read_text()
+)
+
+
+@pytest.fixture
+def narrative_only_brief(tmp_path):
+    """A minimal TalkBrief with no style-guide or brand-profile dependency."""
+    brief = {
+        "topic": "Building Resilient Distributed Systems",
+        "audience": "Senior engineers",
+        "duration_minutes": 30,
+        "tone": "technical",
+        "key_takeaways": [
+            "Understand failure modes in distributed systems",
+            "Apply the CAP theorem in practice",
+            "Design for graceful degradation",
+        ],
+    }
+    brief_path = tmp_path / "talk-brief.json"
+    brief_path.write_text(json.dumps(brief))
+    return brief_path
+
+
+def test_narrative_architect_runs_without_style_guide(narrative_only_brief, tmp_path):
+    deck_dir = tmp_path / "deck"
+    deck_dir.mkdir(parents=True)
+
+    # Copy talk-brief.json into deck_dir (where deckcontext.read_contract looks for it)
+    import shutil
+    shutil.copy(narrative_only_brief, deck_dir / "talk-brief.json")
+
+    from src.deckcontext import init_deck
+    init_deck(str(deck_dir))
+
+    # Confirm style-guide is absent
+    assert not (deck_dir / "style-guide.json").exists()
+
+    from src.narrative_standalone import generate_outline_from_brief_only
+    outline = generate_outline_from_brief_only(str(deck_dir))
+
+    from src.content_validation import validate_outline_schema
+    errors = validate_outline_schema(outline)
+    assert errors == [], f"Outline schema errors: {errors}"
+
+    assert len(outline["slides"]) >= 3
+
+
+def test_speaker_notes_from_standalone_outline(narrative_only_brief, tmp_path):
+    deck_dir = tmp_path / "deck2"
+    deck_dir.mkdir(parents=True)
+
+    import shutil
+    shutil.copy(narrative_only_brief, deck_dir / "talk-brief.json")
+
+    from src.deckcontext import init_deck
+    init_deck(str(deck_dir))
+
+    from src.narrative_standalone import generate_outline_from_brief_only
+    outline = generate_outline_from_brief_only(str(deck_dir))
+    (deck_dir / "outline.json").write_text(json.dumps(outline))
+
+    from src.content_validation import generate_speaker_notes_from_outline
+    notes = generate_speaker_notes_from_outline(outline, tone="technical")
+
+    # Schema conformance — catches future drift automatically
+    jsonschema.validate(notes, SPEAKER_NOTES_SCHEMA)
+
+    assert len(notes["notes"]) == len(outline["slides"])
+    for item in notes["notes"]:
+        assert "text" in item, f"Missing 'text' in note: {item}"
+        assert "estimated_seconds" in item, f"Missing 'estimated_seconds' in note: {item}"


### PR DESCRIPTION
## What

Re-lands the **narrative-standalone** capability (objective 4) that was stranded on the abandoned `feat/release-readiness-phase-a` branch. Ported onto current `main` rather than merged — that branch was 302 commits stale and its plugin.json/CI deltas would have regressed the #76 discipline hook.

Enables the `narrative-architect → speaker-notes-writer` path to run from a **TalkBrief alone**, skipping `brand-manager` and `slide-stylist`. Useful for outline-only drafts and self-presenting, visual-light decks.

## Changes

- **`content_validation.py`** — adds `build_outline_from_brief` + `generate_speaker_notes_from_outline` (pure additions; the existing 5 functions are byte-identical to main).
- **`narrative_standalone.py`** (new) — `generate_outline_from_brief_only(deck_dir)` synthesises a tone-keyed default style when `style-guide.json` is absent (technical → dense/90s, executive → spacious/120s, narrative → moderate/75s).
- **`narrative-architect/SKILL.md`** — documents standalone mode; written fresh against current main (the branch's stale rewrite was discarded).
- **`test_narrative_standalone.py`** (new) — 2 cases: outline without style-guide; speaker notes from the standalone outline, schema-validated.

## Verification

- `pytest plugins/jack-tar-deckhand/tests` → 412 passed, 1 skipped (full suite, content_validation change breaks nothing)
- `pytest .../test_narrative_standalone.py` → 2 passed
- `flake8 --max-line-length=100` → clean

## Context

Part of the repo-cleanup / stale-branch-landing effort (plan: `docs/superpowers/plans/2026-06-02-repo-cleanup-branch-landing.md`). Slice B of the phase-A triage. Slice A (plugin post-install hooks) was found to rely on a non-existent `postInstall` plugin hook and is **not** being re-landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)