### PR TITLE
docs: fix 8 doc-drift defects + add RELEASE-STATE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,7 +295,7 @@ Still-open issues NOT in the v1.4 scope: #86 (discipline-hook propagation — in
   - Create `research/synthesis-[skill-name].md` before implementing any skill
   - `research/report-1-landscape-and-spec.md` and `report-2-implementation-and-validation.md` are the pptx_native SmartArt research Phase 1/2
 
-- **Test suite: 1070 monorepo + 33 cross-plugin integration tests**
+- **Test suite: comprehensive coverage across all plugins (run `pytest` per plugin for current counts)**
   - Phases 1-6: Foundation through Orchestration (518 tests)
   - SmartArt Intelligent Graphics (PR #21, merged 2026-04-07): 132 tests
   - pptx_native SmartArt engine (PR #39, merged 2026-04-10): ~300 tests across 17 test files — 28 layouts, picture embedding, multi-slide integration

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Speaker invokes `/bridge-brief` first; uses the brief to drive `/pptx`; then `/e
 Speaker has already run `/pptx` and isn't satisfied with the deck. The bridge takes a **review-first approach**: assesses what's there, identifies what's salvageable vs what needs redoing, and collaborates with the speaker on whether to enrich in place or rebuild the brief and start over. This is how the bridge handles "rescue" workflows.
 
 ### 3. Jack-Tar direct route
-Speaker invokes `/jack-tar-deckhand:deck-conductor` for the full Jack-Tar pipeline — brand profile, narrative architect, strategy map, full QA, no `/pptx` involvement at all. Best for speakers who want the full Jack-Tar treatment from a brief, not retrofitting onto an existing deck.
+Speaker dispatches the **deck-conductor** agent for the full Jack-Tar pipeline — brand profile, narrative architect, strategy map, full QA, no `/pptx` involvement at all. Best for speakers who want the full Jack-Tar treatment from a brief, not retrofitting onto an existing deck.
 
 ---
 
@@ -82,9 +82,9 @@ Speaker invokes `/jack-tar-deckhand:deck-conductor` for the full Jack-Tar pipeli
 
 ### Direct route
 
-```
-/jack-tar-deckhand:deck-conductor "your topic"
-```
+Dispatch the **deck-conductor** agent with your topic to orchestrate a full deck build (it is a conversational agent, not a slash command):
+
+> Use the deck-conductor agent to build a deck on "your topic"
 
 ---
 

--- a/docs/RELEASE-STATE.md
+++ b/docs/RELEASE-STATE.md
@@ -1,0 +1,63 @@
+# Jack-Tar — Release State
+
+Current-state summary of the Jack-Tar Claude Code marketplace. Versions below are
+read directly from each plugin's `.claude-plugin/plugin.json` and the marketplace
+manifest at `.claude-plugin/marketplace.json`. This is an index / summary doc, not a
+changelog.
+
+## Plugins
+
+| Plugin | Version | Purpose |
+|--------|---------|---------|
+| `jack-tar-ollama` | 1.1.1 | Local AI image generation via Ollama (free draft tier) |
+| `jack-tar-cloud` | 1.3.3 | Cloud AI image generation (OpenAI, Google, FAL.ai, Recraft) |
+| `jack-tar-msft-smartart` | 1.2.2 | Editable PowerPoint SmartArt (29 layouts, native OOXML) |
+| `jack-tar-custom-smartart` | 1.1.1 | Data viz and custom graphics (SVG, Mermaid, Vega-Lite, matplotlib) |
+| `jack-tar-deckhand` | 1.5.1 | Full presentation pipeline orchestrator |
+| `jack-tar-superpower-bridge` | 0.3.0 | Bridge from `/pptx` decks into Jack-Tar enrichment |
+
+## Marketplace manifest
+
+`.claude-plugin/marketplace.json` registers all six plugins under the `jack-tar`
+marketplace (owner: Steve Jones). The manifest tracks versions per-plugin (listed in
+the table above); it does not carry a single top-level marketplace version field.
+
+## What's GA vs in-progress
+
+**GA / shipped:**
+
+- The core deck pipeline in `jack-tar-deckhand` (brand-manager → slide-stylist →
+  narrative-architect → strategy-map → smartart selection/extraction →
+  speaker-notes-writer → imagegen-bridge → deck-assembler → deck-qa).
+- Five rendering strategies plus `full_bleed` (image-is-the-slide, zero chrome).
+- Editable SmartArt (`jack-tar-msft-smartart`) and custom data-viz graphics
+  (`jack-tar-custom-smartart`).
+- Cloud resolution control (1K / 2K / 4K) and Recraft V4 brand-fidelity raster in
+  `jack-tar-cloud`.
+- The Superpower Bridge route (`/bridge-brief`, `/enrich-deck`) for enriching
+  `/pptx`-authored decks.
+
+**Headline recent capability — `creative_vision` (v1.5):**
+
+- Operator prose → vision-faithful full-slide image via a multi-agent cascade
+  (Director's Brief → Prompt Reviewer → Render → image-reviewer → Director's Critic).
+- Always pairs with `full_bleed` assembly. GA flow has four load-bearing parts:
+  strategy-map cost surfacing, a pre-deck Creative Sprint phase, a per-iteration
+  operator gate (F12), and optional deck-level creative anchors.
+- See the "Creative vision pipeline" section of
+  `plugins/jack-tar-deckhand/CLAUDE.md` for the full GA flow.
+
+**Optional external integration:**
+
+- `academic_figure` slides route through the external **paperbanana** CLI when it is
+  installed locally (`pip install 'paperbanana[google]'`, `pipx`, or `uvx`).
+  paperbanana is treated as an external CLI tool — a sibling orchestrator like LaTeX
+  or ImageMagick — not as a Claude Code plugin. When absent, the bridge falls back to
+  Nano Banana Flash 1K with academic-figure-aware prompting; pipelines never break on
+  the absent optional dependency. ADR:
+  `docs/architecture/paperbanana-integration-v2.md`.
+
+## Tests
+
+Per-plugin test counts are not hand-maintained here — run `pytest` within each plugin
+(via `.venv/bin/pytest`) for current counts.

--- a/docs/superpowers/plans/2026-06-02-repo-cleanup-branch-landing.md
+++ b/docs/superpowers/plans/2026-06-02-repo-cleanup-branch-landing.md
@@ -1,0 +1,156 @@
+# Repo Cleanup & Stale-Branch Landing Implementation Plan
+
+> **For agentic workers:** Steps use checkbox (`- [ ]`) syntax for tracking. This is a release-engineering / git-orchestration plan (land + triage + cleanup), not a TDD feature build — steps are concrete git/gh/test commands with expected output, not red-green cycles.
+
+**Goal:** Land the recoverable work stranded in two stale worktree branches (token-pricing spike, phase-A release-readiness), then remove the dead worktrees and stale scratch from the repo.
+
+**Architecture:** Three sequential steps. (1) Land existing PR #106 (token-pricing) — clean, CI-green, just needs freshening. (2) Triage the 42-commit phase-A branch into themed slices, re-landing survivors as small PRs off current `main` rather than one stale conflict-heavy merge. (3) Remove merged/landed worktrees and stale files.
+
+**Tech Stack:** git, gh CLI, pytest (`.venv/bin/pytest`), GitHub Actions (9-job validation workflow).
+
+**Key facts established during investigation (2026-06-02):**
+- PR **#106** already open: base `main`, head `worktree-spike-actual-token-pricing`, 36 files, +4481/−171, **all 9 CI checks green** as of 2026-05-22. Branch is 51 commits behind main; local trial-merge is **clean (zero conflicts)**.
+- `feat/release-readiness-phase-a`: 42 commits, **302 commits behind** main, last touched Apr 19, trial-merge shows **20+ files "changed in both"**. Work is genuinely un-landed (post-install hooks, `narrative_standalone.py`, omnibus builder all absent from main). Worktree is dirty (uncommitted `CLAUDE.md` + 2 untracked phase-e design docs).
+- `feat/plugin-marketplace` worktree: fully merged to main, clean — safe to drop.
+- Both token-pricing prod modules (`actual_cost_calculator.py`, `cloud_results.py`) are net-new on main.
+
+---
+
+## Step 1 — Land token-pricing PR #106
+
+**Files (on branch `worktree-spike-actual-token-pricing`):**
+- Review: `.claude/settings.local.json` (machine-local — should not ship in a feature PR)
+- Ship: `plugins/jack-tar-cloud/src/{actual_cost_calculator,cloud_results,generate_cloud_image}.py`, `src/{actual_cost_calculator,cloud_results,budget_tracker,generate_cloud_image,render_funnel}.py`, spike docs, tools, tests
+
+- [ ] **Step 1.1: Review the settings.local.json delta on the branch**
+
+Run: `git diff main worktree-spike-actual-token-pricing -- .claude/settings.local.json`
+Decide: if it is only local permission/allowlist noise, revert it on the branch (Step 1.2). If it grants a permission the feature genuinely needs, keep it. Default expectation: revert.
+
+- [ ] **Step 1.2: If reverting, drop settings.local.json change from the branch**
+
+```bash
+git -C .claude/worktrees/spike-actual-token-pricing checkout main -- .claude/settings.local.json
+git -C .claude/worktrees/spike-actual-token-pricing commit -m "chore: drop machine-local settings.local.json from PR" .claude/settings.local.json
+```
+Expected: one commit removing the settings delta. (Skip if Step 1.1 decided to keep it.)
+
+- [ ] **Step 1.3: Freshen the branch against current main**
+
+```bash
+git -C .claude/worktrees/spike-actual-token-pricing merge origin/main
+```
+Expected: clean merge (local trial-merge confirmed zero conflicts). If conflicts surface, resolve, favouring main for any plugin.json/package-lock drift.
+
+- [ ] **Step 1.4: Run the full test suite on the freshened branch**
+
+Run: `cd .claude/worktrees/spike-actual-token-pricing && ../../../.venv/bin/pytest plugins/jack-tar-cloud/tests plugins/jack-tar-deckhand/tests tests/test_actual_cost_calculator.py tests/test_budget_tracker.py tests/test_cloud_results.py tests/test_pricing_freshness.py -q`
+Expected: all pass. (Adjust the venv relative path as needed; the repo venv is at the main worktree root.)
+
+- [ ] **Step 1.5: Push and confirm CI re-runs green**
+
+```bash
+git -C .claude/worktrees/spike-actual-token-pricing push
+gh pr checks 106
+```
+Expected: all 9 jobs pass.
+
+- [ ] **Step 1.6: Confirm the #113 cost-table reconciliation scope**
+
+The spike headline is "catalog under-estimates 32%". Decide whether updating `cascade.py TIER_COSTS` (the #113 Pro 2K $0.134-vs-$0.193 gap) belongs in this PR or in follow-ups #108–111. If in-scope, make the edit + a test on the branch and re-push. If follow-up, note it in the PR body and leave for #108–111.
+
+- [ ] **Step 1.7: Merge PR #106**
+
+```bash
+gh pr merge 106 --merge
+```
+Expected: merged to main via merge commit (project convention — never `--squash`).
+
+- [ ] **Step 1.8: Remove the token-pricing worktree**
+
+```bash
+git worktree remove .claude/worktrees/spike-actual-token-pricing
+git worktree prune
+```
+Expected: worktree gone; `git worktree list` no longer shows it. The `.claude/worktrees/` parent dir (now empty) can be removed.
+
+---
+
+## Step 2 — Triage phase-A into themed slices
+
+Do **not** merge `feat/release-readiness-phase-a` wholesale (302 behind, 20+ conflict files, 5 mixed concerns). Investigate per-cluster, then re-land survivors as small PRs off current `main`.
+
+**Cluster map (from the 42-commit log):**
+
+| Slice | Representative commits | Files | Initial call |
+|-------|------------------------|-------|--------------|
+| A. Install/bootstrap infra | `fc2bc13 016bf18 a08dd15 b9d1703 11b2b50 3b19027` + fresh-install CI `6021384 367a527` | `plugins/*/hooks/post-install.sh`, `plugins/*/package-lock.json`, plugin.json manifests | Re-land fresh — high value |
+| B. Narrative/notes standalone | `071b775 07d5bfa 6ad3d23 ee6cdb6` | `src/narrative_standalone.py`, `tests/test_narrative_standalone.py`, narrative-architect/speaker-notes SKILL.md | Re-land fresh — feature + tests |
+| C. Omnibus SmartArt builder | `b60d006 8363720 de3b278 df3c853 0e7772e 9e7a7c6` | `tools/build_smartart_omnibus.py`, `tools/omnibus_config.json`, `tests/test_build_smartart_omnibus.py` | Re-land if still wanted |
+| D. Release docs | `a7f59ef 30e80af b402a3f 52a90ba e09d117 bcd154c 41c62bf 1e2e310` | README/USER-GUIDE, install/troubleshooting, TalkBriefs, env-var doc alignment | Audit — some superseded by 302 commits |
+| E. Polish/fixes | `ad7e224 67a2ee2 46f1ff9 bb4a126 5d4d391` | QA check count, example data shapes, manifest naming | Likely already drifted/fixed — probably drop |
+
+- [ ] **Step 2.1: Per-cluster superseded-check**
+
+For each cluster A–E, confirm whether the target files/behaviour already exist on current main (they mostly do not, per the landing check, but docs/polish clusters D/E are the drift risks). Produce a keep/rework/drop verdict per cluster. Checkpoint with operator before cutting any PR.
+
+- [ ] **Step 2.2: Slice A — install/bootstrap infra PR**
+
+Cherry-pick cluster A commits onto a fresh `feat/plugin-post-install-hooks` branch off main. Resolve package-lock/plugin.json conflicts favouring current main's versions. Run `.venv/bin/pytest` + the fresh-install CI sim. Open PR → base main. Merge when green.
+
+- [ ] **Step 2.3: Slice B — narrative standalone PR**
+
+Cherry-pick cluster B onto `feat/narrative-standalone` off main. Run `.venv/bin/pytest plugins/jack-tar-deckhand/tests/test_narrative_standalone.py`. Open PR → base main. Merge when green.
+
+- [ ] **Step 2.4: Slice C — omnibus builder (operator-gated)**
+
+Confirm with operator the omnibus dev tool is still wanted. If yes, cherry-pick cluster C onto `feat/smartart-omnibus-builder` off main, run `tests/test_build_smartart_omnibus.py`, open PR. If no, skip.
+
+- [ ] **Step 2.5: Slices D + E — audit then re-land survivors**
+
+Diff each doc/polish commit against current main. Re-land only the changes that are still accurate (env-var alignment, deck-conductor invocation fix likely survive; version bumps + test-count docs likely superseded). Bundle survivors into one `docs/release-readiness-survivors` PR. Drop the rest.
+
+- [ ] **Step 2.6: Capture or discard the 2 untracked phase-e design docs**
+
+`docs/superpowers/plans/2026-04-18-phase-e-release-fixes.md` + `.../specs/2026-04-18-phase-e-release-fixes-design.md` live only in the dirty phase-a worktree. If they have forward value, copy into `docs/` on a branch and commit; else note and discard.
+
+- [ ] **Step 2.7: Remove the phase-a worktree once triage is complete**
+
+```bash
+git worktree remove --force .worktrees/phase-a-bootstrap   # --force: worktree is intentionally dirty post-triage
+git branch -D feat/release-readiness-phase-a               # only after all survivors are re-landed
+git worktree prune
+```
+Expected: worktree + stale branch gone. Do NOT run until Steps 2.2–2.6 have salvaged everything wanted.
+
+---
+
+## Step 3 — Worktree / disk / file cleanup
+
+- [ ] **Step 3.1: Remove the fully-merged plugin-marketplace worktree**
+
+```bash
+git worktree remove .worktrees/plugin-marketplace
+git worktree prune
+```
+Expected: gone (branch `feat/plugin-marketplace` is fully merged to main — safe).
+
+- [ ] **Step 3.2: Delete the stale Ralph task spec**
+
+```bash
+rm .claude/ralph-task-creative-vision-ga.md
+```
+Expected: removed (#113 GA work has landed; the task spec is dead).
+
+- [ ] **Step 3.3: Final state check**
+
+Run: `git worktree list && git status --porcelain && du -sh .worktrees .claude/worktrees 2>/dev/null`
+Expected: only the main worktree (+ any in-flight Step 2 branches) remain; no stranded `.worktrees/` or `.claude/worktrees/` clutter.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Step 1 = token-pricing (PR #106). Step 2 = phase-A triage (all 5 clusters + dirty docs + worktree removal). Step 3 = remaining worktrees + ralph file + final check. The earlier `output/`+`tmp/` cleanup is already done (commit `fdc6368`). Covered.
+- **Sequencing risk:** Step 2.7 (remove phase-a worktree) is explicitly gated behind 2.2–2.6 so no unmerged work is lost. Step 1.8 / 3.1 worktree removals are only for merged/landed branches.
+- **Reversibility:** No `git branch -D` of an unmerged branch until its work is re-landed. PR merges use `--merge` per project convention. `--force` worktree removal is only used on phase-a *after* salvage.

--- a/plugins/jack-tar-cloud/CLAUDE.md
+++ b/plugins/jack-tar-cloud/CLAUDE.md
@@ -5,8 +5,9 @@ Cloud AI image generation using OpenAI, Google, FAL.ai, and Recraft APIs. Per-pr
 ## Prerequisites
 
 At least one API key configured:
-- `OPENAI_API_KEY` — for OpenAI GPT Image and Recraft V4 icons
-- `GOOGLE_CLOUD_PROJECT` — for Google Gemini/Imagen
+- `OPENAI_API_KEY` — for OpenAI GPT Image
+- `RECRAFT_API_KEY` — for Recraft V4 icons (or `FAL_KEY` via the FAL.ai route)
+- `GOOGLE_API_KEY` (Gemini Developer API) or `GOOGLE_APPLICATION_CREDENTIALS` (Vertex) — for Google Gemini/Imagen
 - `FAL_KEY` — for FAL.ai FLUX Pro/Klein/Ideogram
 
 ## Skills

--- a/plugins/jack-tar-cloud/README.md
+++ b/plugins/jack-tar-cloud/README.md
@@ -17,9 +17,9 @@ At least one API key configured as an environment variable:
 | Variable | Provider | Used for |
 |----------|----------|----------|
 | `OPENAI_API_KEY` | OpenAI | GPT Image generation |
-| `GOOGLE_CLOUD_PROJECT` | Google | Gemini / Nanobanana image generation |
+| `GOOGLE_API_KEY` / `GOOGLE_APPLICATION_CREDENTIALS` | Google | Gemini / Nanobanana image generation (Developer API key or Vertex credentials) |
 | `FAL_KEY` | FAL.ai | FLUX Pro, Klein, Ideogram |
-| `OPENAI_API_KEY` | Recraft | SVG vector icons via Recraft V4 |
+| `RECRAFT_API_KEY` | Recraft | SVG vector icons via Recraft V4 |
 
 Run `/jack-tar-cloud:verify` to see which providers are reachable with your current keys.
 

--- a/plugins/jack-tar-cloud/skills/google-image/SKILL.md
+++ b/plugins/jack-tar-cloud/skills/google-image/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: google-image
-description: Generate images using Google Gemini/Imagen API. Requires GOOGLE_CLOUD_PROJECT environment variable.
+description: Generate images using Google Gemini/Imagen API. Requires GOOGLE_API_KEY (Gemini Developer API) or GOOGLE_APPLICATION_CREDENTIALS (Vertex).
 argument-hint: "a description of the image" [--output PATH] [--aspect-ratio 16:9|1:1|4:3|9:16|3:4] [--model MODEL] [--tier draft|standard|premium] [--resolution 1K|2K|4K]
 allowed-tools: Bash(python *)
 ---
@@ -56,12 +56,12 @@ If neither is provided, defaults to `standard` tier (Nanobanana Flash).
 ```bash
 PYTHONPATH="$PLUGIN_ROOT" python3 -c "
 import os
-configured = bool(os.environ.get('GOOGLE_CLOUD_PROJECT') or os.environ.get('GOOGLE_API_KEY'))
+configured = bool(os.environ.get('GOOGLE_API_KEY') or os.environ.get('GOOGLE_APPLICATION_CREDENTIALS'))
 print('available' if configured else 'not_configured')
 "
 ```
 
-If `not_configured`, tell the user to set `GOOGLE_API_KEY` (or `GOOGLE_CLOUD_PROJECT`) and stop.
+If `not_configured`, tell the user to set `GOOGLE_API_KEY` (Gemini Developer API) or `GOOGLE_APPLICATION_CREDENTIALS` (Vertex) and stop.
 
 ## Generate
 

--- a/plugins/jack-tar-cloud/skills/recraft-icon/SKILL.md
+++ b/plugins/jack-tar-cloud/skills/recraft-icon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: recraft-icon
-description: Generate vector icons (SVG) using Recraft V4 API (direct or via FAL.ai). Accepts a text prompt with optional brand colors, generates native SVG output, and saves to a path. Requires OPENAI_API_KEY (Recraft direct) or FAL_KEY (FAL.ai route).
+description: Generate vector icons (SVG) using Recraft V4 API (direct or via FAL.ai). Accepts a text prompt with optional brand colors, generates native SVG output, and saves to a path. Requires RECRAFT_API_KEY (Recraft direct) or FAL_KEY (FAL.ai route).
 argument-hint: "icon description" [--provider recraft|fal] [--output PATH] [--colors HEX,HEX,...] [--format svg|png] [--tier standard|pro]
 allowed-tools: Bash(python *), Read, Glob
 ---
@@ -73,7 +73,7 @@ providers = discover_providers()
 provider = '$PROVIDER'
 if provider == 'recraft':
     p = providers.get('recraft', {})
-    env_var = 'RECRAFT_API'
+    env_var = 'RECRAFT_API_KEY'
 else:
     p = providers.get('fal', {})
     env_var = 'FAL_KEY'
@@ -82,7 +82,7 @@ print('available' if p.get('available') else f'not_configured: set {env_var}')
 ```
 
 If not configured, tell the user which environment variable to set:
-- `recraft` needs `RECRAFT_API` (see research/04-cloud-api-setup-licensing.md section D)
+- `recraft` needs `RECRAFT_API_KEY` (see research/04-cloud-api-setup-licensing.md section D)
 - `fal` needs `FAL_KEY` (see research/04-cloud-api-setup-licensing.md section C)
 
 ## Generate the Icon

--- a/plugins/jack-tar-deckhand/CLAUDE.md
+++ b/plugins/jack-tar-deckhand/CLAUDE.md
@@ -29,7 +29,7 @@ Without engine plugins, the pipeline produces text-only slides with placeholder 
 | `/speaker-notes-writer` | Generate timed speaker notes |
 | `/imagegen-bridge` | Route image generation to available plugins |
 | `/deck-assembler` | Assemble .pptx — routes to PptxGenJS (standard) or python-pptx (template mode) |
-| `/deck-qa` | Run 30 anti-pattern checks |
+| `/deck-qa` | Run 25 automated anti-pattern checks |
 | `/iterate-slide` | Single-slide critique-driven refinement via paperbanana `--continue-run` (three modes: auto / enumerate / draft) |
 | `/verify` | Check pipeline readiness and engine plugin availability |
 

--- a/plugins/jack-tar-deckhand/skills/deck-assembler/SKILL.md
+++ b/plugins/jack-tar-deckhand/skills/deck-assembler/SKILL.md
@@ -20,6 +20,26 @@ All of these DeckContext files must exist before running:
 - `./tmp/deck/strategy-map.json` (StrategyMap) — optional, controls per-slide rendering approach
 - `./tmp/deck/images/` directory with referenced image files
 
+## Plugin Setup
+
+```bash
+PLUGIN_ROOT=$(python3 -c "
+from pathlib import Path
+import sys, os
+if os.environ.get('JACK_TAR_DECKHAND_ROOT'):
+    print(os.environ['JACK_TAR_DECKHAND_ROOT']); sys.exit()
+home = Path.home()
+for base in [home / '.claude' / 'plugins' / 'cache']:
+    for p in base.rglob('jack-tar-deckhand/.claude-plugin/plugin.json'):
+        print(str(p.parent.parent)); sys.exit()
+dev = Path.cwd() / 'plugins' / 'jack-tar-deckhand'
+if dev.exists():
+    print(str(dev)); sys.exit()
+print('NOT_FOUND')
+" 2>/dev/null)
+if [ -z "$PLUGIN_ROOT" ] || [ "$PLUGIN_ROOT" = "NOT_FOUND" ]; then echo "ERROR: jack-tar-deckhand not found" && exit 1; fi
+```
+
 ## Usage
 
 **Routing:** Check for `./tmp/deck/template-profile.json` first.

--- a/plugins/jack-tar-deckhand/skills/deck-qa/SKILL.md
+++ b/plugins/jack-tar-deckhand/skills/deck-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deck-qa
-description: Run 30 automated anti-pattern checks on an assembled .pptx and produce a QAReport with verdict and per-slide findings.
+description: Run 25 automated anti-pattern checks on an assembled .pptx and produce a QAReport with verdict and per-slide findings.
 argument-hint: [--pptx-path PATH] [--deck-dir PATH] [--duration MINUTES]
 allowed-tools: Bash(python *), Read, Glob
 ---

--- a/plugins/jack-tar-deckhand/skills/speaker-notes-writer/SKILL.md
+++ b/plugins/jack-tar-deckhand/skills/speaker-notes-writer/SKILL.md
@@ -23,6 +23,28 @@ Invoked by the Deck Conductor after narrative-architect. Can also be invoked dir
 /speaker-notes-writer --deck-dir ./tmp/deck
 ```
 
+## Plugin Setup
+
+Run this first — the steps below reference `$PLUGIN_ROOT`.
+
+```bash
+PLUGIN_ROOT=$(python3 -c "
+from pathlib import Path
+import sys, os
+if os.environ.get('JACK_TAR_DECKHAND_ROOT'):
+    print(os.environ['JACK_TAR_DECKHAND_ROOT']); sys.exit()
+home = Path.home()
+for base in [home / '.claude' / 'plugins' / 'cache']:
+    for p in base.rglob('jack-tar-deckhand/.claude-plugin/plugin.json'):
+        print(str(p.parent.parent)); sys.exit()
+dev = Path.cwd() / 'plugins' / 'jack-tar-deckhand'
+if dev.exists():
+    print(str(dev)); sys.exit()
+print('NOT_FOUND')
+" 2>/dev/null)
+if [ -z "$PLUGIN_ROOT" ] || [ "$PLUGIN_ROOT" = "NOT_FOUND" ]; then echo "ERROR: jack-tar-deckhand not found" && exit 1; fi
+```
+
 ## What It Does
 
 ### Step 0: Check for External Notes (Before Preferences)
@@ -141,26 +163,6 @@ For each slide in the outline, produce a note with:
 - Emphasis markers on key phrases
 - Demo cues (when outline includes demo beats)
 - Build animation triggers (when outline has progressive disclosure)
-
-## Plugin Setup
-
-```bash
-PLUGIN_ROOT=$(python3 -c "
-from pathlib import Path
-import sys, os
-if os.environ.get('JACK_TAR_DECKHAND_ROOT'):
-    print(os.environ['JACK_TAR_DECKHAND_ROOT']); sys.exit()
-home = Path.home()
-for base in [home / '.claude' / 'plugins' / 'cache']:
-    for p in base.rglob('jack-tar-deckhand/.claude-plugin/plugin.json'):
-        print(str(p.parent.parent)); sys.exit()
-dev = Path.cwd() / 'plugins' / 'jack-tar-deckhand'
-if dev.exists():
-    print(str(dev)); sys.exit()
-print('NOT_FOUND')
-" 2>/dev/null)
-if [ -z "$PLUGIN_ROOT" ] || [ "$PLUGIN_ROOT" = "NOT_FOUND" ]; then echo "ERROR: jack-tar-deckhand not found" && exit 1; fi
-```
 
 ### Step 3: Validate and Write
 

--- a/plugins/jack-tar-msft-smartart/skills/render/SKILL.md
+++ b/plugins/jack-tar-msft-smartart/skills/render/SKILL.md
@@ -42,16 +42,25 @@ If `--spec-file` is provided, read it as the spec. Otherwise build a spec from `
 
 ## Build Spec
 
-If building from arguments, construct:
+If building from arguments, construct (note the required `data` wrapper):
 ```json
 {
   "graphic_type": "<TYPE>",
   "layout_id": "<LAYOUT_ID or null>",
-  "items": ["<item1>", "<item2>"]
+  "data": {"items": ["<item1>", "<item2>"]}
 }
 ```
 
-For hierarchical types (org_chart, hierarchy), `--items` is not valid — require `--spec-file` with a `tree` key.
+The engine requires a top-level `data` key — `items` (flat-list types) or `tree` (hierarchical types) go INSIDE `data`. A spec with top-level `items`/`tree` raises `RenderError("spec is missing required key 'data'")`.
+
+For hierarchical types (org_chart, hierarchy), `--items` is not valid — require `--spec-file` whose `data` holds a `tree` key:
+```json
+{
+  "graphic_type": "org_chart",
+  "layout_id": "<LAYOUT_ID or null>",
+  "data": {"tree": {"...": "..."}}
+}
+```
 
 ## Render Carrier
 
@@ -66,15 +75,25 @@ Path(output_dir).mkdir(parents=True, exist_ok=True)
 
 from src.engine import render
 result = render(spec, output_dir)
-print(json.dumps(result, indent=2))
+print(json.dumps({
+    'output_path': str(result.output_path),
+    'layout_id': result.layout_id,
+    'layout_uri': result.layout_uri,
+    'node_count': result.node_count,
+    'engine': result.engine,
+}, indent=2))
 "
 ```
 
-The `render()` function returns a dict with at minimum:
-- `carrier_pptx`: absolute path to the generated carrier file
+The `render()` function returns a `RenderResult` dataclass with these fields:
+- `output_path` (Path): path to the generated carrier `.pptx` file
 - `layout_id`: the layout that was used
-- `status`: `ok` or `error`
+- `layout_uri`: the OOXML layout URI for that layout
+- `node_count` (int): number of data nodes rendered
+- `engine`: the rendering engine identifier
+
+On failure the function raises `RenderError` (e.g. a missing `data` key) rather than returning an error status — catch the exception to report failure.
 
 ## Report
 
-Report the carrier file path, layout used, and status. On error, report the error message.
+Report the carrier file path (`output_path`), layout used (`layout_id`), and node count. On error, report the `RenderError` message.


### PR DESCRIPTION
## What

Slice D of the phase-A salvage. The phase-e audit (cherry-picked from the abandoned branch) found documentation/SKILL inaccuracies that survived v1.3/1.4/1.5. Each fix is **verified against current code**, not the stale April spec.

| # | Defect | Fix |
|---|--------|-----|
| E3 | README shows `deck-conductor` as a runnable slash command | It's a conversational **Agent** — reworded |
| E4 | Recraft docs say `OPENAI_API_KEY` | Code reads `RECRAFT_API_KEY` (or `FAL_KEY`) — fixed in recraft-icon SKILL (frontmatter + body), cloud README, cloud CLAUDE.md |
| E5 | Google docs front `GOOGLE_CLOUD_PROJECT` | Code uses `GOOGLE_API_KEY` / `GOOGLE_APPLICATION_CREDENTIALS` — fixed in google-image SKILL, cloud README, cloud CLAUDE.md |
| E7 | deck-assembler SKILL uses `$PLUGIN_ROOT` undefined | Added the canonical discovery block (from sibling skills) before first use |
| E8 | speaker-notes SKILL uses `PLUGIN_ROOT` before defining it | Relocated Plugin Setup block above first use |
| E9 | QA check count contradictory (30 / 25 / ~12) | Normalised to **25** = verified distinct registered check functions |
| E10 | root CLAUDE.md brittle hand-maintained test count | Softened to "run `pytest` per plugin" |
| E11 | msft render SKILL — wrong input + return shape | Spec needs `data.{items\|tree}` (engine raises on missing `data`); return is `RenderResult(output_path, layout_id, layout_uri, node_count, engine)`, not `{carrier_pptx, status}` |

## New

- **`docs/RELEASE-STATE.md`** — concise current-state summary derived from the plugin manifests (all 6 versions verified against `.claude-plugin/plugin.json`).
- The repo-cleanup / branch-landing **plan** that drove this whole effort (`docs/superpowers/plans/2026-06-02-...`).

## Verification

- `pytest` cloud → 115 passed, deckhand → 412 passed, msft → 10 passed (no SKILL.md drift-detector regressions)
- E4/E5/E9/E11 values confirmed against `generate_cloud_icon.py`, `provider_discovery.py`, `qa/checks/__init__.py`, `engine.py`

## Scope notes

E1/E2/E6 from the audit were **moot** (target files/subsystems no longer exist on main). `review_loop.py` + the rc1 release ceremony were **discarded** as superseded. The omnibus-builder concept → routed to #48; canonical example shapes → #19 (separate issue comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)