### PR TITLE
feat(smartart): shipped example specs + render-guard tests

### DIFF
--- a/plugins/jack-tar-custom-smartart/examples/timeline.json
+++ b/plugins/jack-tar-custom-smartart/examples/timeline.json
@@ -1,0 +1,16 @@
+{
+  "slide_number": 1,
+  "graphic_type": "timeline",
+  "engine": "custom_svg",
+  "enrichment_tier": "pure_programmatic",
+  "data": {
+    "stages": [
+      {"date": "Q1", "label": "Discover"},
+      {"date": "Q2", "label": "Design"},
+      {"date": "Q3", "label": "Build"},
+      {"date": "Q4", "label": "Ship"}
+    ]
+  },
+  "dimensions": {"width": 1920, "height": 1080},
+  "alt_text": "Quarterly delivery timeline from discovery to ship"
+}

--- a/plugins/jack-tar-custom-smartart/examples/venn.json
+++ b/plugins/jack-tar-custom-smartart/examples/venn.json
@@ -1,0 +1,16 @@
+{
+  "slide_number": 1,
+  "graphic_type": "venn",
+  "engine": "custom_svg",
+  "enrichment_tier": "pure_programmatic",
+  "data": {
+    "sets": [
+      {"label": "Fast"},
+      {"label": "Cheap"},
+      {"label": "Good"}
+    ],
+    "intersection": {"label": "Pick 2"}
+  },
+  "dimensions": {"width": 1920, "height": 1080},
+  "alt_text": "Fast-Cheap-Good trade-off Venn diagram"
+}

--- a/plugins/jack-tar-custom-smartart/src/smartart_svg/layouts/timeline.py
+++ b/plugins/jack-tar-custom-smartart/src/smartart_svg/layouts/timeline.py
@@ -78,7 +78,9 @@ def render_timeline(data, container, tokens):
 
     elements = [spine]
 
-    date_font_size = max(9, min(11, int(label_font_size * 0.75)))
+    # Floor at 12px to satisfy PA-03 (minimum legible source font size); the
+    # date badge previously capped at 11px and failed the plugin's own check.
+    date_font_size = max(12, min(14, int(label_font_size * 0.85)))
     date_badge_y = label_top_y - 2 * (label_font_size + 2) - 4   # above the label area
 
     for i, (stage, col) in enumerate(zip(stages, cols)):

--- a/plugins/jack-tar-custom-smartart/tests/test_shipped_examples.py
+++ b/plugins/jack-tar-custom-smartart/tests/test_shipped_examples.py
@@ -1,0 +1,29 @@
+"""Render-guard: every shipped example spec must render cleanly.
+
+Phase-D shipped example files that were never executed and whose data shapes
+did not match the renderer contract. This guard renders each
+`examples/*.json` through the real renderer and asserts the engine reports
+`status == 'rendered'` — which also exercises the PA-03 / dimension / text
+validators, so an example that fails the plugin's own QA fails the test.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+EXAMPLES = sorted((PLUGIN_ROOT / "examples").glob("*.json"))
+
+
+@pytest.mark.parametrize("example", EXAMPLES, ids=lambda p: p.stem)
+def test_shipped_example_renders(example, tmp_path):
+    from src.smartart_renderer import render
+
+    spec = json.loads(example.read_text())
+    result = render(spec, {}, "production", str(tmp_path))
+
+    assert result["status"] == "rendered", f"{example.name}: {result}"
+    assert Path(result["file_path"]).exists(), f"{example.name} produced no file"

--- a/plugins/jack-tar-msft-smartart/examples/cycle.json
+++ b/plugins/jack-tar-msft-smartart/examples/cycle.json
@@ -1,0 +1,7 @@
+{
+  "graphic_type": "cycle",
+  "layout_id": "cycle2",
+  "data": {
+    "items": ["Plan", "Do", "Check", "Act"]
+  }
+}

--- a/plugins/jack-tar-msft-smartart/examples/flowchart.json
+++ b/plugins/jack-tar-msft-smartart/examples/flowchart.json
@@ -1,0 +1,7 @@
+{
+  "graphic_type": "flowchart",
+  "layout_id": "process1",
+  "data": {
+    "items": ["Research", "Design", "Build", "Test", "Ship"]
+  }
+}

--- a/plugins/jack-tar-msft-smartart/examples/org-chart.json
+++ b/plugins/jack-tar-msft-smartart/examples/org-chart.json
@@ -1,0 +1,19 @@
+{
+  "graphic_type": "org_chart",
+  "layout_id": "orgChart1",
+  "data": {
+    "tree": {
+      "title": "CEO",
+      "children": [
+        {"title": "Executive Assistant", "asst": true},
+        {"title": "CTO", "children": [
+          {"title": "VP Engineering"},
+          {"title": "VP Platform"}
+        ]},
+        {"title": "CFO", "children": [
+          {"title": "Controller"}
+        ]}
+      ]
+    }
+  }
+}

--- a/plugins/jack-tar-msft-smartart/tests/test_shipped_examples.py
+++ b/plugins/jack-tar-msft-smartart/tests/test_shipped_examples.py
@@ -1,0 +1,28 @@
+"""Render-guard: every shipped example spec must render to a valid carrier.
+
+Phase-D shipped example files that were never executed and whose data shapes
+did not match the real builder contract. This guard renders each
+`examples/*.json` through the real engine so the examples cannot silently drift
+out of sync with the builders again.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+EXAMPLES = sorted((PLUGIN_ROOT / "examples").glob("*.json"))
+
+
+@pytest.mark.parametrize("example", EXAMPLES, ids=lambda p: p.stem)
+def test_shipped_example_renders(example, tmp_path):
+    from src.engine import render
+
+    spec = json.loads(example.read_text())
+    result = render(spec, str(tmp_path))
+
+    assert Path(result.output_path).exists(), f"{example.name} produced no carrier"
+    assert result.node_count > 0, f"{example.name} rendered zero nodes"


### PR DESCRIPTION
## What

Re-creates the SmartArt **example specs** (Slice E of the phase-A salvage) — validated against the **current** engines, not the stale April shapes. Five examples plus a render-guard test per plugin so they can never silently drift again.

## Why this isn't a straight copy

The phase-A / 2026-04-18 example shapes were **wrong against today's code**, caught only by actually rendering them:
- **msft-smartart** specs need `data.{items|tree}` — the render SKILL.md documents top-level `items`, and the salvage review repeated that. The engine raises `RenderError("spec is missing required key 'data'")`. Examples use the real shape.
- **custom-smartart timeline** rendered but failed the plugin's **own PA-03** check (date badge font capped at 11px < 12px minimum). One-line layout fix (floor at 12px); no test pinned the old value.

## Changes

- `jack-tar-msft-smartart/examples/`: `flowchart`, `cycle`, `org-chart` → render to editable SmartArt carriers (5/4/7 nodes)
- `jack-tar-custom-smartart/examples/`: `timeline`, `venn` → render via `custom_svg`
- **render-guard test per plugin** — parametrised over `examples/*.json`, renders each through the real engine and asserts success. Directly prevents the phase-D regression (examples that were never executed and didn't match the builder contract).
- `custom-smartart` timeline layout: date font floored at 12px to satisfy PA-03.

## Verification

- `pytest plugins/jack-tar-msft-smartart/tests` → 10 passed
- `pytest plugins/jack-tar-custom-smartart/tests` → 8 passed
- All 5 examples render + pass QA; CI-blocking flake8 (`E9,F63,F7,F82`) clean

## Context

Plan: `docs/superpowers/plans/2026-06-02-repo-cleanup-branch-landing.md` (Slice E). Companion to #116 (Slice B, merged). The wrong-doc shapes this surfaced (msft `data` wrapper, `RenderResult` return) are folded into the separate doc-drift cleanup (Slice D).

🤖 Generated with [Claude Code](https://claude.com/claude-code)