### PR TITLE
feat: dynamic model catalog — single source of truth, release-decoupled updates, live discovery (EPIC #125)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "name": "jack-tar-cloud",
       "description": "Cloud AI image generation \u2014 OpenAI, Google, FAL.ai, Recraft with smart provider routing",
       "source": "./plugins/jack-tar-cloud",
-      "version": "1.3.3"
+      "version": "1.4.0"
     },
     {
       "name": "jack-tar-msft-smartart",
@@ -33,13 +33,13 @@
       "name": "jack-tar-deckhand",
       "description": "Full presentation pipeline \u2014 brand, style, narrative, images, SmartArt, assembly, QA + academic-figure rendering (optional paperbanana CLI; local-first Ollama tier + local_only zero-spend mode, #119) + /iterate-slide single-slide critique-driven refinement + full_bleed image-is-the-slide strategy + creative vision renderer (#105) + creative_vision GA: per-slide cost surface, Creative Sprint phase, per-iteration operator gate, deck-level creative anchors (#113)",
       "source": "./plugins/jack-tar-deckhand",
-      "version": "1.6.0"
+      "version": "1.7.0"
     },
     {
       "name": "jack-tar-superpower-bridge",
       "description": "Wraps document-skills:pptx with narrative pre-brief (/bridge-brief) and post-hoc visual enrichment (/enrich-deck) \u2014 combine /pptx structural strength with jack-tar visual capabilities (AI backgrounds, element images, editable SmartArt, native charts)",
       "source": "./plugins/jack-tar-superpower-bridge",
-      "version": "0.3.0"
+      "version": "0.3.1"
     }
   ]
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -342,7 +342,10 @@
       "Bash(chmod +x plugins/jack-tar-deckhand/hooks/block-png-read.sh)",
       "Bash(xargs -I{} echo \"Open issues remaining: {}\")",
       "Bash(pytest tests/test_chart_marker.py -v)",
-      "Bash(pytest -q)"
+      "Bash(pytest -q)",
+      "Bash(uv venv *)",
+      "Bash(uv pip *)",
+      "Bash(sdkcheck/bin/python -c ' *)"
     ],
     "deny": [
       "Bash(git push --force:*)",

--- a/docs/model-catalog.md
+++ b/docs/model-catalog.md
@@ -1,0 +1,82 @@
+# Model Catalog
+
+<!-- AUTO-GENERATED from model-catalog/model-catalog.json — do not edit by hand. -->
+<!-- Regenerate with: python model-catalog/catalog_markdown.py -->
+
+Catalog version **1.0.0**, updated **2026-07-15**, min loader version 1.
+
+Single source of truth for model identity, capability, and pricing across all jack-tar plugins (EPIC #125). Loaded by `model_catalog.py` with shipped → cached-remote → local-config precedence.
+
+## Role defaults
+
+| Role | Default |
+|---|---|
+| icon | `recraft-v4-svg` |
+| image_gen | `gemini-3.1-flash-image` |
+| local_draft | `x/flux2-klein → x/z-image-turbo` |
+| vlm_json | `gemini-3.5-flash` |
+
+## FAL.ai
+
+| Model | Status | Roles | Resolutions | Pricing (USD) | Quirks | Aliases |
+|---|---|---|---|---|---|---|
+| `fal-ai/flux-2-pro` | active | image_gen | 1K, 2K | $0.030 first MP + $0.015/extra MP | — | `flux-2-pro` |
+| `fal-ai/flux-2-klein` | active | image_gen | 1K | $0.014 flat | — | `flux-2-klein` |
+| `fal-ai/ideogram/v3` | active | image_gen | 1K | $0.060 flat *(estimate)* | — | `ideogram-3` |
+
+## Google (Nano Banana + Imagen)
+
+| Model | Status | Roles | Resolutions | Pricing (USD) | Quirks | Aliases |
+|---|---|---|---|---|---|---|
+| `gemini-3.1-flash-image` | active | image_gen | 512, 1K, 2K, 4K | 512 $0.045; 1K $0.067; 2K $0.101; 4K $0.151 | no_negative_prompt | `gemini-3.1-flash-image-preview` |
+| `gemini-3-pro-image` | active | image_gen | 1K, 2K, 4K | 1K $0.134; 2K $0.134; 4K $0.240 | no_negative_prompt | `gemini-3-pro-image-preview` |
+| `imagen-4.0-fast-generate-001` | active | image_gen | 1K | vertex: 1K $0.020; developer: 1K $0.020 | fixed_resolution, no_negative_prompt | `imagen-4-fast` |
+| `imagen-4.0-generate-001` | active | image_gen | 1K, 2K | vertex: 1K $0.040, 2K $0.040; developer: 1K $0.040, 2K $0.101 | no_negative_prompt | `imagen-4`, `imagen-4-standard` |
+| `imagen-4.0-ultra-generate-001` | active | image_gen | 1K, 2K | vertex: 1K $0.060, 2K $0.060; developer: 1K $0.060, 2K $0.101 | no_negative_prompt | `imagen-4-ultra` |
+| `gemini-3.5-flash` | active | vlm, vlm_json | — | — | — | — |
+| `gemini-2.5-flash` | deprecated → `gemini-3.5-flash` | vlm | — | — | thinking | — |
+| `gemini-2.0-flash` | retired → `gemini-3.5-flash` | vlm, vlm_json | — | — | — | — |
+
+## Ollama (local, free)
+
+| Model | Status | Roles | Resolutions | Pricing (USD) | Quirks | Aliases |
+|---|---|---|---|---|---|---|
+| `x/flux2-klein` | active | image_gen, local_draft | 1K | $0.000 flat | — | — |
+| `x/z-image-turbo` | active | image_gen, local_draft | 1K | $0.000 flat | — | — |
+
+## OpenAI
+
+| Model | Status | Roles | Resolutions | Pricing (USD) | Quirks | Aliases |
+|---|---|---|---|---|---|---|
+| `gpt-image-1.5` | active | image_gen | 1K | $0.009–$0.200 by size×quality | no_negative_prompt | — |
+
+## Recraft
+
+| Model | Status | Roles | Resolutions | Pricing (USD) | Quirks | Aliases |
+|---|---|---|---|---|---|---|
+| `recraft-v4-standard` | active | image_gen | 1K | 1K $0.040 | — | `recraft-v4` |
+| `recraft-v4-pro` | active | image_gen | 2K, 4K | 2K $0.250; 4K $0.500 *(estimate)* | upscale_chain_4k | — |
+| `recraft-v4-svg` | active | icon | — | standard $0.08; pro $0.30 | — | `recraftv4` |
+
+## Notes
+
+- **`gemini-3.1-flash-image`** — Nano Banana Flash. The '-preview' suffixed id was deprecated upstream (issue #123, verified 2026-07-15); alias retained so existing manifests and callers resolve.
+- **`gemini-3.1-flash-image` pricing** — EPIC #58 pricing table; reconciled issue #113 AC6. Token rates from ai.google.dev/gemini-api/docs/pricing (captured 2026-05-21).
+- **`gemini-3-pro-image`** — Nano Banana Pro — best in-image text rendering. '-preview' id deprecated upstream (issue #123).
+- **`gemini-3-pro-image` pricing** — Pro 2K priced identically to Pro 1K (issue #113 AC6 reconciliation). Token rates from ai.google.dev/gemini-api/docs/pricing (captured 2026-05-21).
+- **`imagen-4.0-fast-generate-001`** — Fixed native resolution — rejects image_size/sampleImageSize with 400 INVALID_ARGUMENT (issue #74). 'imagen-4-fast' is the router-side alias.
+- **`imagen-4.0-generate-001` pricing** — Dual pricing: Vertex (GOOGLE_APPLICATION_CREDENTIALS) flat per-image; Gemini Developer API (GOOGLE_API_KEY only) token-based, 2K dearer.
+- **`imagen-4.0-ultra-generate-001` pricing** — Developer-API 2K treated as token-based like Standard.
+- **`gpt-image-1.5` pricing** — token_rates are UNVERIFIED_ESTIMATE — all OpenAI pricing URLs 403/404'd during the 2026-05-21 spike; community-cited placeholders pending dashboard verification (see docs/spikes/2026-05-21-actual-token-pricing/).
+- **`fal-ai/flux-2-pro`** — Caps at 2048x2048.
+- **`fal-ai/flux-2-pro` pricing** — ~$0.045 for 1920x1080. budget_tracker previously carried a divergent $0.050 flat figure — the tiered rate here is canonical (EPIC #125).
+- **`fal-ai/ideogram/v3` pricing** — Published range $0.030-$0.090; midpoint used.
+- **`recraft-v4-standard`** — Router-side id; dispatch picks the actual endpoint by tier+resolution (issue #61).
+- **`recraft-v4-standard` pricing** — Verified via fal.ai/models/fal-ai/recraft/v4/*.
+- **`recraft-v4-pro` pricing** — 4K = 2K generation ($0.25) + Creative Upscale ($0.25 FAL-parity assumption — direct-API upscale price not published; env override honoured when positive).
+- **`recraft-v4-svg` pricing** — Same rates via direct API and the FAL route (fal-ai/recraft/v4/text-to-vector). budget_tracker previously carried divergent $0.04/$0.08 svg/png figures — per_tier here is canonical (EPIC #125).
+- **`x/flux2-klein`** — Tag-prefix entry: exact installed tag (e.g. x/flux2-klein:9b) resolves at runtime via /api/tags — never hardcode tags. Preferred local model for academic figures (F16 audit: Klein 9b at 8/9 on the deck-schema brief).
+- **`x/z-image-turbo`** — Fast local draft fallback when flux2-klein is not pulled.
+- **`gemini-3.5-flash`** — Verified 2026-07-15 (issue #123): non-thinking for retriever/planning steps, clean JSON output for paperbanana's parser, publication-quality academic figures in 2-3 iterations at ~$0.02/diagram.
+- **`gemini-2.5-flash`** — Thinking model — reasoning tokens break strict-JSON parsers (paperbanana retriever loops to ~17min timeout, issues #122/#123). NOT eligible for the vlm_json role. Deprecated as a jack-tar default in favour of gemini-3.5-flash.
+- **`gemini-2.0-flash`** — Retired upstream — 404 NOT_FOUND 'This model is no longer available' (verified 2026-07-15, issue #123).

--- a/model-catalog/catalog_markdown.py
+++ b/model-catalog/catalog_markdown.py
@@ -1,0 +1,148 @@
+"""Generate docs/model-catalog.md from model-catalog.json.
+
+Same pattern as smartart_pptx_native/layouts/catalog_markdown.py: the
+markdown is a build artifact of the catalog; CI drift-checks that the two
+were regenerated in the same commit (see
+plugins/integration_tests/test_model_catalog_integrity.py).
+
+Usage:
+    python model-catalog/catalog_markdown.py          # rewrite docs/model-catalog.md
+    python model-catalog/catalog_markdown.py --check  # exit 1 if doc is stale
+"""
+
+import json
+import sys
+from pathlib import Path
+
+CATALOG_DIR = Path(__file__).resolve().parent
+CATALOG_PATH = CATALOG_DIR / "model-catalog.json"
+DOC_PATH = CATALOG_DIR.parent / "docs" / "model-catalog.md"
+
+_PROVIDER_TITLES = {
+    "google": "Google (Nano Banana + Imagen)",
+    "openai": "OpenAI",
+    "fal": "FAL.ai",
+    "recraft": "Recraft",
+    "ollama": "Ollama (local, free)",
+    "mlx": "MLX (local, free)",
+}
+
+
+def _pricing_summary(entry):
+    pricing = entry.get("pricing")
+    if not pricing:
+        return "—"
+    parts = []
+    if "flat" in pricing:
+        parts.append(f"${pricing['flat']:.3f} flat")
+    for res, cost in (pricing.get("per_resolution") or {}).items():
+        parts.append(f"{res} ${cost:.3f}")
+    for backend, table in (pricing.get("backends") or {}).items():
+        inner = ", ".join(f"{res} ${cost:.3f}" for res, cost in table.items())
+        parts.append(f"{backend}: {inner}")
+    psq = pricing.get("per_size_quality") or {}
+    if psq:
+        low = min(psq.values())
+        high = max(psq.values())
+        parts.append(f"${low:.3f}–${high:.3f} by size×quality")
+    for tier, cost in (pricing.get("per_tier") or {}).items():
+        parts.append(f"{tier} ${cost:.2f}")
+    tiered = pricing.get("tiered_megapixel")
+    if tiered:
+        parts.append(
+            f"${tiered['first_mp']:.3f} first MP + "
+            f"${tiered['per_extra_mp']:.3f}/extra MP"
+        )
+    suffix = " *(estimate)*" if pricing.get("estimate") else ""
+    return "; ".join(parts) + suffix
+
+
+def render(catalog):
+    lines = [
+        "# Model Catalog",
+        "",
+        "<!-- AUTO-GENERATED from model-catalog/model-catalog.json — do not edit by hand. -->",
+        "<!-- Regenerate with: python model-catalog/catalog_markdown.py -->",
+        "",
+        f"Catalog version **{catalog['catalog_version']}**, "
+        f"updated **{catalog['updated']}**, "
+        f"min loader version {catalog['min_loader_version']}.",
+        "",
+        "Single source of truth for model identity, capability, and pricing "
+        "across all jack-tar plugins (EPIC #125). Loaded by "
+        "`model_catalog.py` with shipped → cached-remote → local-config "
+        "precedence.",
+        "",
+        "## Role defaults",
+        "",
+        "| Role | Default |",
+        "|---|---|",
+    ]
+    for role, value in sorted((catalog.get("role_defaults") or {}).items()):
+        rendered = value if isinstance(value, str) else " → ".join(value)
+        lines.append(f"| {role} | `{rendered}` |")
+    lines.append("")
+
+    by_provider = {}
+    for entry in catalog["models"]:
+        by_provider.setdefault(entry["provider"], []).append(entry)
+
+    for provider in sorted(by_provider):
+        lines += [
+            f"## {_PROVIDER_TITLES.get(provider, provider)}",
+            "",
+            "| Model | Status | Roles | Resolutions | Pricing (USD) | Quirks | Aliases |",
+            "|---|---|---|---|---|---|---|",
+        ]
+        for entry in by_provider[provider]:
+            caps = entry.get("capabilities") or {}
+            resolutions = ", ".join(caps.get("resolutions", [])) or "—"
+            status = entry["status"]
+            if status == "retired":
+                status = f"retired → `{entry['replacement']}`"
+            elif status == "deprecated" and entry.get("replacement"):
+                status = f"deprecated → `{entry['replacement']}`"
+            quirks = ", ".join(entry.get("quirks", [])) or "—"
+            aliases = ", ".join(f"`{a}`" for a in entry.get("aliases", [])) or "—"
+            lines.append(
+                f"| `{entry['id']}` | {status} | {', '.join(entry['roles'])} "
+                f"| {resolutions} | {_pricing_summary(entry)} | {quirks} "
+                f"| {aliases} |"
+            )
+        lines.append("")
+
+    lines += [
+        "## Notes",
+        "",
+    ]
+    for entry in catalog["models"]:
+        if entry.get("notes"):
+            lines.append(f"- **`{entry['id']}`** — {entry['notes']}")
+        pricing_notes = (entry.get("pricing") or {}).get("notes")
+        if pricing_notes:
+            lines.append(f"- **`{entry['id']}` pricing** — {pricing_notes}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv):
+    catalog = json.loads(CATALOG_PATH.read_text())
+    rendered = render(catalog)
+    if "--check" in argv:
+        current = DOC_PATH.read_text() if DOC_PATH.exists() else ""
+        if current != rendered:
+            print(
+                f"STALE: {DOC_PATH} does not match {CATALOG_PATH}. "
+                f"Regenerate with: python {Path(__file__).relative_to(Path.cwd())}",
+                file=sys.stderr,
+            )
+            return 1
+        print(f"OK: {DOC_PATH} is current.")
+        return 0
+    DOC_PATH.write_text(rendered)
+    print(f"Wrote {DOC_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/model-catalog/model-catalog.json
+++ b/model-catalog/model-catalog.json
@@ -26,7 +26,8 @@
         "verified": "2026-05-24",
         "estimate": false,
         "per_resolution": {"512": 0.045, "1K": 0.067, "2K": 0.101, "4K": 0.151},
-        "notes": "EPIC #58 pricing table; reconciled issue #113 AC6."
+        "token_rates": {"text_input_per_mtok": 0.5, "image_output_per_mtok": 60.0},
+        "notes": "EPIC #58 pricing table; reconciled issue #113 AC6. Token rates from ai.google.dev/gemini-api/docs/pricing (captured 2026-05-21)."
       },
       "sdk": {"api": "generate_content", "config_field": "image_size"},
       "notes": "Nano Banana Flash. The '-preview' suffixed id was deprecated upstream (issue #123, verified 2026-07-15); alias retained so existing manifests and callers resolve."
@@ -48,7 +49,8 @@
         "verified": "2026-05-24",
         "estimate": false,
         "per_resolution": {"1K": 0.134, "2K": 0.134, "4K": 0.24},
-        "notes": "Pro 2K priced identically to Pro 1K (issue #113 AC6 reconciliation)."
+        "token_rates": {"text_input_per_mtok": 2.0, "image_output_per_mtok": 120.0},
+        "notes": "Pro 2K priced identically to Pro 1K (issue #113 AC6 reconciliation). Token rates from ai.google.dev/gemini-api/docs/pricing (captured 2026-05-21)."
       },
       "sdk": {"api": "generate_content", "config_field": "image_size"},
       "notes": "Nano Banana Pro — best in-image text rendering. '-preview' id deprecated upstream (issue #123)."
@@ -149,7 +151,9 @@
           "1024x1536|low": 0.013,
           "1024x1536|medium": 0.051,
           "1024x1536|high": 0.2
-        }
+        },
+        "token_rates": {"input_per_mtok": 5.0, "output_per_mtok": 40.0},
+        "notes": "token_rates are UNVERIFIED_ESTIMATE — all OpenAI pricing URLs 403/404'd during the 2026-05-21 spike; community-cited placeholders pending dashboard verification (see docs/spikes/2026-05-21-actual-token-pricing/)."
       },
       "sdk": {"api": "openai_images"}
     },

--- a/model-catalog/model-catalog.json
+++ b/model-catalog/model-catalog.json
@@ -1,0 +1,366 @@
+{
+  "catalog_version": "1.0.0",
+  "min_loader_version": 1,
+  "updated": "2026-07-15",
+  "role_defaults": {
+    "image_gen": "gemini-3.1-flash-image",
+    "vlm_json": "gemini-3.5-flash",
+    "icon": "recraft-v4-svg",
+    "local_draft": ["x/flux2-klein", "x/z-image-turbo"]
+  },
+  "models": [
+    {
+      "id": "gemini-3.1-flash-image",
+      "provider": "google",
+      "aliases": ["gemini-3.1-flash-image-preview"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["512", "1K", "2K", "4K"],
+        "text_rendering": "good"
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-24",
+        "estimate": false,
+        "per_resolution": {"512": 0.045, "1K": 0.067, "2K": 0.101, "4K": 0.151},
+        "notes": "EPIC #58 pricing table; reconciled issue #113 AC6."
+      },
+      "sdk": {"api": "generate_content", "config_field": "image_size"},
+      "notes": "Nano Banana Flash. The '-preview' suffixed id was deprecated upstream (issue #123, verified 2026-07-15); alias retained so existing manifests and callers resolve."
+    },
+    {
+      "id": "gemini-3-pro-image",
+      "provider": "google",
+      "aliases": ["gemini-3-pro-image-preview"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K", "2K", "4K"],
+        "text_rendering": "excellent"
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-24",
+        "estimate": false,
+        "per_resolution": {"1K": 0.134, "2K": 0.134, "4K": 0.24},
+        "notes": "Pro 2K priced identically to Pro 1K (issue #113 AC6 reconciliation)."
+      },
+      "sdk": {"api": "generate_content", "config_field": "image_size"},
+      "notes": "Nano Banana Pro — best in-image text rendering. '-preview' id deprecated upstream (issue #123)."
+    },
+    {
+      "id": "imagen-4.0-fast-generate-001",
+      "provider": "google",
+      "aliases": ["imagen-4-fast"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["fixed_resolution", "no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K"]
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "backends": {
+          "vertex": {"1K": 0.02},
+          "developer": {"1K": 0.02}
+        }
+      },
+      "sdk": {"api": "generate_images"},
+      "notes": "Fixed native resolution — rejects image_size/sampleImageSize with 400 INVALID_ARGUMENT (issue #74). 'imagen-4-fast' is the router-side alias."
+    },
+    {
+      "id": "imagen-4.0-generate-001",
+      "provider": "google",
+      "aliases": ["imagen-4", "imagen-4-standard"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K", "2K"],
+        "prompt_budget": {"max_words": 40, "style": "concise"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "backends": {
+          "vertex": {"1K": 0.04, "2K": 0.04},
+          "developer": {"1K": 0.04, "2K": 0.101}
+        },
+        "notes": "Dual pricing: Vertex (GOOGLE_APPLICATION_CREDENTIALS) flat per-image; Gemini Developer API (GOOGLE_API_KEY only) token-based, 2K dearer."
+      },
+      "sdk": {"api": "generate_images", "config_field": "image_size"}
+    },
+    {
+      "id": "imagen-4.0-ultra-generate-001",
+      "provider": "google",
+      "aliases": ["imagen-4-ultra"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K", "2K"]
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "backends": {
+          "vertex": {"1K": 0.06, "2K": 0.06},
+          "developer": {"1K": 0.06, "2K": 0.101}
+        },
+        "notes": "Developer-API 2K treated as token-based like Standard."
+      },
+      "sdk": {"api": "generate_images", "config_field": "image_size"}
+    },
+    {
+      "id": "gpt-image-1.5",
+      "provider": "openai",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "prompt_budget": {"max_words": 500, "style": "natural_language"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "per_size_quality": {
+          "1024x1024|low": 0.009,
+          "1024x1024|medium": 0.034,
+          "1024x1024|high": 0.133,
+          "1536x1024|low": 0.013,
+          "1536x1024|medium": 0.051,
+          "1536x1024|high": 0.2,
+          "1024x1536|low": 0.013,
+          "1024x1536|medium": 0.051,
+          "1024x1536|high": 0.2
+        }
+      },
+      "sdk": {"api": "openai_images"}
+    },
+    {
+      "id": "fal-ai/flux-2-pro",
+      "provider": "fal",
+      "aliases": ["flux-2-pro"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K", "2K"],
+        "prompt_budget": {"max_words": 60, "style": "photography"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "tiered_megapixel": {"first_mp": 0.03, "per_extra_mp": 0.015},
+        "notes": "~$0.045 for 1920x1080. budget_tracker previously carried a divergent $0.050 flat figure — the tiered rate here is canonical (EPIC #125)."
+      },
+      "sdk": {"api": "fal_subscribe"},
+      "notes": "Caps at 2048x2048."
+    },
+    {
+      "id": "fal-ai/flux-2-klein",
+      "provider": "fal",
+      "aliases": ["flux-2-klein"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"]
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "flat": 0.014
+      },
+      "sdk": {"api": "fal_subscribe"}
+    },
+    {
+      "id": "fal-ai/ideogram/v3",
+      "provider": "fal",
+      "aliases": ["ideogram-3"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "text_rendering": "excellent",
+        "prompt_budget": {"max_words": 80, "style": "typography"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": true,
+        "flat": 0.06,
+        "notes": "Published range $0.030-$0.090; midpoint used."
+      },
+      "sdk": {"api": "fal_subscribe"}
+    },
+    {
+      "id": "recraft-v4-standard",
+      "provider": "recraft",
+      "aliases": ["recraft-v4"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "brand_hex_fidelity": true,
+        "prompt_budget": {"max_words": 100, "style": "design_centric"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-07",
+        "estimate": false,
+        "per_resolution": {"1K": 0.04},
+        "notes": "Verified via fal.ai/models/fal-ai/recraft/v4/*."
+      },
+      "sdk": {"api": "recraft_rest", "endpoint": "external.api.recraft.ai/v1"},
+      "notes": "Router-side id; dispatch picks the actual endpoint by tier+resolution (issue #61)."
+    },
+    {
+      "id": "recraft-v4-pro",
+      "provider": "recraft",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["upscale_chain_4k"],
+      "capabilities": {
+        "resolutions": ["2K", "4K"],
+        "brand_hex_fidelity": true
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-07",
+        "estimate": true,
+        "per_resolution": {"2K": 0.25, "4K": 0.5},
+        "env_override": {"upscale": "RECRAFT_UPSCALE_COST_USD"},
+        "notes": "4K = 2K generation ($0.25) + Creative Upscale ($0.25 FAL-parity assumption — direct-API upscale price not published; env override honoured when positive)."
+      },
+      "sdk": {"api": "recraft_rest", "endpoint": "external.api.recraft.ai/v1"}
+    },
+    {
+      "id": "recraft-v4-svg",
+      "provider": "recraft",
+      "aliases": ["recraftv4"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["icon"],
+      "quirks": [],
+      "capabilities": {
+        "vector": true,
+        "brand_hex_fidelity": true
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "per_tier": {"standard": 0.08, "pro": 0.3},
+        "notes": "Same rates via direct API and the FAL route (fal-ai/recraft/v4/text-to-vector). budget_tracker previously carried divergent $0.04/$0.08 svg/png figures — per_tier here is canonical (EPIC #125)."
+      },
+      "sdk": {"api": "recraft_rest", "endpoint": "fal-ai/recraft/v4/text-to-vector"}
+    },
+    {
+      "id": "x/flux2-klein",
+      "provider": "ollama",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen", "local_draft"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "timeout_seconds": 600,
+        "prompt_budget": {"max_words": 200, "style": "detailed_spatial"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-07-10",
+        "estimate": false,
+        "flat": 0.0
+      },
+      "sdk": {"api": "ollama_generate"},
+      "notes": "Tag-prefix entry: exact installed tag (e.g. x/flux2-klein:9b) resolves at runtime via /api/tags — never hardcode tags. Preferred local model for academic figures (F16 audit: Klein 9b at 8/9 on the deck-schema brief)."
+    },
+    {
+      "id": "x/z-image-turbo",
+      "provider": "ollama",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen", "local_draft"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "timeout_seconds": 120,
+        "prompt_budget": {"max_words": 50, "style": "concise_camera"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-07-10",
+        "estimate": false,
+        "flat": 0.0
+      },
+      "sdk": {"api": "ollama_generate"},
+      "notes": "Fast local draft fallback when flux2-klein is not pulled."
+    },
+    {
+      "id": "gemini-3.5-flash",
+      "provider": "google",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["vlm", "vlm_json"],
+      "quirks": [],
+      "capabilities": {},
+      "sdk": {"api": "generate_content"},
+      "notes": "Verified 2026-07-15 (issue #123): non-thinking for retriever/planning steps, clean JSON output for paperbanana's parser, publication-quality academic figures in 2-3 iterations at ~$0.02/diagram."
+    },
+    {
+      "id": "gemini-2.5-flash",
+      "provider": "google",
+      "aliases": [],
+      "status": "deprecated",
+      "replacement": "gemini-3.5-flash",
+      "roles": ["vlm"],
+      "quirks": ["thinking"],
+      "capabilities": {},
+      "sdk": {"api": "generate_content"},
+      "notes": "Thinking model — reasoning tokens break strict-JSON parsers (paperbanana retriever loops to ~17min timeout, issues #122/#123). NOT eligible for the vlm_json role. Deprecated as a jack-tar default in favour of gemini-3.5-flash."
+    },
+    {
+      "id": "gemini-2.0-flash",
+      "provider": "google",
+      "aliases": [],
+      "status": "retired",
+      "replacement": "gemini-3.5-flash",
+      "roles": ["vlm", "vlm_json"],
+      "quirks": [],
+      "capabilities": {},
+      "sdk": {"api": "generate_content"},
+      "notes": "Retired upstream — 404 NOT_FOUND 'This model is no longer available' (verified 2026-07-15, issue #123)."
+    }
+  ]
+}

--- a/model-catalog/model-catalog.schema.json
+++ b/model-catalog/model-catalog.schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://raw.githubusercontent.com/SteveGJones/jack-tar-deckhand/main/model-catalog/model-catalog.schema.json",
+  "title": "Jack-Tar Model Catalog",
+  "description": "Single source of truth for AI model identities, capabilities, and pricing across all jack-tar plugins (EPIC #125). Model IDs, aliases, retirement pointers, resolution capability, and cost tables live HERE, not in code. The loader (model_catalog.py) merges: shipped baseline -> cached remote (~/.jack-tar/model-catalog.json) -> local-config.json overrides.",
+  "type": "object",
+  "required": ["catalog_version", "min_loader_version", "updated", "models"],
+  "additionalProperties": false,
+  "properties": {
+    "catalog_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Semver of the catalog DATA (independent of plugin versions). Bump patch for price/name corrections, minor for new models, major for schema-shape changes."
+    },
+    "min_loader_version": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Minimum model_catalog.py LOADER_VERSION able to consume this catalog. A remote catalog with min_loader_version > installed loader is rejected at refresh time."
+    },
+    "updated": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "Date this catalog content was last verified/edited (YYYY-MM-DD)."
+    },
+    "role_defaults": {
+      "type": "object",
+      "description": "Default model id per role. Value is a model id string, or an ordered preference list of model ids (first available wins — used for local_draft where installation varies per machine).",
+      "additionalProperties": {
+        "oneOf": [
+          {"type": "string", "minLength": 1},
+          {"type": "array", "items": {"type": "string", "minLength": 1}, "minItems": 1}
+        ]
+      }
+    },
+    "models": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/definitions/model"}
+    }
+  },
+  "definitions": {
+    "model": {
+      "type": "object",
+      "required": ["id", "provider", "status", "roles"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Canonical model identifier as the provider's API accepts it TODAY (e.g. 'gemini-3.1-flash-image', 'fal-ai/flux-2-pro', 'x/flux2-klein'). Ollama entries are tag-prefixes; exact installed tags resolve at runtime via /api/tags."
+        },
+        "provider": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Provider family: google | openai | fal | recraft | ollama | mlx | ..."
+        },
+        "aliases": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true,
+          "description": "Former or alternate names that resolve to this entry (e.g. retired '-preview' suffixed ids, router-side short names). Must be globally unique across all ids and aliases."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["active", "deprecated", "retired"],
+          "description": "active: use freely. deprecated: works but scheduled for retirement — loader warns. retired: provider no longer serves it — loader substitutes 'replacement'."
+        },
+        "replacement": {
+          "type": ["string", "null"],
+          "description": "Model id to substitute when this entry is retired/deprecated. REQUIRED (non-null) when status is 'retired'."
+        },
+        "roles": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true,
+          "description": "What this model is FOR. Known roles: image_gen (raster generation), vlm (vision-language), vlm_json (VLM safe for strict-JSON parsers — thinking models are NOT), icon (vector icon generation), upscale, local_draft (free local draft tier)."
+        },
+        "quirks": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1},
+          "uniqueItems": true,
+          "description": "Behavioural gotchas encoded as data. Known quirks: thinking (emits reasoning tokens that break strict JSON parsers), fixed_resolution (rejects image_size/sampleImageSize param — issue #74), no_negative_prompt, upscale_chain_4k (4K = 2K generation + creative upscale chain)."
+        },
+        "capabilities": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "resolutions": {
+              "type": "array",
+              "items": {"type": "string", "enum": ["512", "1K", "2K", "4K"]},
+              "uniqueItems": true,
+              "description": "Supported resolution tiers."
+            },
+            "text_rendering": {
+              "type": "string",
+              "enum": ["poor", "fair", "good", "excellent"],
+              "description": "In-image text rendering quality — drives router preference for text-bearing slides."
+            },
+            "vector": {"type": "boolean", "description": "Produces vector (SVG) output."},
+            "brand_hex_fidelity": {"type": "boolean", "description": "Renders exact specified hex colours (Recraft) vs approximating them."},
+            "timeout_seconds": {"type": "integer", "minimum": 1, "description": "Recommended per-render timeout (local models)."},
+            "prompt_budget": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["max_words", "style"],
+              "properties": {
+                "max_words": {"type": "integer", "minimum": 1},
+                "style": {"type": "string", "minLength": 1}
+              },
+              "description": "Prompt-translator budget: word cap + translation style key."
+            }
+          }
+        },
+        "pricing": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["currency", "verified", "estimate"],
+          "properties": {
+            "currency": {"type": "string", "enum": ["USD"]},
+            "verified": {
+              "type": "string",
+              "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+              "description": "Date this pricing was last checked against provider docs/billing."
+            },
+            "estimate": {
+              "type": "boolean",
+              "description": "true when the numbers are inferred/assumed rather than provider-published (e.g. Recraft direct-API upscale FAL-parity assumption)."
+            },
+            "flat": {"type": "number", "minimum": 0, "description": "Flat USD per image regardless of parameters."},
+            "per_resolution": {
+              "type": "object",
+              "additionalProperties": {"type": "number", "minimum": 0},
+              "description": "USD per image keyed by resolution tier ('512'|'1K'|'2K'|'4K')."
+            },
+            "backends": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "object",
+                "additionalProperties": {"type": "number", "minimum": 0}
+              },
+              "description": "Backend-dependent per-resolution pricing (Google Imagen: 'vertex' flat vs 'developer' token-based). Keys are backend names, values are per-resolution maps."
+            },
+            "per_size_quality": {
+              "type": "object",
+              "additionalProperties": {"type": "number", "minimum": 0},
+              "description": "USD per image keyed by '<size>|<quality>' (OpenAI: '1024x1024|low')."
+            },
+            "per_tier": {
+              "type": "object",
+              "additionalProperties": {"type": "number", "minimum": 0},
+              "description": "USD per image keyed by provider tier name (icon generation: 'standard'|'pro')."
+            },
+            "tiered_megapixel": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["first_mp", "per_extra_mp"],
+              "properties": {
+                "first_mp": {"type": "number", "minimum": 0},
+                "per_extra_mp": {"type": "number", "minimum": 0}
+              },
+              "description": "USD for first megapixel + per additional megapixel (FAL FLUX 2 Pro)."
+            },
+            "env_override": {
+              "type": "object",
+              "additionalProperties": {"type": "string"},
+              "description": "Env vars that override specific price components at call time, keyed by component (e.g. {\"upscale\": \"RECRAFT_UPSCALE_COST_USD\"})."
+            },
+            "notes": {"type": "string"}
+          }
+        },
+        "sdk": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "api": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Which API surface serves this model: generate_content (Nano Banana), generate_images (Imagen), openai_images, fal_subscribe, recraft_rest, ollama_generate, ..."
+            },
+            "config_field": {
+              "type": "string",
+              "description": "SDK config field carrying the resolution (google-genai ImageConfig: 'image_size' — verified present on SDK 2.11.0, issue #121)."
+            },
+            "endpoint": {"type": "string", "description": "Endpoint path/id where it differs from the model id."}
+          }
+        },
+        "notes": {"type": "string", "description": "Provenance, verification context, decision history."}
+      }
+    }
+  }
+}

--- a/model-catalog/model-catalog.schema.json
+++ b/model-catalog/model-catalog.schema.json
@@ -150,6 +150,11 @@
               "additionalProperties": {"type": "number", "minimum": 0},
               "description": "USD per image keyed by provider tier name (icon generation: 'standard'|'pro')."
             },
+            "token_rates": {
+              "type": "object",
+              "additionalProperties": {"type": "number", "minimum": 0},
+              "description": "Per-MTok token rates for actual-cost computation from API usage metadata (e.g. text_input_per_mtok, image_output_per_mtok). Component names follow the provider's usage surface."
+            },
             "tiered_megapixel": {
               "type": "object",
               "additionalProperties": false,

--- a/plugins/integration_tests/test_model_catalog_integrity.py
+++ b/plugins/integration_tests/test_model_catalog_integrity.py
@@ -1,0 +1,176 @@
+"""Model catalog integrity — EPIC #125, issue #126.
+
+Three guarantees:
+
+1. **Copy identity** — the canonical catalog + loader at the repo top level
+   and the vendored copies inside each consumer plugin are byte-identical.
+   (Same pattern as the router capability drift test: the canonical artifact
+   is authoritative; plugin copies are distribution details.)
+2. **Schema validity** — the catalog validates against
+   model-catalog/model-catalog.schema.json (full JSON-Schema, not just the
+   loader's structural check).
+3. **Price agreement** — while the legacy hardcoded tables still exist
+   (until issue #127 deletes them), the catalog and the cloud module's
+   estimators must agree. The catalog's alias resolution bridges the old
+   '-preview' ids the cloud module still uses.
+"""
+import json
+import sys
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+WORKTREE = Path(__file__).resolve().parents[2]
+CANONICAL_DIR = WORKTREE / "model-catalog"
+CANONICAL_CATALOG = CANONICAL_DIR / "model-catalog.json"
+CANONICAL_SCHEMA = CANONICAL_DIR / "model-catalog.schema.json"
+CANONICAL_LOADER = WORKTREE / "src" / "model_catalog.py"
+
+CLOUD_ROOT = WORKTREE / "plugins" / "jack-tar-cloud"
+DECKHAND_ROOT = WORKTREE / "plugins" / "jack-tar-deckhand"
+
+VENDORED_CATALOGS = [
+    CLOUD_ROOT / "src" / "model-catalog.json",
+    DECKHAND_ROOT / "src" / "model-catalog.json",
+]
+VENDORED_LOADERS = [
+    CLOUD_ROOT / "src" / "model_catalog.py",
+    DECKHAND_ROOT / "src" / "model_catalog.py",
+]
+
+PLUGIN_ROOT = CLOUD_ROOT  # for the conftest src-namespace isolation fixture
+
+
+class TestCopyIdentity:
+    @pytest.mark.parametrize("vendored", VENDORED_CATALOGS, ids=lambda p: p.parts[-3])
+    def test_catalog_copies_identical(self, vendored):
+        assert vendored.read_bytes() == CANONICAL_CATALOG.read_bytes(), (
+            f"{vendored} has drifted from {CANONICAL_CATALOG} — edit the "
+            f"canonical file and re-copy: cp {CANONICAL_CATALOG} {vendored}"
+        )
+
+    @pytest.mark.parametrize("vendored", VENDORED_LOADERS, ids=lambda p: p.parts[-3])
+    def test_loader_copies_identical(self, vendored):
+        assert vendored.read_bytes() == CANONICAL_LOADER.read_bytes(), (
+            f"{vendored} has drifted from {CANONICAL_LOADER} — edit the "
+            f"canonical file and re-copy: cp {CANONICAL_LOADER} {vendored}"
+        )
+
+
+class TestSchemaValidity:
+    def test_catalog_validates_against_schema(self):
+        catalog = json.loads(CANONICAL_CATALOG.read_text())
+        schema = json.loads(CANONICAL_SCHEMA.read_text())
+        jsonschema.validate(catalog, schema)
+
+    def test_schema_itself_is_valid_draft07(self):
+        schema = json.loads(CANONICAL_SCHEMA.read_text())
+        jsonschema.Draft7Validator.check_schema(schema)
+
+
+class TestPriceAgreementWithLegacyTables:
+    """Until #127 deletes the hardcoded tables, catalog and code must agree.
+
+    The cloud module still keys its tables by the retired '-preview' ids;
+    the catalog resolves those via aliases — asserting through the alias
+    proves both the price AND the alias mapping.
+    """
+
+    @pytest.fixture
+    def catalog(self, tmp_path):
+        sys.path.insert(0, str(CLOUD_ROOT))
+        from src.model_catalog import load_catalog
+        return load_catalog(
+            shipped_path=CLOUD_ROOT / "src" / "model-catalog.json",
+            cache_path=tmp_path / "no-cache.json",
+            local_config_path=tmp_path / "no-local.json",
+        )
+
+    def test_nano_banana_costs_match(self, catalog):
+        from src.generate_cloud_image import _NANO_BANANA_COSTS
+        for (legacy_model, resolution), expected in _NANO_BANANA_COSTS.items():
+            assert catalog.cost(legacy_model, resolution=resolution) == expected, (
+                f"{legacy_model}@{resolution}: catalog disagrees with "
+                f"_NANO_BANANA_COSTS"
+            )
+
+    def test_imagen_costs_match_both_backends(self, catalog):
+        from src.generate_cloud_image import (
+            _IMAGEN_DEVELOPER_COSTS,
+            _IMAGEN_VERTEX_COSTS,
+        )
+        for backend, table in [
+            ("vertex", _IMAGEN_VERTEX_COSTS),
+            ("developer", _IMAGEN_DEVELOPER_COSTS),
+        ]:
+            for (model, resolution), expected in table.items():
+                assert catalog.cost(
+                    model, resolution=resolution, backend=backend
+                ) == expected
+
+    def test_openai_costs_match(self, catalog):
+        from src.generate_cloud_image import _OPENAI_COSTS
+        for (size, quality), expected in _OPENAI_COSTS.items():
+            assert catalog.cost("gpt-image-1.5", size=size, quality=quality) == expected
+
+    def test_fal_flat_costs_match(self, catalog):
+        from src.generate_cloud_image import _FAL_FLAT_COSTS
+        for model, expected in _FAL_FLAT_COSTS.items():
+            assert catalog.cost(model) == expected
+
+    def test_fal_tiered_costs_match(self, catalog):
+        from src.generate_cloud_image import _FAL_TIERED_COSTS
+        for model, (first_mp, per_extra) in _FAL_TIERED_COSTS.items():
+            entry = catalog.get(model)
+            rates = entry["pricing"]["tiered_megapixel"]
+            assert (rates["first_mp"], rates["per_extra_mp"]) == (first_mp, per_extra)
+
+    def test_recraft_costs_match(self, catalog, monkeypatch):
+        monkeypatch.delenv("RECRAFT_UPSCALE_COST_USD", raising=False)
+        from src.generate_cloud_image import estimate_recraft_cost
+        assert catalog.cost("recraft-v4-standard", resolution="1K") == \
+            estimate_recraft_cost(tier="standard", resolution="1K")
+        assert catalog.cost("recraft-v4-pro", resolution="2K") == \
+            estimate_recraft_cost(tier="pro", resolution="2K")
+        assert catalog.cost("recraft-v4-pro", resolution="4K") == \
+            estimate_recraft_cost(tier="pro", resolution="4K")
+
+    def test_model_resolutions_match(self, catalog):
+        from src.generate_cloud_image import _MODEL_RESOLUTIONS
+        for legacy_model, expected in _MODEL_RESOLUTIONS.items():
+            assert catalog.resolutions(legacy_model) == expected, (
+                f"{legacy_model}: catalog capability disagrees with "
+                f"_MODEL_RESOLUTIONS"
+            )
+
+    def test_icon_costs_match(self, catalog):
+        from src.generate_cloud_icon import _ICON_COSTS
+        for (provider, tier), expected in _ICON_COSTS.items():
+            assert catalog.cost("recraft-v4-svg", tier=tier) == expected, (
+                f"icon {provider}/{tier}: catalog disagrees with _ICON_COSTS"
+            )
+
+    def test_cascade_tier_costs_match(self, catalog, monkeypatch):
+        """cascade.py TIER_COSTS is the deckhand projection of cloud pricing;
+        the catalog must agree with every cascade tier."""
+        monkeypatch.delenv("RECRAFT_UPSCALE_COST_USD", raising=False)
+        sys.path.insert(0, str(DECKHAND_ROOT))
+        for key in [k for k in list(sys.modules) if k == "src" or k.startswith("src.")]:
+            del sys.modules[key]
+        from src.creative_vision.cascade import (
+            TIER_COSTS,
+            TIER_TO_PROVIDER_MODEL_RESOLUTION,
+        )
+        deckhand_catalog_path = DECKHAND_ROOT / "src" / "model-catalog.json"
+        from src.model_catalog import load_catalog as deckhand_load
+        deckhand_catalog = deckhand_load(
+            shipped_path=deckhand_catalog_path,
+            cache_path=Path("/nonexistent/no-cache.json"),
+            local_config_path=Path("/nonexistent/no-local.json"),
+        )
+        for tier, (provider, model, resolution) in TIER_TO_PROVIDER_MODEL_RESOLUTION.items():
+            if provider is None:
+                continue
+            assert deckhand_catalog.cost(model, resolution=resolution) == \
+                TIER_COSTS[tier], f"cascade tier {tier}: catalog disagrees"

--- a/plugins/integration_tests/test_model_catalog_integrity.py
+++ b/plugins/integration_tests/test_model_catalog_integrity.py
@@ -9,10 +9,10 @@ Three guarantees:
 2. **Schema validity** — the catalog validates against
    model-catalog/model-catalog.schema.json (full JSON-Schema, not just the
    loader's structural check).
-3. **Price agreement** — while the legacy hardcoded tables still exist
-   (until issue #127 deletes them), the catalog and the cloud module's
-   estimators must agree. The catalog's alias resolution bridges the old
-   '-preview' ids the cloud module still uses.
+3. **Price agreement** — the cloud module's tables are DERIVED from the
+   catalog since #127; these tests now guard the derivation logic (a
+   derivation bug would desynchronise them). The alias assertions also
+   prove the retired '-preview' ids still resolve.
 """
 import json
 import subprocess
@@ -45,6 +45,11 @@ VENDORED_REFRESH = [
     CLOUD_ROOT / "src" / "model_catalog_refresh.py",
 ]
 
+CANONICAL_PROBE = WORKTREE / "src" / "model_probe.py"
+VENDORED_PROBE = [
+    CLOUD_ROOT / "src" / "model_probe.py",
+]
+
 PLUGIN_ROOT = CLOUD_ROOT  # for the conftest src-namespace isolation fixture
 
 
@@ -68,6 +73,13 @@ class TestCopyIdentity:
         assert vendored.read_bytes() == CANONICAL_REFRESH.read_bytes(), (
             f"{vendored} has drifted from {CANONICAL_REFRESH} — edit the "
             f"canonical file and re-copy: cp {CANONICAL_REFRESH} {vendored}"
+        )
+
+    @pytest.mark.parametrize("vendored", VENDORED_PROBE, ids=lambda p: p.parts[-3])
+    def test_probe_copies_identical(self, vendored):
+        assert vendored.read_bytes() == CANONICAL_PROBE.read_bytes(), (
+            f"{vendored} has drifted from {CANONICAL_PROBE} — edit the "
+            f"canonical file and re-copy: cp {CANONICAL_PROBE} {vendored}"
         )
 
 
@@ -131,12 +143,10 @@ class TestSchemaValidity:
 
 
 class TestPriceAgreementWithLegacyTables:
-    """Until #127 deletes the hardcoded tables, catalog and code must agree.
-
-    The cloud module still keys its tables by the retired '-preview' ids;
-    the catalog resolves those via aliases — asserting through the alias
-    proves both the price AND the alias mapping.
-    """
+    """The cloud module's tables derive from the catalog (#127); these
+    assertions guard the derivation — a bug in the derivation loops would
+    desynchronise catalog.cost() from the module tables. Alias-keyed
+    assertions also prove retired '-preview' ids still resolve."""
 
     @pytest.fixture
     def catalog(self, tmp_path):

--- a/plugins/integration_tests/test_model_catalog_integrity.py
+++ b/plugins/integration_tests/test_model_catalog_integrity.py
@@ -40,6 +40,11 @@ VENDORED_LOADERS = [
     DECKHAND_ROOT / "src" / "model_catalog.py",
 ]
 
+CANONICAL_REFRESH = WORKTREE / "src" / "model_catalog_refresh.py"
+VENDORED_REFRESH = [
+    CLOUD_ROOT / "src" / "model_catalog_refresh.py",
+]
+
 PLUGIN_ROOT = CLOUD_ROOT  # for the conftest src-namespace isolation fixture
 
 
@@ -56,6 +61,13 @@ class TestCopyIdentity:
         assert vendored.read_bytes() == CANONICAL_LOADER.read_bytes(), (
             f"{vendored} has drifted from {CANONICAL_LOADER} — edit the "
             f"canonical file and re-copy: cp {CANONICAL_LOADER} {vendored}"
+        )
+
+    @pytest.mark.parametrize("vendored", VENDORED_REFRESH, ids=lambda p: p.parts[-3])
+    def test_refresh_copies_identical(self, vendored):
+        assert vendored.read_bytes() == CANONICAL_REFRESH.read_bytes(), (
+            f"{vendored} has drifted from {CANONICAL_REFRESH} — edit the "
+            f"canonical file and re-copy: cp {CANONICAL_REFRESH} {vendored}"
         )
 
 

--- a/plugins/integration_tests/test_model_catalog_integrity.py
+++ b/plugins/integration_tests/test_model_catalog_integrity.py
@@ -15,6 +15,7 @@ Three guarantees:
    '-preview' ids the cloud module still uses.
 """
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -55,6 +56,54 @@ class TestCopyIdentity:
         assert vendored.read_bytes() == CANONICAL_LOADER.read_bytes(), (
             f"{vendored} has drifted from {CANONICAL_LOADER} — edit the "
             f"canonical file and re-copy: cp {CANONICAL_LOADER} {vendored}"
+        )
+
+
+class TestGeneratedDoc:
+    def test_docs_model_catalog_md_is_current(self):
+        """docs/model-catalog.md is a build artifact of the catalog — it must
+        be regenerated in the same commit that edits model-catalog.json
+        (same pattern as the SmartArt catalog markdown drift check)."""
+        result = subprocess.run(
+            [sys.executable, str(CANONICAL_DIR / "catalog_markdown.py"), "--check"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+
+class TestNoStaleModelIds:
+    """Retired model ids must not reappear in source or operational docs.
+
+    The retired '-preview' Gemini ids and the thinking-model VLM config
+    (issues #121/#122/#123) live ONLY as catalog aliases/entries now. This
+    guard walks every plugin's src and skills tree so a stale id cannot
+    silently return in a future edit.
+    """
+
+    FORBIDDEN = (
+        "gemini-3.1-flash-image-preview",
+        "gemini-3-pro-image-preview",
+        "--vlm-model gemini-2.5-flash",
+        "--vlm-model gemini-2.0-flash",
+    )
+
+    # The catalog itself legitimately carries retired names as aliases.
+    EXEMPT_NAMES = {"model-catalog.json"}
+
+    def test_no_stale_ids_in_plugin_sources_or_skills(self):
+        offenders = []
+        for pattern in ("plugins/*/src/**/*.py", "plugins/*/skills/**/*.md",
+                        "plugins/*/agents/*.md", "plugins/*/CLAUDE.md"):
+            for path in WORKTREE.glob(pattern):
+                if path.name in self.EXEMPT_NAMES:
+                    continue
+                text = path.read_text(encoding="utf-8", errors="ignore")
+                for needle in self.FORBIDDEN:
+                    if needle in text:
+                        offenders.append(f"{path.relative_to(WORKTREE)}: {needle}")
+        assert not offenders, (
+            "Stale model ids found — the catalog is the only place retired "
+            "names may live (as aliases):\n" + "\n".join(offenders)
         )
 
 

--- a/plugins/integration_tests/test_resolution_end_to_end.py
+++ b/plugins/integration_tests/test_resolution_end_to_end.py
@@ -34,7 +34,7 @@ def _ensure_generate_cloud_image_stub():
 
 
 def test_4k_hero_slide_routes_to_nano_banana_pro():
-    """A hero slide marked resolution='4K' must route to gemini-3-pro-image-preview."""
+    """A hero slide marked resolution='4K' must route to gemini-3-pro-image."""
     from src import image_router
 
     slide = {
@@ -53,7 +53,7 @@ def test_4k_hero_slide_routes_to_nano_banana_pro():
         budget_state='allow',
     )
     assert decision.provider == 'google'
-    assert decision.model == 'gemini-3-pro-image-preview'
+    assert decision.model == 'gemini-3-pro-image'
     assert decision.resolution == '4K'
 
 
@@ -96,7 +96,7 @@ def test_4k_funnel_stage_threads_resolution_to_generate_cloud_image():
                 strategy='full_render',
                 prompt='a lighthouse at sunset',
                 funnel_stage='cloud_4k',
-                model='gemini-3-pro-image-preview',
+                model='gemini-3-pro-image',
                 output_path='/tmp/x.png',
                 provider='google',
             )
@@ -104,4 +104,4 @@ def test_4k_funnel_stage_threads_resolution_to_generate_cloud_image():
     call_kwargs = fake.call_args.kwargs
     assert call_kwargs['resolution'] == '4K'
     assert call_kwargs['provider'] == 'google'
-    assert call_kwargs['model'] == 'gemini-3-pro-image-preview'
+    assert call_kwargs['model'] == 'gemini-3-pro-image'

--- a/plugins/jack-tar-cloud/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-cloud/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-cloud",
   "description": "Cloud AI image generation — OpenAI, Google, FAL.ai, Recraft with smart provider routing",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-cloud/CLAUDE.md
+++ b/plugins/jack-tar-cloud/CLAUDE.md
@@ -46,7 +46,7 @@ Per-model resolution capability is also surfaced via `discover_providers()`:
 ```python
 from src.provider_discovery import discover_providers
 providers = discover_providers()
-providers["google"]["models"]["gemini-3-pro-image-preview"]["supported_resolutions"]
+providers["google"]["models"]["gemini-3-pro-image"]["supported_resolutions"]
 # ['1K', '2K', '4K']
 ```
 

--- a/plugins/jack-tar-cloud/agents/image-generation-expert.md
+++ b/plugins/jack-tar-cloud/agents/image-generation-expert.md
@@ -36,8 +36,8 @@ Both models are distilled and use natural language prompts only. Neither support
 |-------|----------|-----------|----------|------|-------|
 | GPT Image 1.5 | OpenAI | `gpt-image-1.5` | Illustrations, text-in-image, reasoning | $0.009-$0.133 | Low/Med/High quality. Natural language paragraphs. |
 | FLUX.2 Pro | BFL via FAL.ai | `flux-2-pro` | Hero images, photorealism | $0.03/MP | 30-80 word sweet spot. Photography prompts. |
-| Nano Banana Flash | Google | `gemini-3.1-flash-image-preview` | Speed, high volume | ~$0.067 | Efficient. Uses generate_content API. |
-| Nano Banana Pro | Google | `gemini-3-pro-image-preview` | Fidelity, complex prompts | ~$0.134 | Professional quality. Uses generate_content API. |
+| Nano Banana Flash | Google | `gemini-3.1-flash-image` | Speed, high volume | ~$0.067 | Efficient. Uses generate_content API. |
+| Nano Banana Pro | Google | `gemini-3-pro-image` | Fidelity, complex prompts | ~$0.134 | Professional quality. Uses generate_content API. |
 | Imagen 4 | Google | `imagen-4.0-generate-001` | Backgrounds, textures, people | $0.02-$0.06 | Fast/Standard/Ultra. Deprecated June 2026. |
 | Recraft V4 | Recraft | `recraft-v4` | Icons, SVG vector output | $0.08-$0.30 | ONLY native SVG model. Design-centric prompts. |
 | Ideogram 3.0 | Ideogram | `ideogram-3` | Typography, text in images | $0.03-$0.09 | 90%+ text accuracy. But prefer overlay pattern. |
@@ -122,9 +122,9 @@ FLUX.2 Pro is a 32B-parameter model. Photography-specific prompts work best.
 
 Nano Banana models use the generate_content API with natural language prompts.
 
-**Flash (gemini-3.1-flash-image-preview):** Optimised for speed. Keep prompts concise (50-100 words). Good for high-volume batch generation.
+**Flash (gemini-3.1-flash-image):** Optimised for speed. Keep prompts concise (50-100 words). Good for high-volume batch generation.
 
-**Pro (gemini-3-pro-image-preview):** Designed for professional asset production. Handles complex instructions well. Use for hero images when high fidelity is needed.
+**Pro (gemini-3-pro-image):** Designed for professional asset production. Handles complex instructions well. Use for hero images when high fidelity is needed.
 
 **Dimension control:** Nanobanana has NO explicit width/height or aspect_ratio API parameter. Output dimensions are model-determined. For full-slide images (16:9), prefix the prompt with "Slide:" — this guides the model to generate at presentation slide dimensions. For non-standard aspect ratios, use FLUX Pro instead (supports arbitrary dimensions).
 

--- a/plugins/jack-tar-cloud/skills/google-image/SKILL.md
+++ b/plugins/jack-tar-cloud/skills/google-image/SKILL.md
@@ -38,15 +38,15 @@ Parse `$ARGUMENTS` for:
 - **--resolution RES**: Tier (`1K`, `2K`, `4K`). Default: `1K`. Per-model support:
   - `imagen-4.0-fast-generate-001`: 1K only
   - `imagen-4.0-generate-001` / `imagen-4.0-ultra-generate-001`: 1K, 2K
-  - `gemini-3.1-flash-image-preview`: 512, 1K, 2K, 4K
-  - `gemini-3-pro-image-preview`: 1K, 2K, 4K
+  - `gemini-3.1-flash-image`: 512, 1K, 2K, 4K
+  - `gemini-3-pro-image`: 1K, 2K, 4K
 
   Unsupported model/resolution combinations raise `ProviderResolutionUnsupportedError`; the exception message lists supported tiers so callers can retry intelligently.
 - **--model MODEL**: Specific Google model ID (overrides --tier)
 - **--tier TIER**: Shorthand for model selection (prices shown @1K; see Cost Reference for full tier ladder):
   - `draft` → `imagen-4.0-fast-generate-001` ($0.020 @1K, no higher tiers)
-  - `standard` → `gemini-3.1-flash-image-preview` ($0.067 @1K, $0.151 @4K) — default
-  - `premium` → `gemini-3-pro-image-preview` ($0.134 @1K, $0.240 @4K)
+  - `standard` → `gemini-3.1-flash-image` ($0.067 @1K, $0.151 @4K) — default
+  - `premium` → `gemini-3-pro-image` ($0.134 @1K, $0.240 @4K)
 
 If both `--model` and `--tier` are provided, `--model` takes precedence.
 If neither is provided, defaults to `standard` tier (Nanobanana Flash).
@@ -93,8 +93,8 @@ If failed, report the error.
 | imagen-4.0-generate-001 (Dev API) | — | $0.040 | $0.101 | n/a |
 | imagen-4.0-ultra-generate-001 (Vertex) | — | $0.060 | $0.060 | n/a |
 | imagen-4.0-ultra-generate-001 (Dev API) | — | $0.060 | $0.101 | n/a |
-| gemini-3.1-flash-image-preview | $0.045 | $0.067 | $0.101 | $0.151 |
-| gemini-3-pro-image-preview | — | $0.134 | $0.134 | $0.240 |
+| gemini-3.1-flash-image | $0.045 | $0.067 | $0.101 | $0.151 |
+| gemini-3-pro-image | — | $0.134 | $0.134 | $0.240 |
 
 Imagen pricing depends on backend: `GOOGLE_APPLICATION_CREDENTIALS` set → Vertex AI flat per-image; `GOOGLE_API_KEY` only → Gemini Developer API token-based.
 

--- a/plugins/jack-tar-cloud/skills/image/SKILL.md
+++ b/plugins/jack-tar-cloud/skills/image/SKILL.md
@@ -67,8 +67,8 @@ Otherwise, route based on content suitability:
 
 When routing to Google, pass the appropriate `--model` based on use case:
 - Budget: `--model imagen-4.0-fast-generate-001`
-- Standard: `--model gemini-3.1-flash-image-preview`
-- Premium: `--model gemini-3-pro-image-preview`
+- Standard: `--model gemini-3.1-flash-image`
+- Premium: `--model gemini-3-pro-image`
 
 Dispatch the appropriate per-provider skill:
 - `fal` → `/jack-tar-cloud:fal-image`
@@ -81,7 +81,7 @@ Dispatch the appropriate per-provider skill:
 Forward the flag to the dispatched per-provider skill:
 - `--resolution 1K` (or omitted) → no change to existing routing
 - `--resolution 2K` → fal-image (FLUX 2 Pro) or google-image (Imagen Standard / Nano Banana Pro)
-- `--resolution 4K` → google-image with `--model gemini-3.1-flash-image-preview` (Flash 4K, $0.151) or `--model gemini-3-pro-image-preview` (Pro 4K, $0.240)
+- `--resolution 4K` → google-image with `--model gemini-3.1-flash-image` (Flash 4K, $0.151) or `--model gemini-3-pro-image` (Pro 4K, $0.240)
 
 **Brand-color-fidelity routing (issue #61):** when the prompt or context indicates exact brand-color match matters (logos, product shots, brand-led hero slides with 3+ specified hexes), prefer Recraft V4 raster over the photorealistic providers:
 - 1K, 2K → `/jack-tar-cloud:recraft-image --tier pro --resolution 2K --colors HEX,HEX,...`

--- a/plugins/jack-tar-cloud/skills/refresh-models/SKILL.md
+++ b/plugins/jack-tar-cloud/skills/refresh-models/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: refresh-models
+description: Fetch the latest model catalog (model names, capabilities, pricing) from the repository and install it locally after an operator-gated price review — no plugin release required.
+allowed-tools: Bash(python *)
+---
+
+# /refresh-models
+
+Update the local model catalog from the canonical published copy on the
+repository's `main` branch. Model retirements, renames, new models, and
+price corrections land as catalog-only commits — this skill picks them up
+without reinstalling any plugin (EPIC #125, issue #128).
+
+**The price diff is an operator gate.** Catalog prices drive the F10
+free→cost cascade gates, so a refresh that changes ANY price must be shown
+to the operator and explicitly accepted before it takes effect. Never skip
+the gate; never auto-refresh.
+
+## Step 1: Fetch and diff (read-only)
+
+```bash
+python3 - << 'EOF'
+import json, sys
+sys.path.insert(0, "PLUGIN_ROOT")  # replace with the plugin root path
+from src.model_catalog_refresh import check_remote
+from src.model_catalog import CatalogError
+
+try:
+    result = check_remote()
+except CatalogError as exc:
+    print(f"REFRESH BLOCKED: {exc}")
+    print("The current catalog is unchanged. If this persists, the remote "
+          "may require a newer plugin (min_loader_version) — update the "
+          "plugin instead.")
+    sys.exit(1)
+
+diff = result["diff"]
+print(f"Current: {result['current_version']} ({result['current_source']})")
+print(f"Remote:  {diff['version']['new']}")
+print(json.dumps(diff, indent=2))
+# Persist the fetched doc for Step 3 so apply uses EXACTLY what was reviewed.
+with open("/tmp/jack-tar-remote-catalog.json", "w") as f:
+    json.dump(result["remote_doc"], f)
+EOF
+```
+
+## Step 2: Operator gate
+
+Render the diff for the operator:
+
+- **`price_changes`** — table of model / component / old → new. This is the
+  gate-relevant section. If non-empty, ask explicitly: *"These price changes
+  will drive future cost estimates and cascade gates. Apply?"* and WAIT for
+  an affirmative ("yes", "apply", "go").
+- **`status_changes`** — retirements and deprecations (e.g. a model going
+  `active → retired` with its replacement). Informational; include in the
+  summary.
+- **`added_models` / `removed_models`** — informational.
+- If the diff is empty (same version, no changes), report "already current"
+  and STOP — do not write anything.
+
+## Step 3: Apply (only after explicit go-ahead)
+
+```bash
+python3 - << 'EOF'
+import json, sys
+sys.path.insert(0, "PLUGIN_ROOT")
+from src.model_catalog_refresh import apply_refresh
+
+with open("/tmp/jack-tar-remote-catalog.json") as f:
+    doc = json.load(f)
+summary = apply_refresh(doc)
+print(f"Installed catalog {summary['version']} at {summary['cache_path']}")
+if summary["previous_kept"]:
+    print("Previous catalog kept alongside — roll back with: /refresh-models --rollback")
+EOF
+```
+
+The write is atomic (temp file + rename); the previous cache is preserved at
+`~/.jack-tar/model-catalog.json.prev`. Loaded catalogs pick up the new cache
+on next process start; long-running sessions can force it with
+`get_catalog(reload=True)`.
+
+## Rollback (`--rollback`)
+
+```bash
+python3 - << 'EOF'
+import sys
+sys.path.insert(0, "PLUGIN_ROOT")
+from src.model_catalog_refresh import rollback
+print(rollback())
+EOF
+```
+
+## Safety properties
+
+- A remote catalog that fails validation, or whose `min_loader_version`
+  exceeds the installed loader, is rejected BEFORE touching the cache.
+- The loader independently re-validates the cache on every load and falls
+  back to the shipped baseline if it is corrupt — a bad refresh can never
+  brick image generation.
+- Deleting `~/.jack-tar/model-catalog.json` always returns the install to
+  the shipped baseline.

--- a/plugins/jack-tar-cloud/skills/verify/SKILL.md
+++ b/plugins/jack-tar-cloud/skills/verify/SKILL.md
@@ -121,3 +121,35 @@ PYEOF
 This never blocks verification — model ids and prices move faster than
 plugin releases (EPIC #125), so the hint just tells the operator when a
 refresh is worth running.
+
+## Step 5 (optional, on request): live model probe
+
+When the operator asks to "check the models", "find the latest models", or
+after any 404/NOT_FOUND from a provider, run the live discovery probe. It
+asks each probeable provider (Google, OpenAI, Ollama) what it serves RIGHT
+NOW and classifies every catalog entry:
+
+```bash
+python3 - << 'PYEOF'
+import json, sys
+sys.path.insert(0, "PLUGIN_ROOT")  # replace with the plugin root path
+from src.model_probe import probe_report
+report = probe_report()
+print(json.dumps(report, indent=2))
+PYEOF
+```
+
+Present the results as:
+
+- **suspect_retired** entries — lead with these: the catalog thinks the
+  model is active but the provider no longer lists it. Recommend
+  `/jack-tar-cloud:refresh-models` (a corrected catalog may already be
+  published) or a local-config override.
+- **new_candidates** — upstream models no catalog entry covers. These are
+  NOT routable: existence is provable, price is not, and the budget
+  tracker cannot cost an uncataloged model. Offer them as candidates the
+  operator can add via a `model_catalog` override in `local-config.json`
+  (explicit opt-in) or propose for the canonical catalog.
+- **unprobed** — FAL/Recraft have no list API; entries with no configured
+  credentials are skipped with the reason shown. Never treat unprobed as
+  a failure.

--- a/plugins/jack-tar-cloud/skills/verify/SKILL.md
+++ b/plugins/jack-tar-cloud/skills/verify/SKILL.md
@@ -83,8 +83,8 @@ PROVIDERS:
   recraft:             READY (uses OPENAI_API_KEY)
 
 GOOGLE TIERS:
-  Nanobanana Flash:    gemini-3.1-flash-image-preview     $0.067/image  (best text rendering)
-  Nanobanana Pro:      gemini-3-pro-image-preview          $0.134/image  (premium quality)
+  Nanobanana Flash:    gemini-3.1-flash-image     $0.067/image  (best text rendering)
+  Nanobanana Pro:      gemini-3-pro-image          $0.134/image  (premium quality)
   Imagen Fast:         imagen-4.0-fast-generate-001        $0.020/image  (budget bulk)
   Imagen Standard:     imagen-4.0-generate-001             $0.040/image  (standard quality)
 

--- a/plugins/jack-tar-cloud/skills/verify/SKILL.md
+++ b/plugins/jack-tar-cloud/skills/verify/SKILL.md
@@ -95,3 +95,29 @@ CAPABILITIES:
 STATUS: PARTIALLY_AVAILABLE
 REASON: All providers configured
 ```
+
+## Step 4: Model catalog staleness hint (non-blocking)
+
+Report which model catalog is in effect and how old the local cache is:
+
+```bash
+python3 - << 'PYEOF'
+import sys
+sys.path.insert(0, "PLUGIN_ROOT")  # replace with the plugin root path
+from src.model_catalog_refresh import staleness_report
+report = staleness_report()
+print("MODEL CATALOG:")
+print(f"  version:  {report['version']} (data updated {report['updated']})")
+print(f"  source:   {report['source']}")
+if "cache_age_days" in report:
+    print(f"  cache age: {report['cache_age_days']} days")
+    if report["cache_age_days"] > 30:
+        print("  hint: cache is over a month old — run /jack-tar-cloud:refresh-models")
+else:
+    print("  hint: running on the shipped baseline — /jack-tar-cloud:refresh-models fetches the latest")
+PYEOF
+```
+
+This never blocks verification — model ids and prices move faster than
+plugin releases (EPIC #125), so the hint just tells the operator when a
+refresh is worth running.

--- a/plugins/jack-tar-cloud/src/actual_cost_calculator.py
+++ b/plugins/jack-tar-cloud/src/actual_cost_calculator.py
@@ -1,21 +1,32 @@
 """Compute actual USD cost from API-returned usage metadata.
 
-Pure functions; no I/O, no SDK imports. Token rates are sourced from the
-official provider pricing pages — see docs/spikes/2026-05-21-actual-token-pricing/
-token-pricing-rates.md for current values and source URLs.
+Pure functions; no I/O, no SDK imports. Token rates come from the model
+catalog's ``pricing.token_rates`` (EPIC #125) — provenance and source URLs
+live in the catalog entry notes and
+docs/spikes/2026-05-21-actual-token-pricing/token-pricing-rates.md.
 """
 
-# Source: https://ai.google.dev/gemini-api/docs/pricing (captured 2026-05-21)
-_NANO_BANANA_RATES = {
-    "gemini-3.1-flash-image-preview": {
-        "text_input_per_mtok": 0.50,
-        "image_output_per_mtok": 60.00,
-    },
-    "gemini-3-pro-image-preview": {
-        "text_input_per_mtok": 2.00,
-        "image_output_per_mtok": 120.00,
-    },
-}
+try:
+    from .model_catalog import get_catalog as _get_model_catalog
+except ImportError:  # pragma: no cover - direct-script execution path
+    from model_catalog import get_catalog as _get_model_catalog
+
+
+def _rates_by_name(provider, api=None):
+    """Token-rate table keyed by every id AND alias of matching entries."""
+    table = {}
+    for entry in _get_model_catalog().entries(role='image_gen', provider=provider):
+        if api and (entry.get('sdk') or {}).get('api') != api:
+            continue
+        rates = (entry.get('pricing') or {}).get('token_rates')
+        if not rates:
+            continue
+        for name in [entry['id'], *entry.get('aliases', [])]:
+            table[name] = dict(rates)
+    return table
+
+
+_NANO_BANANA_RATES = _rates_by_name('google', api='generate_content')
 
 
 def compute_nano_banana_actual_cost(model: str, usage: dict) -> float:
@@ -40,29 +51,12 @@ def compute_nano_banana_actual_cost(model: str, usage: dict) -> float:
     return text_cost + image_cost
 
 
-# UNVERIFIED_ESTIMATE — all OpenAI pricing URLs (openai.com/api/pricing/,
-# platform.openai.com/docs/pricing, help.openai.com, web.archive.org)
-# returned 403/404 during the 2026-05-21 spike. These placeholder rates
-# ($5.00/MTok input, $40.00/MTok output) are widely-cited in community
-# discussions but have NOT been verified against an authoritative source.
-#
-# MUST re-validate via a logged-in browser session or the OpenAI dashboard
-# (https://platform.openai.com/settings/organization/billing/overview) before
-# this function is used in Phase 2 production cost-tracking code.
+# UNVERIFIED_ESTIMATE — the OpenAI token rates in the catalog are
+# community-cited placeholders; every OpenAI pricing URL 403/404'd during
+# the 2026-05-21 spike. The catalog entry's pricing notes carry the flag;
+# re-validate via the OpenAI dashboard before production cost-tracking.
 # See docs/spikes/2026-05-21-actual-token-pricing/token-pricing-rates.md.
-_OPENAI_IMAGE_RATES = {
-    # UNVERIFIED_ESTIMATE — see module comment above
-    "gpt-image-1": {
-        "input_per_mtok": 5.00,
-        "output_per_mtok": 40.00,
-    },
-    # UNVERIFIED_ESTIMATE — gpt-image-1.5 rates unknown; sharing gpt-image-1
-    # placeholders until verified. These two models may differ in production.
-    "gpt-image-1.5": {
-        "input_per_mtok": 5.00,
-        "output_per_mtok": 40.00,
-    },
-}
+_OPENAI_IMAGE_RATES = _rates_by_name('openai')
 
 
 def compute_openai_image_actual_cost(model: str, usage: dict) -> float:

--- a/plugins/jack-tar-cloud/src/generate_cloud_icon.py
+++ b/plugins/jack-tar-cloud/src/generate_cloud_icon.py
@@ -28,13 +28,23 @@ class ProviderNotImplementedError(NotImplementedError):
     """Raised when a provider is configured but implementation is pending."""
 
 
-# --- Cost tables (from research/04-cloud-api-setup-licensing.md) ---
+# --- Cost table (derived from the model catalog, EPIC #125) ---
+# The icon model bills the same per-tier rate on the direct Recraft API
+# and the FAL.ai route, so both provider keys map to the catalog's
+# per_tier pricing on the icon-role default entry.
+
+try:
+    from .model_catalog import get_catalog
+except ImportError:  # pragma: no cover - direct-script execution path
+    from model_catalog import get_catalog
 
 _ICON_COSTS = {
-    ('recraft', 'standard'): 0.08,
-    ('recraft', 'pro'): 0.30,
-    ('fal', 'standard'): 0.08,
-    ('fal', 'pro'): 0.30,
+    (_provider, _tier): _cost
+    for _provider in ('recraft', 'fal')
+    for _tier, _cost in (
+        get_catalog().default_model('icon').get('pricing', {})
+        .get('per_tier', {}).items()
+    )
 }
 
 

--- a/plugins/jack-tar-cloud/src/generate_cloud_image.py
+++ b/plugins/jack-tar-cloud/src/generate_cloud_image.py
@@ -245,19 +245,42 @@ def _normalise_resolution(resolution):
     )
 
 
-# --- Cost tables (from research/04-cloud-api-setup-licensing.md) ---
+# --- Cost + capability tables (derived from the model catalog) --------------
+#
+# EPIC #125 / issue #127: model identities, capabilities, and pricing live in
+# model-catalog.json (single source of truth), loaded via model_catalog.py
+# with shipped -> cached-remote -> local-config precedence. The module-level
+# tables below are DERIVED from the catalog at import time so the rest of
+# this module keeps its historical shape; the literal values now exist in
+# exactly one place. Aliases (including the retired '-preview' Gemini ids,
+# issue #123) key into the same entries, and generate_google canonicalises
+# to the current API id before any network call.
 
-_OPENAI_COSTS = {
-    ('1024x1024', 'low'): 0.009,
-    ('1024x1024', 'medium'): 0.034,
-    ('1024x1024', 'high'): 0.133,
-    ('1536x1024', 'low'): 0.013,
-    ('1536x1024', 'medium'): 0.051,
-    ('1536x1024', 'high'): 0.200,
-    ('1024x1536', 'low'): 0.013,
-    ('1024x1536', 'medium'): 0.051,
-    ('1024x1536', 'high'): 0.200,
-}
+try:
+    from .model_catalog import UnknownModelError, get_catalog
+except ImportError:  # pragma: no cover - direct-script execution path
+    from model_catalog import UnknownModelError, get_catalog
+
+_CATALOG = get_catalog()
+
+
+def _catalog_names(entry):
+    """All names that should resolve to this entry: id + aliases."""
+    return [entry['id'], *entry.get('aliases', [])]
+
+
+def _google_image_entries(api):
+    return [
+        e for e in _CATALOG.entries(role='image_gen', provider='google')
+        if (e.get('sdk') or {}).get('api') == api
+    ]
+
+
+_OPENAI_COSTS = {}
+for _entry in _CATALOG.entries(role='image_gen', provider='openai'):
+    for _key, _cost in (_entry.get('pricing') or {}).get('per_size_quality', {}).items():
+        _size, _quality = _key.split('|', 1)
+        _OPENAI_COSTS[(_size, _quality)] = _cost
 
 
 def estimate_openai_cost(size='1536x1024', quality='medium'):
@@ -286,74 +309,49 @@ def estimate_openai_cost(size='1536x1024', quality='medium'):
 #   - Vertex AI (GOOGLE_APPLICATION_CREDENTIALS): flat per-image pricing
 #   - Gemini Developer API (GOOGLE_API_KEY only): token-based, 2K is dearer
 # Nano Banana Pro/Flash bill identically on both backends (per-image).
+# Nano Banana = generate_content API; Imagen 4 = generate_images API.
 
-# Per-resolution costs (provider-agnostic, used for Nano Banana too).
-# Sourced from research May 2026; see EPIC #58 pricing table.
-_NANO_BANANA_COSTS = {
-    ('gemini-3-pro-image-preview', '1K'): 0.134,
-    ('gemini-3-pro-image-preview', '2K'): 0.134,
-    ('gemini-3-pro-image-preview', '4K'): 0.24,
-    ('gemini-3.1-flash-image-preview', '512'): 0.045,
-    ('gemini-3.1-flash-image-preview', '1K'): 0.067,
-    ('gemini-3.1-flash-image-preview', '2K'): 0.101,
-    ('gemini-3.1-flash-image-preview', '4K'): 0.151,
-}
+_NANO_BANANA_MODELS = set()
+_NANO_BANANA_COSTS = {}
+for _entry in _google_image_entries('generate_content'):
+    _per_res = (_entry.get('pricing') or {}).get('per_resolution', {})
+    for _name in _catalog_names(_entry):
+        _NANO_BANANA_MODELS.add(_name)
+        for _res, _cost in _per_res.items():
+            _NANO_BANANA_COSTS[(_name, _res)] = _cost
 
-# Imagen Vertex AI flat pricing (per-tier, uniform within tier).
-_IMAGEN_VERTEX_COSTS = {
-    ('imagen-4.0-fast-generate-001', '1K'): 0.020,
-    ('imagen-4.0-generate-001', '1K'): 0.040,
-    ('imagen-4.0-generate-001', '2K'): 0.040,
-    ('imagen-4.0-ultra-generate-001', '1K'): 0.060,
-    ('imagen-4.0-ultra-generate-001', '2K'): 0.060,
-}
-
-# Imagen Gemini Developer API token-based pricing.
-# 1K matches Vertex flat; 2K is dearer (1680 tokens at the Imagen rate).
-_IMAGEN_DEVELOPER_COSTS = {
-    ('imagen-4.0-fast-generate-001', '1K'): 0.020,
-    ('imagen-4.0-generate-001', '1K'): 0.040,
-    ('imagen-4.0-generate-001', '2K'): 0.101,
-    ('imagen-4.0-ultra-generate-001', '1K'): 0.060,
-    ('imagen-4.0-ultra-generate-001', '2K'): 0.101,  # treat as token-based too
-}
-
-# Issue #74 — Imagen models that render at a fixed native resolution and
-# reject the image_size / sampleImageSize parameter (400 INVALID_ARGUMENT).
-# These models render at 1K only; the parameter is meaningless and must be
-# omitted from the request body.
-_IMAGEN_FIXED_RESOLUTION_MODELS = frozenset({
-    'imagen-4.0-fast-generate-001',
-})
-
-
-# Models that use generate_content API (Nano Banana) vs generate_images API (Imagen 4)
-_NANO_BANANA_MODELS = {
-    'gemini-3.1-flash-image-preview',
-    'gemini-3-pro-image-preview',
-}
-
-_IMAGEN_MODELS = {
-    'imagen-4.0-generate-001',
-    'imagen-4.0-fast-generate-001',
-    'imagen-4.0-ultra-generate-001',
-}
+_IMAGEN_MODELS = set()
+_IMAGEN_VERTEX_COSTS = {}
+_IMAGEN_DEVELOPER_COSTS = {}
+# Issue #74 — models with the fixed_resolution quirk render at a fixed
+# native resolution and reject the image_size / sampleImageSize parameter
+# (400 INVALID_ARGUMENT); the parameter must be omitted from the request.
+_IMAGEN_FIXED_RESOLUTION_MODELS = set()
+for _entry in _google_image_entries('generate_images'):
+    _backends = (_entry.get('pricing') or {}).get('backends', {})
+    for _name in _catalog_names(_entry):
+        _IMAGEN_MODELS.add(_name)
+        for _res, _cost in _backends.get('vertex', {}).items():
+            _IMAGEN_VERTEX_COSTS[(_name, _res)] = _cost
+        for _res, _cost in _backends.get('developer', {}).items():
+            _IMAGEN_DEVELOPER_COSTS[(_name, _res)] = _cost
+        if 'fixed_resolution' in _entry.get('quirks', []):
+            _IMAGEN_FIXED_RESOLUTION_MODELS.add(_name)
+_IMAGEN_FIXED_RESOLUTION_MODELS = frozenset(_IMAGEN_FIXED_RESOLUTION_MODELS)
 
 # Per-model supported resolutions (used by validation and discovery).
-_MODEL_RESOLUTIONS = {
-    'imagen-4.0-fast-generate-001': ['1K'],
-    'imagen-4.0-generate-001': ['1K', '2K'],
-    'imagen-4.0-ultra-generate-001': ['1K', '2K'],
-    'gemini-3.1-flash-image-preview': ['512', '1K', '2K', '4K'],
-    'gemini-3-pro-image-preview': ['1K', '2K', '4K'],
-    # Recraft V4 raster (issue #61). 'recraft-v4-*' identifiers are router-side;
-    # internal dispatch picks the actual endpoint by tier+resolution.
-    'recraft-v4-standard': ['1K'],
-    'recraft-v4-pro': ['2K', '4K'],
-}
+# Google models plus the router-side 'recraft-v4-*' identifiers (issue #61);
+# internal Recraft dispatch picks the actual endpoint by tier+resolution.
+_MODEL_RESOLUTIONS = {}
+for _entry in _CATALOG.entries(role='image_gen'):
+    if _entry['provider'] not in ('google', 'recraft'):
+        continue
+    _resolutions = list((_entry.get('capabilities') or {}).get('resolutions', []))
+    for _name in _catalog_names(_entry):
+        _MODEL_RESOLUTIONS[_name] = _resolutions
 
 
-def estimate_google_cost(model='gemini-3.1-flash-image-preview', resolution='1K'):
+def estimate_google_cost(model='gemini-3.1-flash-image', resolution='1K'):
     """Return estimated USD cost for a Google image generation call.
 
     For Imagen models, billing depends on which Google backend the SDK uses:
@@ -405,20 +403,20 @@ def estimate_google_cost(model='gemini-3.1-flash-image-preview', resolution='1K'
     )
 
 
-# FAL.ai cost data (from research/04-cloud-api-setup-licensing.md)
-# FLUX.2 Pro: $0.030 for 1st MP + $0.015 per extra MP (~$0.045 for 1920x1080)
-# FLUX.2 Klein: $0.014 flat per image
-# Ideogram 3.0: ~$0.030-$0.090 per image (use midpoint $0.060)
-
-_FAL_FLAT_COSTS = {
-    'fal-ai/flux-2-klein': 0.014,
-    'fal-ai/ideogram/v3': 0.060,
-}
-
-# Tiered megapixel models: (base_cost_first_mp, cost_per_extra_mp)
-_FAL_TIERED_COSTS = {
-    'fal-ai/flux-2-pro': (0.030, 0.015),
-}
+# FAL.ai pricing: flat-rate models vs tiered megapixel models
+# (first-MP base cost + per-extra-MP), derived from the catalog.
+_FAL_FLAT_COSTS = {}
+_FAL_TIERED_COSTS = {}
+for _entry in _CATALOG.entries(role='image_gen', provider='fal'):
+    _pricing = _entry.get('pricing') or {}
+    for _name in _catalog_names(_entry):
+        if 'flat' in _pricing:
+            _FAL_FLAT_COSTS[_name] = _pricing['flat']
+        if 'tiered_megapixel' in _pricing:
+            _FAL_TIERED_COSTS[_name] = (
+                _pricing['tiered_megapixel']['first_mp'],
+                _pricing['tiered_megapixel']['per_extra_mp'],
+            )
 
 # Approximate megapixel counts for FAL image_size presets
 _FAL_SIZE_MEGAPIXELS = {
@@ -453,41 +451,16 @@ _FAL_SUPPORTED_RESOLUTIONS = {
 }
 
 
-# --- Recraft V4 raster pricing (FAL.ai parity assumption for upscale) ---
-# Generation costs verified 2026-05-07 via fal.ai/models/fal-ai/recraft/v4/*.
-# Upscale cost on direct API not surfaced in public docs; assume FAL parity
-# ($0.25). RECRAFT_UPSCALE_COST_USD env var overrides if discovered to differ.
-
-_RECRAFT_GENERATION_COSTS = {
-    ('standard', '1K'): 0.04,
-    ('pro', '2K'): 0.25,
-    # 4K is generate-at-2K then upscale chain — see estimate_recraft_cost
-}
-
-_RECRAFT_UPSCALE_COST_DEFAULT = 0.25  # FAL parity; override via env
-
-# Recraft V4 raster supported resolutions per tier
+# --- Recraft V4 raster (issue #61) ---
+# Pricing and per-tier resolution capability come from the catalog's
+# 'recraft-v4-standard' / 'recraft-v4-pro' entries. The 4K price is the
+# 2K-generation + Creative-Upscale chain; the catalog applies the
+# RECRAFT_UPSCALE_COST_USD env override to the upscale component
+# (upscale_chain_4k quirk).
 _RECRAFT_TIER_RESOLUTIONS = {
-    'standard': ['1K'],
-    'pro': ['2K', '4K'],  # 4K is upscale-chained on top of 2K Pro
+    tier: _CATALOG.resolutions(f'recraft-v4-{tier}')
+    for tier in ('standard', 'pro')
 }
-
-
-def _recraft_upscale_cost():
-    """Return the assumed upscale cost; env override allowed for hot-fix.
-
-    Override is only honoured if it parses to a positive float — guards
-    against a speaker accidentally pricing a paid API at $0 or negative.
-    """
-    override = os.environ.get('RECRAFT_UPSCALE_COST_USD')
-    if override:
-        try:
-            value = float(override)
-            if value > 0:
-                return value
-        except ValueError:
-            pass
-    return _RECRAFT_UPSCALE_COST_DEFAULT
 
 
 def estimate_recraft_cost(tier='pro', resolution='2K'):
@@ -521,11 +494,9 @@ def estimate_recraft_cost(tier='pro', resolution='2K'):
             f"For 4K use tier='pro' (chains 2K + Creative Upscale)."
         )
 
-    if resolution == '4K':
-        # Chain: 2K Pro generation + Creative Upscale
-        return _RECRAFT_GENERATION_COSTS[('pro', '2K')] + _recraft_upscale_cost()
-
-    return _RECRAFT_GENERATION_COSTS[(tier, resolution)]
+    # The catalog prices the 4K chain (2K Pro generation + Creative Upscale,
+    # RECRAFT_UPSCALE_COST_USD override honoured) alongside the plain tiers.
+    return _CATALOG.cost(f'recraft-v4-{tier}', resolution=resolution)
 
 
 def estimate_fal_cost(model='fal-ai/flux-2-pro', image_size='landscape_16_9'):
@@ -667,7 +638,9 @@ def generate_google(prompt, output_path, **kwargs):
         prompt: Text prompt for image generation.
         output_path: Where to save the generated PNG.
         **kwargs: Optional arguments:
-            model: Model name (default: 'gemini-3.1-flash-image-preview').
+            model: Model name (default: the catalog's image_gen role
+                default — Nano Banana Flash). Aliases and retired ids
+                are canonicalised via the model catalog.
             aspect_ratio: Aspect ratio for Imagen 4 (e.g. '16:9', '1:1').
             resolution: '512' | '1K' | '2K' | '4K'. Default '1K'.
                 Per-model support varies; see _MODEL_RESOLUTIONS.
@@ -688,7 +661,15 @@ def generate_google(prompt, output_path, **kwargs):
             'See research/04-cloud-api-setup-licensing.md section B for setup.'
         )
 
-    model = kwargs.get('model', 'gemini-3.1-flash-image-preview')
+    model = kwargs.get('model') or _CATALOG.default_model('image_gen')['id']
+    # Canonicalise via the catalog: aliases (including the retired '-preview'
+    # ids, issue #123) resolve to the id the live API accepts today, and
+    # retired models substitute their replacement. Unknown names fall through
+    # to the legacy unknown-model error below.
+    try:
+        model = _CATALOG.get(model)['id']
+    except UnknownModelError:
+        pass
     aspect_ratio = kwargs.get('aspect_ratio', '16:9')
     resolution = _normalise_resolution(kwargs.get('resolution', '1K'))
 
@@ -758,7 +739,7 @@ def _generate_via_nano_banana(client, model, prompt, resolution='1K'):
 
     Args:
         client: google.genai.Client instance.
-        model: 'gemini-3-pro-image-preview' or 'gemini-3.1-flash-image-preview'.
+        model: 'gemini-3-pro-image' or 'gemini-3.1-flash-image' (aliases resolve).
         prompt: text prompt.
         resolution: '512' | '1K' | '2K' | '4K' (must be supported by model).
 

--- a/plugins/jack-tar-cloud/src/model-catalog.json
+++ b/plugins/jack-tar-cloud/src/model-catalog.json
@@ -26,7 +26,8 @@
         "verified": "2026-05-24",
         "estimate": false,
         "per_resolution": {"512": 0.045, "1K": 0.067, "2K": 0.101, "4K": 0.151},
-        "notes": "EPIC #58 pricing table; reconciled issue #113 AC6."
+        "token_rates": {"text_input_per_mtok": 0.5, "image_output_per_mtok": 60.0},
+        "notes": "EPIC #58 pricing table; reconciled issue #113 AC6. Token rates from ai.google.dev/gemini-api/docs/pricing (captured 2026-05-21)."
       },
       "sdk": {"api": "generate_content", "config_field": "image_size"},
       "notes": "Nano Banana Flash. The '-preview' suffixed id was deprecated upstream (issue #123, verified 2026-07-15); alias retained so existing manifests and callers resolve."
@@ -48,7 +49,8 @@
         "verified": "2026-05-24",
         "estimate": false,
         "per_resolution": {"1K": 0.134, "2K": 0.134, "4K": 0.24},
-        "notes": "Pro 2K priced identically to Pro 1K (issue #113 AC6 reconciliation)."
+        "token_rates": {"text_input_per_mtok": 2.0, "image_output_per_mtok": 120.0},
+        "notes": "Pro 2K priced identically to Pro 1K (issue #113 AC6 reconciliation). Token rates from ai.google.dev/gemini-api/docs/pricing (captured 2026-05-21)."
       },
       "sdk": {"api": "generate_content", "config_field": "image_size"},
       "notes": "Nano Banana Pro — best in-image text rendering. '-preview' id deprecated upstream (issue #123)."
@@ -149,7 +151,9 @@
           "1024x1536|low": 0.013,
           "1024x1536|medium": 0.051,
           "1024x1536|high": 0.2
-        }
+        },
+        "token_rates": {"input_per_mtok": 5.0, "output_per_mtok": 40.0},
+        "notes": "token_rates are UNVERIFIED_ESTIMATE — all OpenAI pricing URLs 403/404'd during the 2026-05-21 spike; community-cited placeholders pending dashboard verification (see docs/spikes/2026-05-21-actual-token-pricing/)."
       },
       "sdk": {"api": "openai_images"}
     },

--- a/plugins/jack-tar-cloud/src/model-catalog.json
+++ b/plugins/jack-tar-cloud/src/model-catalog.json
@@ -1,0 +1,366 @@
+{
+  "catalog_version": "1.0.0",
+  "min_loader_version": 1,
+  "updated": "2026-07-15",
+  "role_defaults": {
+    "image_gen": "gemini-3.1-flash-image",
+    "vlm_json": "gemini-3.5-flash",
+    "icon": "recraft-v4-svg",
+    "local_draft": ["x/flux2-klein", "x/z-image-turbo"]
+  },
+  "models": [
+    {
+      "id": "gemini-3.1-flash-image",
+      "provider": "google",
+      "aliases": ["gemini-3.1-flash-image-preview"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["512", "1K", "2K", "4K"],
+        "text_rendering": "good"
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-24",
+        "estimate": false,
+        "per_resolution": {"512": 0.045, "1K": 0.067, "2K": 0.101, "4K": 0.151},
+        "notes": "EPIC #58 pricing table; reconciled issue #113 AC6."
+      },
+      "sdk": {"api": "generate_content", "config_field": "image_size"},
+      "notes": "Nano Banana Flash. The '-preview' suffixed id was deprecated upstream (issue #123, verified 2026-07-15); alias retained so existing manifests and callers resolve."
+    },
+    {
+      "id": "gemini-3-pro-image",
+      "provider": "google",
+      "aliases": ["gemini-3-pro-image-preview"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K", "2K", "4K"],
+        "text_rendering": "excellent"
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-24",
+        "estimate": false,
+        "per_resolution": {"1K": 0.134, "2K": 0.134, "4K": 0.24},
+        "notes": "Pro 2K priced identically to Pro 1K (issue #113 AC6 reconciliation)."
+      },
+      "sdk": {"api": "generate_content", "config_field": "image_size"},
+      "notes": "Nano Banana Pro — best in-image text rendering. '-preview' id deprecated upstream (issue #123)."
+    },
+    {
+      "id": "imagen-4.0-fast-generate-001",
+      "provider": "google",
+      "aliases": ["imagen-4-fast"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["fixed_resolution", "no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K"]
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "backends": {
+          "vertex": {"1K": 0.02},
+          "developer": {"1K": 0.02}
+        }
+      },
+      "sdk": {"api": "generate_images"},
+      "notes": "Fixed native resolution — rejects image_size/sampleImageSize with 400 INVALID_ARGUMENT (issue #74). 'imagen-4-fast' is the router-side alias."
+    },
+    {
+      "id": "imagen-4.0-generate-001",
+      "provider": "google",
+      "aliases": ["imagen-4", "imagen-4-standard"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K", "2K"],
+        "prompt_budget": {"max_words": 40, "style": "concise"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "backends": {
+          "vertex": {"1K": 0.04, "2K": 0.04},
+          "developer": {"1K": 0.04, "2K": 0.101}
+        },
+        "notes": "Dual pricing: Vertex (GOOGLE_APPLICATION_CREDENTIALS) flat per-image; Gemini Developer API (GOOGLE_API_KEY only) token-based, 2K dearer."
+      },
+      "sdk": {"api": "generate_images", "config_field": "image_size"}
+    },
+    {
+      "id": "imagen-4.0-ultra-generate-001",
+      "provider": "google",
+      "aliases": ["imagen-4-ultra"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K", "2K"]
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "backends": {
+          "vertex": {"1K": 0.06, "2K": 0.06},
+          "developer": {"1K": 0.06, "2K": 0.101}
+        },
+        "notes": "Developer-API 2K treated as token-based like Standard."
+      },
+      "sdk": {"api": "generate_images", "config_field": "image_size"}
+    },
+    {
+      "id": "gpt-image-1.5",
+      "provider": "openai",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "prompt_budget": {"max_words": 500, "style": "natural_language"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "per_size_quality": {
+          "1024x1024|low": 0.009,
+          "1024x1024|medium": 0.034,
+          "1024x1024|high": 0.133,
+          "1536x1024|low": 0.013,
+          "1536x1024|medium": 0.051,
+          "1536x1024|high": 0.2,
+          "1024x1536|low": 0.013,
+          "1024x1536|medium": 0.051,
+          "1024x1536|high": 0.2
+        }
+      },
+      "sdk": {"api": "openai_images"}
+    },
+    {
+      "id": "fal-ai/flux-2-pro",
+      "provider": "fal",
+      "aliases": ["flux-2-pro"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K", "2K"],
+        "prompt_budget": {"max_words": 60, "style": "photography"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "tiered_megapixel": {"first_mp": 0.03, "per_extra_mp": 0.015},
+        "notes": "~$0.045 for 1920x1080. budget_tracker previously carried a divergent $0.050 flat figure — the tiered rate here is canonical (EPIC #125)."
+      },
+      "sdk": {"api": "fal_subscribe"},
+      "notes": "Caps at 2048x2048."
+    },
+    {
+      "id": "fal-ai/flux-2-klein",
+      "provider": "fal",
+      "aliases": ["flux-2-klein"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"]
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "flat": 0.014
+      },
+      "sdk": {"api": "fal_subscribe"}
+    },
+    {
+      "id": "fal-ai/ideogram/v3",
+      "provider": "fal",
+      "aliases": ["ideogram-3"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "text_rendering": "excellent",
+        "prompt_budget": {"max_words": 80, "style": "typography"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": true,
+        "flat": 0.06,
+        "notes": "Published range $0.030-$0.090; midpoint used."
+      },
+      "sdk": {"api": "fal_subscribe"}
+    },
+    {
+      "id": "recraft-v4-standard",
+      "provider": "recraft",
+      "aliases": ["recraft-v4"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "brand_hex_fidelity": true,
+        "prompt_budget": {"max_words": 100, "style": "design_centric"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-07",
+        "estimate": false,
+        "per_resolution": {"1K": 0.04},
+        "notes": "Verified via fal.ai/models/fal-ai/recraft/v4/*."
+      },
+      "sdk": {"api": "recraft_rest", "endpoint": "external.api.recraft.ai/v1"},
+      "notes": "Router-side id; dispatch picks the actual endpoint by tier+resolution (issue #61)."
+    },
+    {
+      "id": "recraft-v4-pro",
+      "provider": "recraft",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["upscale_chain_4k"],
+      "capabilities": {
+        "resolutions": ["2K", "4K"],
+        "brand_hex_fidelity": true
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-07",
+        "estimate": true,
+        "per_resolution": {"2K": 0.25, "4K": 0.5},
+        "env_override": {"upscale": "RECRAFT_UPSCALE_COST_USD"},
+        "notes": "4K = 2K generation ($0.25) + Creative Upscale ($0.25 FAL-parity assumption — direct-API upscale price not published; env override honoured when positive)."
+      },
+      "sdk": {"api": "recraft_rest", "endpoint": "external.api.recraft.ai/v1"}
+    },
+    {
+      "id": "recraft-v4-svg",
+      "provider": "recraft",
+      "aliases": ["recraftv4"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["icon"],
+      "quirks": [],
+      "capabilities": {
+        "vector": true,
+        "brand_hex_fidelity": true
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "per_tier": {"standard": 0.08, "pro": 0.3},
+        "notes": "Same rates via direct API and the FAL route (fal-ai/recraft/v4/text-to-vector). budget_tracker previously carried divergent $0.04/$0.08 svg/png figures — per_tier here is canonical (EPIC #125)."
+      },
+      "sdk": {"api": "recraft_rest", "endpoint": "fal-ai/recraft/v4/text-to-vector"}
+    },
+    {
+      "id": "x/flux2-klein",
+      "provider": "ollama",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen", "local_draft"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "timeout_seconds": 600,
+        "prompt_budget": {"max_words": 200, "style": "detailed_spatial"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-07-10",
+        "estimate": false,
+        "flat": 0.0
+      },
+      "sdk": {"api": "ollama_generate"},
+      "notes": "Tag-prefix entry: exact installed tag (e.g. x/flux2-klein:9b) resolves at runtime via /api/tags — never hardcode tags. Preferred local model for academic figures (F16 audit: Klein 9b at 8/9 on the deck-schema brief)."
+    },
+    {
+      "id": "x/z-image-turbo",
+      "provider": "ollama",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen", "local_draft"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "timeout_seconds": 120,
+        "prompt_budget": {"max_words": 50, "style": "concise_camera"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-07-10",
+        "estimate": false,
+        "flat": 0.0
+      },
+      "sdk": {"api": "ollama_generate"},
+      "notes": "Fast local draft fallback when flux2-klein is not pulled."
+    },
+    {
+      "id": "gemini-3.5-flash",
+      "provider": "google",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["vlm", "vlm_json"],
+      "quirks": [],
+      "capabilities": {},
+      "sdk": {"api": "generate_content"},
+      "notes": "Verified 2026-07-15 (issue #123): non-thinking for retriever/planning steps, clean JSON output for paperbanana's parser, publication-quality academic figures in 2-3 iterations at ~$0.02/diagram."
+    },
+    {
+      "id": "gemini-2.5-flash",
+      "provider": "google",
+      "aliases": [],
+      "status": "deprecated",
+      "replacement": "gemini-3.5-flash",
+      "roles": ["vlm"],
+      "quirks": ["thinking"],
+      "capabilities": {},
+      "sdk": {"api": "generate_content"},
+      "notes": "Thinking model — reasoning tokens break strict-JSON parsers (paperbanana retriever loops to ~17min timeout, issues #122/#123). NOT eligible for the vlm_json role. Deprecated as a jack-tar default in favour of gemini-3.5-flash."
+    },
+    {
+      "id": "gemini-2.0-flash",
+      "provider": "google",
+      "aliases": [],
+      "status": "retired",
+      "replacement": "gemini-3.5-flash",
+      "roles": ["vlm", "vlm_json"],
+      "quirks": [],
+      "capabilities": {},
+      "sdk": {"api": "generate_content"},
+      "notes": "Retired upstream — 404 NOT_FOUND 'This model is no longer available' (verified 2026-07-15, issue #123)."
+    }
+  ]
+}

--- a/plugins/jack-tar-cloud/src/model_catalog.py
+++ b/plugins/jack-tar-cloud/src/model_catalog.py
@@ -1,0 +1,501 @@
+"""Model catalog loader — single source of truth for AI model identity,
+capability, and pricing (EPIC #125).
+
+Model IDs, aliases, retirement pointers, resolution capability, and cost
+tables live in ``model-catalog.json``, NOT in code. This loader merges three
+layers, lowest precedence first:
+
+1. **Shipped baseline** — the ``model-catalog.json`` vendored next to this
+   module (or the repo-level ``model-catalog/`` directory in development).
+2. **Cached remote** — ``~/.jack-tar/model-catalog.json``, written by the
+   refresh-models skill (issue #128). Replaces the baseline wholesale when
+   present, valid, and loader-compatible; a bad cache falls back to shipped.
+3. **Local overrides** — the ``model_catalog`` key in the project's
+   ``local-config.json`` (gitignored). Entries merge per-model by id;
+   ``role_defaults`` merge per-key.
+
+Stdlib-only. Schema-level validation lives in
+``model-catalog/model-catalog.schema.json`` (enforced by tests/CI); this
+module performs structural validation sufficient to reject a broken cache
+at runtime without a jsonschema dependency.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Bump when the loader's expectations of the catalog shape change.
+#: A catalog whose ``min_loader_version`` exceeds this is rejected.
+LOADER_VERSION = 1
+
+CATALOG_FILENAME = "model-catalog.json"
+
+#: Env var pointing at an explicit catalog file (highest-priority baseline).
+CATALOG_PATH_ENV = "JACK_TAR_MODEL_CATALOG"
+
+#: Env var overriding the cached-remote location.
+CATALOG_CACHE_ENV = "JACK_TAR_CATALOG_CACHE"
+
+_DEFAULT_CACHE_PATH = Path.home() / ".jack-tar" / CATALOG_FILENAME
+
+_ENTRY_REQUIRED_FIELDS = ("id", "provider", "status", "roles")
+_VALID_STATUSES = frozenset({"active", "deprecated", "retired"})
+_RESOLUTION_ALIASES = {"512": "512", "1K": "1K", "2K": "2K", "4K": "4K"}
+
+
+class CatalogError(Exception):
+    """Catalog missing, unparseable, or structurally invalid."""
+
+
+class UnknownModelError(KeyError):
+    """No catalog entry (id or alias) matches the requested model."""
+
+
+class PricingError(ValueError):
+    """The entry has no price for the requested parameters."""
+
+
+def _normalise_resolution(resolution):
+    key = str(resolution).strip().upper()
+    if key in _RESOLUTION_ALIASES:
+        return _RESOLUTION_ALIASES[key]
+    raise PricingError(
+        f"resolution={resolution!r} not recognised. "
+        f"Valid values: {sorted(_RESOLUTION_ALIASES)}"
+    )
+
+
+def validate_catalog(doc):
+    """Structurally validate a catalog document. Raises CatalogError.
+
+    This is the runtime gate (cheap, stdlib-only). Full JSON-Schema
+    validation runs in the test suite against model-catalog.schema.json.
+    """
+    if not isinstance(doc, dict):
+        raise CatalogError("catalog root must be an object")
+    for key in ("catalog_version", "min_loader_version", "updated", "models"):
+        if key not in doc:
+            raise CatalogError(f"catalog missing required key: {key}")
+    min_loader = doc["min_loader_version"]
+    if not isinstance(min_loader, int) or min_loader < 1:
+        raise CatalogError("min_loader_version must be a positive integer")
+    if min_loader > LOADER_VERSION:
+        raise CatalogError(
+            f"catalog requires loader version >= {min_loader}; "
+            f"this loader is version {LOADER_VERSION} — update the plugin"
+        )
+    models = doc["models"]
+    if not isinstance(models, list) or not models:
+        raise CatalogError("models must be a non-empty list")
+
+    seen = {}
+    for entry in models:
+        if not isinstance(entry, dict):
+            raise CatalogError("every model entry must be an object")
+        for field in _ENTRY_REQUIRED_FIELDS:
+            if field not in entry:
+                raise CatalogError(
+                    f"model entry {entry.get('id', '<no id>')!r} missing "
+                    f"required field: {field}"
+                )
+        status = entry["status"]
+        if status not in _VALID_STATUSES:
+            raise CatalogError(
+                f"model {entry['id']!r} has invalid status {status!r}"
+            )
+        if status == "retired" and not entry.get("replacement"):
+            raise CatalogError(
+                f"retired model {entry['id']!r} must name a replacement"
+            )
+        for name in [entry["id"], *entry.get("aliases", [])]:
+            if name in seen:
+                raise CatalogError(
+                    f"duplicate model id/alias {name!r} "
+                    f"(in {entry['id']!r} and {seen[name]!r})"
+                )
+            seen[name] = entry["id"]
+
+    # Replacements and role defaults must resolve to real ids/aliases.
+    for entry in models:
+        replacement = entry.get("replacement")
+        if replacement and replacement not in seen:
+            raise CatalogError(
+                f"model {entry['id']!r} names unknown replacement "
+                f"{replacement!r}"
+            )
+    for role, value in (doc.get("role_defaults") or {}).items():
+        ids = [value] if isinstance(value, str) else list(value)
+        for model_id in ids:
+            if model_id not in seen:
+                raise CatalogError(
+                    f"role_defaults[{role!r}] names unknown model {model_id!r}"
+                )
+
+
+def _read_json(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _find_shipped_catalog(shipped_path=None):
+    """Locate the shipped baseline catalog.
+
+    Search order: explicit arg -> JACK_TAR_MODEL_CATALOG env var -> file
+    next to this module (vendored plugin layout) -> repo-level
+    model-catalog/ directory walking up from this module (dev layout).
+    """
+    if shipped_path:
+        return Path(shipped_path)
+    env_path = os.environ.get(CATALOG_PATH_ENV)
+    if env_path:
+        return Path(env_path)
+    module_dir = Path(__file__).resolve().parent
+    candidate = module_dir / CATALOG_FILENAME
+    if candidate.exists():
+        return candidate
+    for ancestor in module_dir.parents[:3]:
+        candidate = ancestor / "model-catalog" / CATALOG_FILENAME
+        if candidate.exists():
+            return candidate
+    raise CatalogError(
+        f"shipped {CATALOG_FILENAME} not found next to {module_dir} "
+        f"or in an ancestor model-catalog/ directory"
+    )
+
+
+def _load_cached_remote(cache_path=None):
+    """Return (doc, path) for a valid cached remote catalog, else None.
+
+    A missing cache is normal (install has never refreshed). An invalid
+    or loader-incompatible cache logs a warning and is ignored — the
+    shipped baseline always keeps the pipeline running.
+    """
+    path = Path(
+        cache_path
+        or os.environ.get(CATALOG_CACHE_ENV)
+        or _DEFAULT_CACHE_PATH
+    )
+    if not path.exists():
+        return None
+    try:
+        doc = _read_json(path)
+        validate_catalog(doc)
+        return doc, path
+    except (OSError, json.JSONDecodeError, CatalogError) as exc:
+        logger.warning(
+            "ignoring invalid cached model catalog at %s: %s "
+            "(falling back to shipped baseline)", path, exc,
+        )
+        return None
+
+
+def _apply_local_overrides(doc, local_config_path):
+    """Merge local-config.json's ``model_catalog`` key into the catalog.
+
+    ``models`` entries merge per-model by id (shallow field update; unknown
+    ids append as new entries). ``role_defaults`` merge per-key. The merged
+    document is re-validated so a broken override fails loudly — local
+    overrides are operator-authored and should not degrade silently.
+    """
+    path = Path(local_config_path) if local_config_path else Path("local-config.json")
+    if not path.exists():
+        return doc, False
+    try:
+        local = _read_json(path)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("ignoring unreadable local-config.json: %s", exc)
+        return doc, False
+    overrides = local.get("model_catalog")
+    if not isinstance(overrides, dict):
+        return doc, False
+
+    merged = copy.deepcopy(doc)
+    by_id = {entry["id"]: entry for entry in merged["models"]}
+    for patch in overrides.get("models", []):
+        target = by_id.get(patch.get("id"))
+        if target is not None:
+            target.update(copy.deepcopy(patch))
+        else:
+            merged["models"].append(copy.deepcopy(patch))
+    if "role_defaults" in overrides:
+        merged.setdefault("role_defaults", {}).update(overrides["role_defaults"])
+    validate_catalog(merged)
+    return merged, True
+
+
+class ModelCatalog:
+    """Immutable view over a validated catalog document."""
+
+    def __init__(self, doc, source="shipped"):
+        self._doc = doc
+        self.source = source
+        self._by_name = {}
+        for entry in doc["models"]:
+            self._by_name[entry["id"]] = entry
+            for alias in entry.get("aliases", []):
+                self._by_name[alias] = entry
+
+    @property
+    def version(self):
+        return self._doc["catalog_version"]
+
+    @property
+    def updated(self):
+        return self._doc["updated"]
+
+    def ids(self):
+        return [entry["id"] for entry in self._doc["models"]]
+
+    def get(self, id_or_alias, follow_replacement=True):
+        """Return a copy of the entry for a model id or alias.
+
+        Retired entries resolve to their replacement when
+        ``follow_replacement`` (the substitution is logged and recorded in
+        the returned dict's ``resolved_from``). Deprecated entries return
+        themselves with a warning. Unknown names raise UnknownModelError.
+        """
+        entry = self._by_name.get(id_or_alias)
+        if entry is None:
+            raise UnknownModelError(
+                f"model {id_or_alias!r} not in catalog "
+                f"(version {self.version}); known ids: {self.ids()}"
+            )
+        resolved_from = None
+        if id_or_alias != entry["id"]:
+            resolved_from = id_or_alias
+        hops = 0
+        while follow_replacement and entry["status"] == "retired":
+            replacement = entry["replacement"]
+            logger.info(
+                "model %s is retired — substituting %s (catalog %s)",
+                entry["id"], replacement, self.version,
+            )
+            resolved_from = resolved_from or entry["id"]
+            entry = self._by_name[replacement]
+            hops += 1
+            if hops > len(self._doc["models"]):
+                raise CatalogError(
+                    f"replacement cycle detected at {entry['id']!r}"
+                )
+        if entry["status"] == "deprecated":
+            logger.warning(
+                "model %s is deprecated%s", entry["id"],
+                f" — prefer {entry['replacement']}" if entry.get("replacement") else "",
+            )
+        result = copy.deepcopy(entry)
+        if resolved_from:
+            result["resolved_from"] = resolved_from
+        return result
+
+    def entries(self, role=None, provider=None, status="active"):
+        """Return copies of entries filtered by role/provider/status.
+
+        ``status=None`` disables the status filter.
+        """
+        out = []
+        for entry in self._doc["models"]:
+            if status is not None and entry["status"] != status:
+                continue
+            if role is not None and role not in entry["roles"]:
+                continue
+            if provider is not None and entry["provider"] != provider:
+                continue
+            out.append(copy.deepcopy(entry))
+        return out
+
+    def role_default(self, role):
+        """Return the raw role_defaults value: a model id or preference list."""
+        defaults = self._doc.get("role_defaults") or {}
+        if role not in defaults:
+            raise UnknownModelError(
+                f"no role_default for {role!r}; defined roles: "
+                f"{sorted(defaults)}"
+            )
+        return copy.deepcopy(defaults[role])
+
+    def default_model(self, role):
+        """Return the resolved entry for a role's default.
+
+        For preference-list defaults (e.g. local_draft) the first entry
+        wins — callers that can probe availability should use
+        ``role_default`` and filter the list themselves.
+        """
+        value = self.role_default(role)
+        model_id = value if isinstance(value, str) else value[0]
+        return self.get(model_id)
+
+    def resolutions(self, id_or_alias):
+        entry = self.get(id_or_alias)
+        return list((entry.get("capabilities") or {}).get("resolutions", []))
+
+    def supports(self, id_or_alias, resolution):
+        return _normalise_resolution(resolution) in self.resolutions(id_or_alias)
+
+    def has_quirk(self, id_or_alias, quirk):
+        return quirk in self.get(id_or_alias).get("quirks", [])
+
+    def cost(self, id_or_alias, resolution=None, backend=None, size=None,
+             quality=None, tier=None, megapixels=None):
+        """Return the USD cost for one generation with the given parameters.
+
+        Dispatches across the pricing shapes:
+          flat                     -> no parameters needed
+          per_resolution           -> ``resolution``
+          backends                 -> ``resolution`` + ``backend`` (Google
+                                      Imagen: 'vertex' when
+                                      GOOGLE_APPLICATION_CREDENTIALS is set,
+                                      else 'developer' — auto-detected when
+                                      backend is None)
+          per_size_quality         -> ``size`` + ``quality`` (OpenAI)
+          per_tier                 -> ``tier`` (icons)
+          tiered_megapixel         -> ``megapixels`` (FAL FLUX 2 Pro)
+
+        The upscale_chain_4k quirk (Recraft Pro) applies the documented
+        env override to the upscale component of the 4K chain price.
+        """
+        entry = self.get(id_or_alias)
+        pricing = entry.get("pricing")
+        if pricing is None:
+            raise PricingError(
+                f"model {entry['id']!r} has no pricing data in the catalog"
+            )
+
+        if "flat" in pricing and resolution is None and size is None \
+                and tier is None and megapixels is None:
+            return pricing["flat"]
+
+        if "per_resolution" in pricing and resolution is not None:
+            res = _normalise_resolution(resolution)
+            table = pricing["per_resolution"]
+            if res not in table:
+                raise PricingError(
+                    f"model {entry['id']!r} has no {res} price; "
+                    f"priced resolutions: {sorted(table)}"
+                )
+            if res == "4K" and "upscale_chain_4k" in entry.get("quirks", []):
+                return self._chained_4k_cost(entry, table, pricing)
+            return table[res]
+
+        if "backends" in pricing and resolution is not None:
+            res = _normalise_resolution(resolution)
+            if backend is None:
+                backend = (
+                    "vertex"
+                    if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+                    else "developer"
+                )
+            table = pricing["backends"].get(backend)
+            if table is None:
+                raise PricingError(
+                    f"model {entry['id']!r} has no backend {backend!r}; "
+                    f"priced backends: {sorted(pricing['backends'])}"
+                )
+            if res not in table:
+                raise PricingError(
+                    f"model {entry['id']!r} has no {res} price on "
+                    f"backend {backend!r}; priced: {sorted(table)}"
+                )
+            return table[res]
+
+        if "per_size_quality" in pricing and size is not None:
+            key = f"{size}|{quality}"
+            table = pricing["per_size_quality"]
+            if key not in table:
+                raise PricingError(
+                    f"model {entry['id']!r} has no price for "
+                    f"size/quality {key!r}; priced: {sorted(table)}"
+                )
+            return table[key]
+
+        if "per_tier" in pricing and tier is not None:
+            table = pricing["per_tier"]
+            if tier not in table:
+                raise PricingError(
+                    f"model {entry['id']!r} has no tier {tier!r}; "
+                    f"priced tiers: {sorted(table)}"
+                )
+            return table[tier]
+
+        if "tiered_megapixel" in pricing and megapixels is not None:
+            rates = pricing["tiered_megapixel"]
+            extra = max(0.0, float(megapixels) - 1.0)
+            return rates["first_mp"] + extra * rates["per_extra_mp"]
+
+        if "flat" in pricing:
+            return pricing["flat"]
+
+        raise PricingError(
+            f"model {entry['id']!r}: no pricing shape matches the given "
+            f"parameters (resolution={resolution!r}, size={size!r}, "
+            f"quality={quality!r}, tier={tier!r}, megapixels={megapixels!r}); "
+            f"available shapes: {sorted(set(pricing) - {'currency', 'verified', 'estimate', 'notes', 'env_override'})}"
+        )
+
+    @staticmethod
+    def _chained_4k_cost(entry, table, pricing):
+        """4K = 2K generation + upscale; env override adjusts the upscale part.
+
+        Override is only honoured when it parses to a positive float —
+        guards against accidentally pricing a paid API at $0 or negative
+        (mirrors the historical RECRAFT_UPSCALE_COST_USD behaviour).
+        """
+        base = table.get("2K", 0.0)
+        upscale = table["4K"] - base
+        env_var = (pricing.get("env_override") or {}).get("upscale")
+        if env_var:
+            raw = os.environ.get(env_var)
+            if raw:
+                try:
+                    value = float(raw)
+                    if value > 0:
+                        upscale = value
+                except ValueError:
+                    pass
+        return base + upscale
+
+
+def load_catalog(shipped_path=None, cache_path=None, local_config_path=None):
+    """Load the catalog with full precedence merging. Returns ModelCatalog.
+
+    Precedence (low to high): shipped baseline -> cached remote ->
+    local-config.json ``model_catalog`` overrides. See module docstring.
+    """
+    source = "shipped"
+    cached = _load_cached_remote(cache_path)
+    if cached is not None:
+        doc, path = cached
+        source = f"cached:{path}"
+    else:
+        path = _find_shipped_catalog(shipped_path)
+        try:
+            doc = _read_json(path)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise CatalogError(f"cannot read shipped catalog at {path}: {exc}")
+        validate_catalog(doc)
+
+    doc, overridden = _apply_local_overrides(doc, local_config_path)
+    if overridden:
+        source += "+local"
+    catalog = ModelCatalog(doc, source=source)
+    logger.debug(
+        "model catalog loaded: version=%s source=%s models=%d",
+        catalog.version, source, len(doc["models"]),
+    )
+    return catalog
+
+
+_catalog_singleton = None
+
+
+def get_catalog(reload=False):
+    """Process-wide cached catalog. ``reload=True`` re-reads from disk."""
+    global _catalog_singleton
+    if _catalog_singleton is None or reload:
+        _catalog_singleton = load_catalog()
+    return _catalog_singleton

--- a/plugins/jack-tar-cloud/src/model_catalog.py
+++ b/plugins/jack-tar-cloud/src/model_catalog.py
@@ -242,6 +242,11 @@ class ModelCatalog:
                 self._by_name[alias] = entry
 
     @property
+    def doc(self):
+        """The raw validated catalog document (read-only by convention)."""
+        return self._doc
+
+    @property
     def version(self):
         return self._doc["catalog_version"]
 

--- a/plugins/jack-tar-cloud/src/model_catalog_refresh.py
+++ b/plugins/jack-tar-cloud/src/model_catalog_refresh.py
@@ -1,0 +1,261 @@
+"""Model catalog refresh — release-decoupled catalog updates (EPIC #125, #128).
+
+Fetches the canonical model catalog from the repository's main branch,
+validates it against the installed loader, surfaces a pricing/model diff
+for the operator gate, and atomically swaps it into the local cache that
+``model_catalog.load_catalog`` prefers over the shipped baseline.
+
+Design constraints:
+
+- **The operator gate is load-bearing** (CLAUDE.md F10): cost figures drive
+  the free→cost cascade gates, so a refresh that changes any price MUST be
+  surfaced to the operator before it takes effect. ``diff_catalogs`` is the
+  gate's evidence; the refresh-models skill presents it and waits for
+  explicit go-ahead. Refresh is on-request, never silent.
+- **A bad remote can never brick an install**: the remote document is
+  validated (structure + min_loader_version) BEFORE it touches the cache;
+  the previous cache is kept alongside for one-command rollback; and the
+  loader independently re-validates the cache on every load, falling back
+  to the shipped baseline if it is somehow corrupt.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+try:
+    from .model_catalog import (
+        CATALOG_CACHE_ENV,
+        CatalogError,
+        load_catalog,
+        validate_catalog,
+    )
+except ImportError:  # pragma: no cover - direct-script execution path
+    from model_catalog import (
+        CATALOG_CACHE_ENV,
+        CatalogError,
+        load_catalog,
+        validate_catalog,
+    )
+
+logger = logging.getLogger(__name__)
+
+#: Canonical published location — the repo's main branch. A catalog-only
+#: commit to main is picked up by every install on next refresh, no plugin
+#: release required.
+DEFAULT_REMOTE_URL = (
+    "https://raw.githubusercontent.com/SteveGJones/jack-tar-deckhand/"
+    "main/model-catalog/model-catalog.json"
+)
+
+REMOTE_URL_ENV = "JACK_TAR_CATALOG_URL"
+
+_DEFAULT_CACHE_PATH = Path.home() / ".jack-tar" / "model-catalog.json"
+_PREV_SUFFIX = ".prev"
+
+
+def _cache_path(cache_path=None):
+    return Path(
+        cache_path
+        or os.environ.get(CATALOG_CACHE_ENV)
+        or _DEFAULT_CACHE_PATH
+    )
+
+
+def fetch_remote_catalog(url=None, timeout=15):
+    """Fetch and parse the remote catalog document. Raises CatalogError.
+
+    The document is structurally validated (including min_loader_version
+    against the installed loader) before being returned — callers never
+    see an unusable catalog.
+    """
+    import requests
+
+    target = url or os.environ.get(REMOTE_URL_ENV) or DEFAULT_REMOTE_URL
+    try:
+        response = requests.get(target, timeout=timeout)
+        response.raise_for_status()
+        doc = response.json()
+    except requests.RequestException as exc:
+        raise CatalogError(f"cannot fetch remote catalog from {target}: {exc}")
+    except ValueError as exc:
+        raise CatalogError(f"remote catalog at {target} is not valid JSON: {exc}")
+    validate_catalog(doc)
+    return doc
+
+
+def diff_catalogs(current_doc, new_doc):
+    """Diff two catalog documents for the operator gate.
+
+    Returns a dict:
+        price_changes: [{model, component, old, new}]  — GATE-RELEVANT
+        added_models: [id]
+        removed_models: [id]
+        status_changes: [{model, old, new, replacement}]
+        version: {old, new}
+    """
+    def _by_id(doc):
+        return {e["id"]: e for e in doc["models"]}
+
+    def _flatten_pricing(entry):
+        flat = {}
+        pricing = entry.get("pricing") or {}
+        for key in ("flat",):
+            if key in pricing:
+                flat[key] = pricing[key]
+        for res, cost in (pricing.get("per_resolution") or {}).items():
+            flat[f"per_resolution.{res}"] = cost
+        for backend, table in (pricing.get("backends") or {}).items():
+            for res, cost in table.items():
+                flat[f"backends.{backend}.{res}"] = cost
+        for key, cost in (pricing.get("per_size_quality") or {}).items():
+            flat[f"per_size_quality.{key}"] = cost
+        for tier, cost in (pricing.get("per_tier") or {}).items():
+            flat[f"per_tier.{tier}"] = cost
+        tiered = pricing.get("tiered_megapixel")
+        if tiered:
+            flat["tiered_megapixel.first_mp"] = tiered["first_mp"]
+            flat["tiered_megapixel.per_extra_mp"] = tiered["per_extra_mp"]
+        for component, rate in (pricing.get("token_rates") or {}).items():
+            flat[f"token_rates.{component}"] = rate
+        return flat
+
+    current = _by_id(current_doc)
+    new = _by_id(new_doc)
+
+    price_changes = []
+    status_changes = []
+    for model_id in sorted(set(current) & set(new)):
+        old_prices = _flatten_pricing(current[model_id])
+        new_prices = _flatten_pricing(new[model_id])
+        for component in sorted(set(old_prices) | set(new_prices)):
+            old_value = old_prices.get(component)
+            new_value = new_prices.get(component)
+            if old_value != new_value:
+                price_changes.append({
+                    "model": model_id,
+                    "component": component,
+                    "old": old_value,
+                    "new": new_value,
+                })
+        if current[model_id]["status"] != new[model_id]["status"]:
+            status_changes.append({
+                "model": model_id,
+                "old": current[model_id]["status"],
+                "new": new[model_id]["status"],
+                "replacement": new[model_id].get("replacement"),
+            })
+
+    return {
+        "price_changes": price_changes,
+        "added_models": sorted(set(new) - set(current)),
+        "removed_models": sorted(set(current) - set(new)),
+        "status_changes": status_changes,
+        "version": {
+            "old": current_doc["catalog_version"],
+            "new": new_doc["catalog_version"],
+        },
+    }
+
+
+def check_remote(url=None, cache_path=None, local_config_path=None):
+    """Fetch the remote catalog and diff it against the effective catalog.
+
+    Read-only: nothing is written. Returns {remote_doc, diff, current_version,
+    current_source} — the refresh-models skill renders the diff for the
+    operator gate and only calls apply_refresh after explicit go-ahead.
+    """
+    current = load_catalog(
+        cache_path=cache_path, local_config_path=local_config_path
+    )
+    remote_doc = fetch_remote_catalog(url=url)
+    return {
+        "remote_doc": remote_doc,
+        "diff": diff_catalogs(current.doc, remote_doc),
+        "current_version": current.version,
+        "current_source": current.source,
+    }
+
+
+def apply_refresh(new_doc, cache_path=None):
+    """Atomically install a validated catalog document into the cache.
+
+    The previous cache (if any) is preserved at ``<cache>.prev`` for
+    rollback. Returns {cache_path, previous_kept, version}.
+    """
+    validate_catalog(new_doc)
+    path = _cache_path(cache_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    previous_kept = False
+    if path.exists():
+        path.with_suffix(path.suffix + _PREV_SUFFIX).write_bytes(path.read_bytes())
+        previous_kept = True
+
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(new_doc, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+    logger.info(
+        "model catalog cache updated: %s (version %s)",
+        path, new_doc["catalog_version"],
+    )
+    return {
+        "cache_path": str(path),
+        "previous_kept": previous_kept,
+        "version": new_doc["catalog_version"],
+    }
+
+
+def rollback(cache_path=None):
+    """Restore the previous cached catalog. Returns the restored version.
+
+    Raises CatalogError when there is no previous copy to restore.
+    """
+    path = _cache_path(cache_path)
+    prev = path.with_suffix(path.suffix + _PREV_SUFFIX)
+    if not prev.exists():
+        raise CatalogError(
+            f"no previous catalog to roll back to at {prev} — "
+            f"delete {path} instead to fall back to the shipped baseline"
+        )
+    doc = json.loads(prev.read_text())
+    validate_catalog(doc)
+    os.replace(prev, path)
+    logger.info("model catalog cache rolled back to version %s", doc["catalog_version"])
+    return {"cache_path": str(path), "version": doc["catalog_version"]}
+
+
+def staleness_report(cache_path=None, local_config_path=None):
+    """Non-blocking staleness hint for /verify: current catalog identity.
+
+    Does NOT hit the network — reports what is loaded and from where, plus
+    the cache file's age in days when a cache is in use.
+    """
+    catalog = load_catalog(
+        cache_path=cache_path, local_config_path=local_config_path
+    )
+    report = {
+        "version": catalog.version,
+        "updated": catalog.updated,
+        "source": catalog.source,
+    }
+    path = _cache_path(cache_path)
+    if path.exists():
+        import time
+        age_days = (time.time() - path.stat().st_mtime) / 86400
+        report["cache_age_days"] = round(age_days, 1)
+    return report

--- a/plugins/jack-tar-cloud/src/model_probe.py
+++ b/plugins/jack-tar-cloud/src/model_probe.py
@@ -1,0 +1,229 @@
+"""Live provider discovery — verify catalog entries against provider APIs
+(EPIC #125, issue #129).
+
+Where a provider exposes a list-models API, probe it on request and classify
+every catalog entry:
+
+- ``verified``          — the model id exists upstream right now
+- ``suspect_retired``   — catalog says active/deprecated but the provider no
+                          longer lists it (the gemini-2.0-flash failure mode,
+                          issue #123, caught BEFORE a 404 in a deck build)
+- ``confirmed_retired`` — catalog already says retired and upstream agrees
+- ``unprobed``          — the provider has no list API (FAL, Recraft) or no
+                          credentials are configured; catalog-driven only
+
+Upstream models that no catalog entry covers are reported as
+``new_candidates``. Live discovery attests EXISTENCE, never price — a
+candidate is not routable until a catalog entry prices it (the budget
+tracker cannot cost an uncataloged model), so candidates require explicit
+operator opt-in via a local-config override or a catalog update.
+
+Probes degrade gracefully: a provider with no API key is skipped with a
+reason, never an exception.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+try:
+    from .model_catalog import get_catalog
+except ImportError:  # pragma: no cover - direct-script execution path
+    from model_catalog import get_catalog
+
+logger = logging.getLogger(__name__)
+
+#: Providers with no list-models API — their entries are always unprobed.
+UNPROBEABLE_PROVIDERS = frozenset({"fal", "recraft"})
+
+
+def probe_google_models(timeout=30):
+    """List model ids the Google API serves right now.
+
+    Returns {'status': 'ok', 'models': set[str]} or
+    {'status': 'skipped', 'reason': str}.
+    """
+    if not (os.environ.get("GOOGLE_API_KEY")
+            or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")):
+        return {"status": "skipped", "reason": "no Google credentials configured"}
+    try:
+        from google import genai
+    except ImportError:
+        return {"status": "skipped", "reason": "google-genai SDK not installed"}
+    try:
+        client_kwargs = {}
+        api_key = os.environ.get("GOOGLE_API_KEY")
+        if api_key:
+            client_kwargs["api_key"] = api_key
+        client = genai.Client(**client_kwargs)
+        names = set()
+        for model in client.models.list():
+            name = getattr(model, "name", "") or ""
+            # API returns "models/gemini-..." — strip the resource prefix.
+            names.add(name.removeprefix("models/"))
+        return {"status": "ok", "models": names}
+    except Exception as exc:  # network/auth errors must not break verify
+        return {"status": "skipped", "reason": f"probe failed: {exc}"}
+
+
+def probe_openai_models(timeout=30):
+    """List model ids the OpenAI API serves right now."""
+    if not os.environ.get("OPENAI_API_KEY"):
+        return {"status": "skipped", "reason": "OPENAI_API_KEY not set"}
+    try:
+        from openai import OpenAI
+    except ImportError:
+        return {"status": "skipped", "reason": "openai SDK not installed"}
+    try:
+        client = OpenAI()
+        return {
+            "status": "ok",
+            "models": {m.id for m in client.models.list()},
+        }
+    except Exception as exc:
+        return {"status": "skipped", "reason": f"probe failed: {exc}"}
+
+
+def probe_ollama_models(endpoint="http://localhost:11434"):
+    """List locally installed Ollama model tags."""
+    import requests
+
+    try:
+        response = requests.get(f"{endpoint}/api/tags", timeout=5)
+        data = response.json()
+        return {
+            "status": "ok",
+            "models": {m["name"] for m in data.get("models", [])},
+        }
+    except Exception as exc:
+        return {"status": "skipped", "reason": f"Ollama not reachable: {exc}"}
+
+
+def _entry_upstream_match(entry, upstream):
+    """True when any name of this entry exists upstream.
+
+    Ollama catalog ids are tag-prefixes (``x/flux2-klein`` matches the
+    installed ``x/flux2-klein:9b``); other providers match exactly.
+    """
+    names = [entry["id"], *entry.get("aliases", [])]
+    if entry["provider"] == "ollama":
+        return any(
+            tag == name or tag.startswith(f"{name}:")
+            for name in names
+            for tag in upstream
+        )
+    return any(name in upstream for name in names)
+
+
+def classify_entries(catalog, probes):
+    """Classify every catalog entry against the probe results.
+
+    Args:
+        catalog: a ModelCatalog.
+        probes: {provider: {'status': 'ok'|'skipped', 'models': set, ...}}
+
+    Returns:
+        list of {model, provider, status, verdict[, note]}.
+    """
+    results = []
+    for entry in catalog.entries(status=None):
+        provider = entry["provider"]
+        probe = probes.get(provider)
+        if provider in UNPROBEABLE_PROVIDERS:
+            verdict = {"verdict": "unprobed",
+                       "note": "provider has no list-models API; catalog-driven"}
+        elif probe is None or probe.get("status") != "ok":
+            reason = (probe or {}).get("reason", "provider not probed")
+            verdict = {"verdict": "unprobed", "note": reason}
+        elif _entry_upstream_match(entry, probe["models"]):
+            if entry["status"] == "retired":
+                verdict = {"verdict": "verified",
+                           "note": "catalog says retired but upstream still "
+                                   "lists it — consider un-retiring"}
+            else:
+                verdict = {"verdict": "verified"}
+        else:
+            if entry["status"] == "retired":
+                verdict = {"verdict": "confirmed_retired"}
+            else:
+                verdict = {"verdict": "suspect_retired",
+                           "note": "not listed upstream — update the catalog "
+                                   "(or run refresh-models) before relying "
+                                   "on this model"}
+        results.append({
+            "model": entry["id"],
+            "provider": provider,
+            "status": entry["status"],
+            **verdict,
+        })
+    return results
+
+
+# Substring filters for candidate relevance per provider — the list APIs
+# return every model family; only image/vision-relevant ones are useful
+# candidates for this pipeline.
+_CANDIDATE_FILTERS = {
+    "google": ("image", "imagen", "flash", "pro"),
+    "openai": ("image", "dall-e"),
+    "ollama": ("x/",),
+}
+
+
+def find_new_candidates(catalog, probes):
+    """Upstream models no catalog entry covers, filtered to relevant kinds.
+
+    Candidates are NOT routable: existence is provable, price is not. They
+    surface for the operator to add to the catalog (or a local-config
+    override) before use.
+    """
+    known = set()
+    for entry in catalog.entries(status=None):
+        known.add(entry["id"])
+        known.update(entry.get("aliases", []))
+
+    candidates = {}
+    for provider, probe in probes.items():
+        if probe.get("status") != "ok":
+            continue
+        filters = _CANDIDATE_FILTERS.get(provider, ())
+        found = []
+        for name in sorted(probe["models"]):
+            if any(name == k or name.startswith(f"{k}:") for k in known):
+                continue
+            if filters and not any(f in name for f in filters):
+                continue
+            found.append(name)
+        if found:
+            candidates[provider] = found
+    return candidates
+
+
+def probe_report(catalog=None, probes=None):
+    """Full live-discovery report for /verify and refresh-models.
+
+    Args:
+        catalog: ModelCatalog (defaults to the effective loaded catalog).
+        probes: pre-computed probe results (tests / callers that already
+            probed); defaults to probing google + openai + ollama live.
+
+    Returns:
+        {catalog_version, probes: {provider: status/reason},
+         entries: [classification...], new_candidates: {provider: [id...]}}
+    """
+    catalog = catalog or get_catalog()
+    if probes is None:
+        probes = {
+            "google": probe_google_models(),
+            "openai": probe_openai_models(),
+            "ollama": probe_ollama_models(),
+        }
+    return {
+        "catalog_version": catalog.version,
+        "probes": {
+            provider: {k: v for k, v in probe.items() if k != "models"}
+            for provider, probe in probes.items()
+        },
+        "entries": classify_entries(catalog, probes),
+        "new_candidates": find_new_candidates(catalog, probes),
+    }

--- a/plugins/jack-tar-cloud/src/prompt_translator.py
+++ b/plugins/jack-tar-cloud/src/prompt_translator.py
@@ -16,16 +16,25 @@ The translator also injects palette colours and image_style_tokens
 from the StyleGuide for visual consistency.
 """
 
-# Token/word budget per model
-MODEL_BUDGETS = {
-    'x/z-image-turbo': {'max_words': 50, 'style': 'concise_camera'},
-    'x/flux2-klein': {'max_words': 200, 'style': 'detailed_spatial'},
-    'gpt-image-1.5': {'max_words': 500, 'style': 'natural_language'},
-    'flux-2-pro': {'max_words': 60, 'style': 'photography'},
-    'recraft-v4': {'max_words': 100, 'style': 'design_centric'},
-    'imagen-4': {'max_words': 40, 'style': 'concise'},
-    'ideogram-3': {'max_words': 80, 'style': 'typography'},
-}
+try:
+    from .model_catalog import get_catalog as _get_model_catalog
+except ImportError:  # pragma: no cover - direct-script execution path
+    from model_catalog import get_catalog as _get_model_catalog
+
+# Token/word budget per model, derived from the catalog's prompt_budget
+# capability (EPIC #125). Ids AND aliases key the same budget, so callers
+# holding either name ('imagen-4' vs 'imagen-4.0-generate-001') resolve.
+MODEL_BUDGETS = {}
+# Models that do NOT support negative prompts (no_negative_prompt quirk).
+_NO_NEGATIVE_PROMPT_MODELS = set()
+for _entry in _get_model_catalog().entries(role='image_gen'):
+    _names = [_entry['id'], *_entry.get('aliases', [])]
+    _budget = (_entry.get('capabilities') or {}).get('prompt_budget')
+    for _name in _names:
+        if _budget:
+            MODEL_BUDGETS[_name] = dict(_budget)
+        if 'no_negative_prompt' in _entry.get('quirks', []):
+            _NO_NEGATIVE_PROMPT_MODELS.add(_name)
 
 # Standard negative prompt for models that support it.
 # Text overlay is handled by PptxGenJS — never generate in-image text.
@@ -33,9 +42,6 @@ _NEGATIVE_PROMPT = (
     "text, watermark, logo, words, letters, typography, writing, "
     "blurry, low quality, distorted, deformed, ugly, noisy, grainy"
 )
-
-# Models that do NOT support negative prompts
-_NO_NEGATIVE_PROMPT_MODELS = {'gpt-image-1.5', 'imagen-4'}
 
 # Style-specific prefix additions
 _STYLE_PREFIXES = {

--- a/plugins/jack-tar-cloud/src/provider_discovery.py
+++ b/plugins/jack-tar-cloud/src/provider_discovery.py
@@ -23,33 +23,39 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-# Known FAL.ai image generation models
-_FAL_IMAGE_MODELS = ['flux-2-pro', 'recraft-v4', 'ideogram-3']
+try:
+    from .model_catalog import get_catalog
+except ImportError:  # pragma: no cover - direct-script execution path
+    from model_catalog import get_catalog
+
+_CATALOG = get_catalog()
+
+# Known FAL.ai image generation models (short display names). 'recraft-v4'
+# rides along because FAL hosts Recraft V4 as a fallback route.
+_FAL_IMAGE_MODELS = sorted(
+    alias
+    for entry in _CATALOG.entries(role='image_gen', provider='fal')
+    for alias in entry.get('aliases', [])
+) + ['recraft-v4']
 
 # Per-model supported resolutions — exposed via discover_providers().
-# Matches _MODEL_RESOLUTIONS in generate_cloud_image.py for Google models;
-# mirrors the FAL/OpenAI capability per model.
-_PROVIDER_MODEL_RESOLUTIONS = {
-    'openai': {
-        'gpt-image-1.5': ['1K'],
-    },
-    'google': {
-        'imagen-4.0-fast-generate-001': ['1K'],
-        'imagen-4.0-generate-001': ['1K', '2K'],
-        'imagen-4.0-ultra-generate-001': ['1K', '2K'],
-        'gemini-3.1-flash-image-preview': ['512', '1K', '2K', '4K'],
-        'gemini-3-pro-image-preview': ['1K', '2K', '4K'],
-    },
-    'fal': {
-        'fal-ai/flux-2-pro': ['1K', '2K'],
-        'fal-ai/flux-2-klein': ['1K'],
-        'fal-ai/ideogram/v3': ['1K'],
-    },
-    'recraft': {
-        'recraft-v4-standard': ['1K'],
-        'recraft-v4-pro': ['2K', '4K'],
-    },
-}
+# Derived from the model catalog (EPIC #125): canonical ids AND their
+# aliases (including retired '-preview' Gemini ids, issue #123) both
+# resolve, so callers holding either name see the same capability.
+# Local backends (ollama/mlx) are excluded: their 'models' surface is the
+# live install list from probe_ollama, not a static capability table.
+_CLOUD_PROVIDERS = frozenset({'openai', 'google', 'fal', 'recraft'})
+
+_PROVIDER_MODEL_RESOLUTIONS = {}
+for _entry in _CATALOG.entries(role='image_gen'):
+    if _entry['provider'] not in _CLOUD_PROVIDERS:
+        continue
+    _resolutions = list((_entry.get('capabilities') or {}).get('resolutions', []))
+    if not _resolutions:
+        continue
+    _per_provider = _PROVIDER_MODEL_RESOLUTIONS.setdefault(_entry['provider'], {})
+    for _name in [_entry['id'], *_entry.get('aliases', [])]:
+        _per_provider[_name] = _resolutions
 
 # Default env vars per provider (matches official SDK conventions)
 _PROVIDER_DEFAULTS = {
@@ -215,8 +221,8 @@ def discover_providers(config_path='provider_config.json'):
                         'imagen-4.0-fast-generate-001': {'supported_resolutions': ['1K']},
                         'imagen-4.0-generate-001': {'supported_resolutions': ['1K', '2K']},
                         'imagen-4.0-ultra-generate-001': {'supported_resolutions': ['1K', '2K']},
-                        'gemini-3.1-flash-image-preview': {'supported_resolutions': ['512', '1K', '2K', '4K']},
-                        'gemini-3-pro-image-preview': {'supported_resolutions': ['1K', '2K', '4K']},
+                        'gemini-3.1-flash-image': {'supported_resolutions': ['512', '1K', '2K', '4K']},
+                        'gemini-3-pro-image': {'supported_resolutions': ['1K', '2K', '4K']},
                     },
                 },
                 'fal': {

--- a/plugins/jack-tar-cloud/tests/test_model_catalog.py
+++ b/plugins/jack-tar-cloud/tests/test_model_catalog.py
@@ -1,0 +1,376 @@
+"""Tests for the model catalog loader (EPIC #125, issue #126).
+
+The catalog is the single source of truth for model identity, capability,
+and pricing. These tests pin the loader's behaviour: alias resolution,
+retired-model substitution, role selection, the pricing shapes, and the
+three-layer precedence merge (shipped -> cached remote -> local overrides).
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from src.model_catalog import (  # noqa: E402
+    LOADER_VERSION,
+    CatalogError,
+    ModelCatalog,
+    PricingError,
+    UnknownModelError,
+    load_catalog,
+    validate_catalog,
+)
+
+SHIPPED = PLUGIN_ROOT / "src" / "model-catalog.json"
+
+
+@pytest.fixture
+def catalog(tmp_path):
+    """Shipped catalog with the remote cache pointed at a non-existent file
+    so a developer's real ~/.jack-tar cache can never leak into tests."""
+    return load_catalog(
+        shipped_path=SHIPPED,
+        cache_path=tmp_path / "no-cache.json",
+        local_config_path=tmp_path / "no-local-config.json",
+    )
+
+
+def minimal_doc(**overrides):
+    doc = {
+        "catalog_version": "1.0.0",
+        "min_loader_version": 1,
+        "updated": "2026-07-15",
+        "models": [
+            {
+                "id": "m1",
+                "provider": "test",
+                "status": "active",
+                "replacement": None,
+                "roles": ["image_gen"],
+                "pricing": {
+                    "currency": "USD",
+                    "verified": "2026-07-15",
+                    "estimate": False,
+                    "flat": 0.01,
+                },
+            }
+        ],
+    }
+    doc.update(overrides)
+    return doc
+
+
+class TestValidation:
+    def test_shipped_catalog_is_valid(self):
+        validate_catalog(json.loads(SHIPPED.read_text()))
+
+    def test_missing_top_key_rejected(self):
+        doc = minimal_doc()
+        del doc["updated"]
+        with pytest.raises(CatalogError, match="updated"):
+            validate_catalog(doc)
+
+    def test_future_loader_version_rejected(self):
+        doc = minimal_doc(min_loader_version=LOADER_VERSION + 1)
+        with pytest.raises(CatalogError, match="loader version"):
+            validate_catalog(doc)
+
+    def test_duplicate_alias_rejected(self):
+        doc = minimal_doc()
+        doc["models"].append(
+            {
+                "id": "m2",
+                "provider": "test",
+                "aliases": ["m1"],
+                "status": "active",
+                "roles": ["image_gen"],
+            }
+        )
+        with pytest.raises(CatalogError, match="duplicate"):
+            validate_catalog(doc)
+
+    def test_retired_without_replacement_rejected(self):
+        doc = minimal_doc()
+        doc["models"][0]["status"] = "retired"
+        doc["models"][0]["replacement"] = None
+        with pytest.raises(CatalogError, match="replacement"):
+            validate_catalog(doc)
+
+    def test_unknown_replacement_rejected(self):
+        doc = minimal_doc()
+        doc["models"][0]["status"] = "retired"
+        doc["models"][0]["replacement"] = "ghost"
+        with pytest.raises(CatalogError, match="ghost"):
+            validate_catalog(doc)
+
+    def test_role_default_naming_unknown_model_rejected(self):
+        doc = minimal_doc(role_defaults={"image_gen": "ghost"})
+        with pytest.raises(CatalogError, match="ghost"):
+            validate_catalog(doc)
+
+
+class TestLookup:
+    def test_get_by_id(self, catalog):
+        entry = catalog.get("gemini-3.1-flash-image")
+        assert entry["provider"] == "google"
+        assert "resolved_from" not in entry
+
+    def test_deprecated_preview_alias_resolves(self, catalog):
+        """Issue #123: '-preview' ids retired upstream; callers holding the
+        old name must land on the current one."""
+        entry = catalog.get("gemini-3.1-flash-image-preview")
+        assert entry["id"] == "gemini-3.1-flash-image"
+        assert entry["resolved_from"] == "gemini-3.1-flash-image-preview"
+
+    def test_retired_model_substitutes_replacement(self, catalog):
+        """Issue #123: gemini-2.0-flash 404s upstream — the loader routes
+        callers to the verified working replacement."""
+        entry = catalog.get("gemini-2.0-flash")
+        assert entry["id"] == "gemini-3.5-flash"
+        assert entry["resolved_from"] == "gemini-2.0-flash"
+
+    def test_retired_model_reachable_without_substitution(self, catalog):
+        entry = catalog.get("gemini-2.0-flash", follow_replacement=False)
+        assert entry["id"] == "gemini-2.0-flash"
+        assert entry["status"] == "retired"
+
+    def test_unknown_model_raises(self, catalog):
+        with pytest.raises(UnknownModelError):
+            catalog.get("gpt-99-vision-max")
+
+    def test_get_returns_copy(self, catalog):
+        catalog.get("gemini-3.1-flash-image")["provider"] = "mutated"
+        assert catalog.get("gemini-3.1-flash-image")["provider"] == "google"
+
+
+class TestRoles:
+    def test_thinking_model_not_vlm_json_eligible(self, catalog):
+        """Issue #122: gemini-2.5-flash's reasoning tokens break strict-JSON
+        parsers — it must never come back from a vlm_json role query."""
+        ids = [e["id"] for e in catalog.entries(role="vlm_json")]
+        assert "gemini-2.5-flash" not in ids
+        assert "gemini-3.5-flash" in ids
+
+    def test_vlm_json_default(self, catalog):
+        assert catalog.default_model("vlm_json")["id"] == "gemini-3.5-flash"
+
+    def test_local_draft_preference_order(self, catalog):
+        prefs = catalog.role_default("local_draft")
+        assert prefs == ["x/flux2-klein", "x/z-image-turbo"]
+        assert catalog.default_model("local_draft")["id"] == "x/flux2-klein"
+
+    def test_icon_default(self, catalog):
+        assert catalog.default_model("icon")["id"] == "recraft-v4-svg"
+
+    def test_entries_filter_by_provider(self, catalog):
+        assert all(
+            e["provider"] == "ollama"
+            for e in catalog.entries(provider="ollama")
+        )
+
+
+class TestCapabilities:
+    def test_resolutions(self, catalog):
+        assert catalog.resolutions("gemini-3.1-flash-image") == ["512", "1K", "2K", "4K"]
+        assert catalog.resolutions("imagen-4.0-fast-generate-001") == ["1K"]
+
+    def test_supports_normalises_case(self, catalog):
+        assert catalog.supports("gemini-3-pro-image", "4k")
+        assert not catalog.supports("fal-ai/flux-2-klein", "4K")
+
+    def test_quirks(self, catalog):
+        # Deprecated (not retired) entries are inspected directly — 2.5-flash
+        # itself carries the thinking quirk that disqualifies it from vlm_json.
+        assert catalog.has_quirk("gemini-2.5-flash", "thinking")
+        assert catalog.has_quirk("imagen-4.0-fast-generate-001", "fixed_resolution")
+        assert not catalog.has_quirk("gemini-3.5-flash", "thinking")
+
+    def test_nano_banana_sdk_config_field_is_image_size(self, catalog):
+        """Issue #121 ground truth: google-genai 2.11.0 accepts
+        ImageConfig(image_size=...) — verified 2026-07-15. The catalog must
+        carry the verified field name, not the misreported aspectRatio."""
+        assert catalog.get("gemini-3.1-flash-image")["sdk"]["config_field"] == "image_size"
+
+
+class TestCost:
+    def test_per_resolution(self, catalog):
+        assert catalog.cost("gemini-3.1-flash-image", resolution="1K") == 0.067
+        assert catalog.cost("gemini-3-pro-image", resolution="4K") == 0.24
+
+    def test_per_resolution_via_alias(self, catalog):
+        assert catalog.cost("gemini-3.1-flash-image-preview", resolution="2K") == 0.101
+
+    def test_unpriced_resolution_raises(self, catalog):
+        with pytest.raises(PricingError):
+            catalog.cost("gemini-3-pro-image", resolution="512")
+
+    def test_imagen_backend_pricing(self, catalog, monkeypatch):
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        assert catalog.cost("imagen-4.0-generate-001", resolution="2K") == 0.101
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/tmp/adc.json")
+        assert catalog.cost("imagen-4.0-generate-001", resolution="2K") == 0.04
+        assert catalog.cost(
+            "imagen-4.0-generate-001", resolution="2K", backend="developer"
+        ) == 0.101
+
+    def test_openai_size_quality(self, catalog):
+        assert catalog.cost("gpt-image-1.5", size="1536x1024", quality="medium") == 0.051
+
+    def test_icon_per_tier(self, catalog):
+        assert catalog.cost("recraft-v4-svg", tier="standard") == 0.08
+        assert catalog.cost("recraft-v4-svg", tier="pro") == 0.3
+
+    def test_flat(self, catalog):
+        assert catalog.cost("fal-ai/flux-2-klein") == 0.014
+
+    def test_flat_wins_even_with_resolution_param(self, catalog):
+        assert catalog.cost("x/flux2-klein", resolution="1K") == 0.0
+
+    def test_tiered_megapixel(self, catalog):
+        cost = catalog.cost("fal-ai/flux-2-pro", megapixels=2.0736)
+        assert cost == pytest.approx(0.03 + 1.0736 * 0.015)
+
+    def test_recraft_4k_chain_default(self, catalog, monkeypatch):
+        monkeypatch.delenv("RECRAFT_UPSCALE_COST_USD", raising=False)
+        assert catalog.cost("recraft-v4-pro", resolution="4K") == 0.5
+
+    def test_recraft_4k_chain_env_override(self, catalog, monkeypatch):
+        monkeypatch.setenv("RECRAFT_UPSCALE_COST_USD", "0.10")
+        assert catalog.cost("recraft-v4-pro", resolution="4K") == pytest.approx(0.35)
+
+    def test_recraft_4k_chain_rejects_bad_override(self, catalog, monkeypatch):
+        monkeypatch.setenv("RECRAFT_UPSCALE_COST_USD", "-1")
+        assert catalog.cost("recraft-v4-pro", resolution="4K") == 0.5
+        monkeypatch.setenv("RECRAFT_UPSCALE_COST_USD", "banana")
+        assert catalog.cost("recraft-v4-pro", resolution="4K") == 0.5
+
+    def test_model_without_pricing_raises(self, catalog):
+        with pytest.raises(PricingError):
+            catalog.cost("gemini-3.5-flash", resolution="1K")
+
+
+class TestPrecedence:
+    def test_valid_cache_wins_over_shipped(self, tmp_path):
+        doc = json.loads(SHIPPED.read_text())
+        doc["catalog_version"] = "9.9.9"
+        cache = tmp_path / "cache.json"
+        cache.write_text(json.dumps(doc))
+        catalog = load_catalog(
+            shipped_path=SHIPPED,
+            cache_path=cache,
+            local_config_path=tmp_path / "none.json",
+        )
+        assert catalog.version == "9.9.9"
+        assert catalog.source.startswith("cached:")
+
+    def test_invalid_cache_falls_back_to_shipped(self, tmp_path):
+        cache = tmp_path / "cache.json"
+        cache.write_text("{not json")
+        catalog = load_catalog(
+            shipped_path=SHIPPED,
+            cache_path=cache,
+            local_config_path=tmp_path / "none.json",
+        )
+        assert catalog.source == "shipped"
+
+    def test_incompatible_cache_falls_back_to_shipped(self, tmp_path):
+        doc = json.loads(SHIPPED.read_text())
+        doc["min_loader_version"] = LOADER_VERSION + 1
+        cache = tmp_path / "cache.json"
+        cache.write_text(json.dumps(doc))
+        catalog = load_catalog(
+            shipped_path=SHIPPED,
+            cache_path=cache,
+            local_config_path=tmp_path / "none.json",
+        )
+        assert catalog.source == "shipped"
+
+    def test_local_override_patches_price(self, tmp_path):
+        local = tmp_path / "local-config.json"
+        local.write_text(json.dumps({
+            "model_catalog": {
+                "models": [{
+                    "id": "fal-ai/flux-2-klein",
+                    "pricing": {
+                        "currency": "USD",
+                        "verified": "2026-07-15",
+                        "estimate": False,
+                        "flat": 0.02,
+                    },
+                }],
+            },
+        }))
+        catalog = load_catalog(
+            shipped_path=SHIPPED,
+            cache_path=tmp_path / "none.json",
+            local_config_path=local,
+        )
+        assert catalog.cost("fal-ai/flux-2-klein") == 0.02
+        assert catalog.source.endswith("+local")
+
+    def test_local_override_adds_model(self, tmp_path):
+        """The MLX seam (#124): an operator can register a locally-served
+        model without waiting for a catalog release."""
+        local = tmp_path / "local-config.json"
+        local.write_text(json.dumps({
+            "model_catalog": {
+                "models": [{
+                    "id": "mlx/flux-dev-q8",
+                    "provider": "mlx",
+                    "status": "active",
+                    "replacement": None,
+                    "roles": ["image_gen", "local_draft"],
+                }],
+                "role_defaults": {
+                    "local_draft": ["mlx/flux-dev-q8", "x/flux2-klein"],
+                },
+            },
+        }))
+        catalog = load_catalog(
+            shipped_path=SHIPPED,
+            cache_path=tmp_path / "none.json",
+            local_config_path=local,
+        )
+        assert catalog.get("mlx/flux-dev-q8")["provider"] == "mlx"
+        assert catalog.default_model("local_draft")["id"] == "mlx/flux-dev-q8"
+
+    def test_broken_local_override_fails_loudly(self, tmp_path):
+        local = tmp_path / "local-config.json"
+        local.write_text(json.dumps({
+            "model_catalog": {
+                "models": [{"id": "half-entry"}],
+            },
+        }))
+        with pytest.raises(CatalogError):
+            load_catalog(
+                shipped_path=SHIPPED,
+                cache_path=tmp_path / "none.json",
+                local_config_path=local,
+            )
+
+    def test_local_config_without_catalog_key_ignored(self, tmp_path):
+        local = tmp_path / "local-config.json"
+        local.write_text(json.dumps({"ollama": {"model": "x/flux2-klein:9b"}}))
+        catalog = load_catalog(
+            shipped_path=SHIPPED,
+            cache_path=tmp_path / "none.json",
+            local_config_path=local,
+        )
+        assert catalog.source == "shipped"
+
+
+class TestReplacementCycle:
+    def test_cycle_detected(self):
+        doc = minimal_doc()
+        doc["models"] = [
+            {"id": "a", "provider": "t", "status": "retired",
+             "replacement": "b", "roles": ["image_gen"]},
+            {"id": "b", "provider": "t", "status": "retired",
+             "replacement": "a", "roles": ["image_gen"]},
+        ]
+        catalog = ModelCatalog(doc)
+        with pytest.raises(CatalogError, match="cycle"):
+            catalog.get("a")

--- a/plugins/jack-tar-cloud/tests/test_model_catalog_refresh.py
+++ b/plugins/jack-tar-cloud/tests/test_model_catalog_refresh.py
@@ -1,0 +1,215 @@
+"""Tests for the model catalog refresh mechanism (EPIC #125, issue #128).
+
+Pins the release-decoupling safety properties: validated-before-write,
+atomic swap with rollback copy, operator-gate diff correctness, and
+graceful rejection of bad/incompatible remotes.
+"""
+import copy
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from src.model_catalog import (  # noqa: E402
+    LOADER_VERSION,
+    CatalogError,
+    load_catalog,
+)
+from src import model_catalog_refresh as refresh  # noqa: E402
+
+SHIPPED = PLUGIN_ROOT / "src" / "model-catalog.json"
+
+
+@pytest.fixture
+def shipped_doc():
+    return json.loads(SHIPPED.read_text())
+
+
+@pytest.fixture
+def cache(tmp_path, monkeypatch):
+    """Isolated cache path — tests never touch the real ~/.jack-tar."""
+    path = tmp_path / "cache" / "model-catalog.json"
+    monkeypatch.setenv("JACK_TAR_CATALOG_CACHE", str(path))
+    return path
+
+
+class TestDiff:
+    def test_no_changes_yields_empty_diff(self, shipped_doc):
+        diff = refresh.diff_catalogs(shipped_doc, copy.deepcopy(shipped_doc))
+        assert diff["price_changes"] == []
+        assert diff["added_models"] == []
+        assert diff["removed_models"] == []
+        assert diff["status_changes"] == []
+
+    def test_price_change_detected(self, shipped_doc):
+        new_doc = copy.deepcopy(shipped_doc)
+        for entry in new_doc["models"]:
+            if entry["id"] == "gemini-3-pro-image":
+                entry["pricing"]["per_resolution"]["4K"] = 0.26
+        diff = refresh.diff_catalogs(shipped_doc, new_doc)
+        assert diff["price_changes"] == [{
+            "model": "gemini-3-pro-image",
+            "component": "per_resolution.4K",
+            "old": 0.24,
+            "new": 0.26,
+        }]
+
+    def test_status_change_carries_replacement(self, shipped_doc):
+        new_doc = copy.deepcopy(shipped_doc)
+        for entry in new_doc["models"]:
+            if entry["id"] == "gemini-2.5-flash":
+                entry["status"] = "retired"
+        diff = refresh.diff_catalogs(shipped_doc, new_doc)
+        assert diff["status_changes"] == [{
+            "model": "gemini-2.5-flash",
+            "old": "deprecated",
+            "new": "retired",
+            "replacement": "gemini-3.5-flash",
+        }]
+
+    def test_added_and_removed_models(self, shipped_doc):
+        new_doc = copy.deepcopy(shipped_doc)
+        new_doc["models"] = [
+            e for e in new_doc["models"] if e["id"] != "fal-ai/ideogram/v3"
+        ]
+        new_doc["models"].append({
+            "id": "mlx/flux-dev", "provider": "mlx", "status": "active",
+            "replacement": None, "roles": ["local_draft"],
+        })
+        diff = refresh.diff_catalogs(shipped_doc, new_doc)
+        assert diff["added_models"] == ["mlx/flux-dev"]
+        assert diff["removed_models"] == ["fal-ai/ideogram/v3"]
+
+
+class TestFetch:
+    def test_fetch_validates_remote(self, monkeypatch, shipped_doc):
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return shipped_doc
+
+        import requests
+        monkeypatch.setattr(requests, "get", lambda url, timeout: FakeResponse())
+        doc = refresh.fetch_remote_catalog(url="https://example.test/catalog.json")
+        assert doc["catalog_version"] == shipped_doc["catalog_version"]
+
+    def test_fetch_rejects_incompatible_remote(self, monkeypatch, shipped_doc):
+        bad = copy.deepcopy(shipped_doc)
+        bad["min_loader_version"] = LOADER_VERSION + 1
+
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return bad
+
+        import requests
+        monkeypatch.setattr(requests, "get", lambda url, timeout: FakeResponse())
+        with pytest.raises(CatalogError, match="loader version"):
+            refresh.fetch_remote_catalog(url="https://example.test/catalog.json")
+
+    def test_fetch_wraps_network_errors(self, monkeypatch):
+        import requests
+
+        def boom(url, timeout):
+            raise requests.ConnectionError("no route to host")
+
+        monkeypatch.setattr(requests, "get", boom)
+        with pytest.raises(CatalogError, match="cannot fetch"):
+            refresh.fetch_remote_catalog(url="https://example.test/catalog.json")
+
+
+class TestApplyAndRollback:
+    def test_apply_writes_cache_and_loader_prefers_it(self, cache, shipped_doc, tmp_path):
+        new_doc = copy.deepcopy(shipped_doc)
+        new_doc["catalog_version"] = "1.1.0"
+        summary = refresh.apply_refresh(new_doc, cache_path=cache)
+        assert summary["version"] == "1.1.0"
+        assert summary["previous_kept"] is False
+
+        catalog = load_catalog(
+            shipped_path=SHIPPED, cache_path=cache,
+            local_config_path=tmp_path / "none.json",
+        )
+        assert catalog.version == "1.1.0"
+        assert catalog.source.startswith("cached:")
+
+    def test_apply_rejects_invalid_doc_without_touching_cache(self, cache):
+        with pytest.raises(CatalogError):
+            refresh.apply_refresh({"not": "a catalog"}, cache_path=cache)
+        assert not cache.exists()
+
+    def test_second_apply_keeps_previous_for_rollback(self, cache, shipped_doc):
+        v1 = copy.deepcopy(shipped_doc)
+        v1["catalog_version"] = "1.1.0"
+        refresh.apply_refresh(v1, cache_path=cache)
+
+        v2 = copy.deepcopy(shipped_doc)
+        v2["catalog_version"] = "1.2.0"
+        summary = refresh.apply_refresh(v2, cache_path=cache)
+        assert summary["previous_kept"] is True
+        assert json.loads(cache.read_text())["catalog_version"] == "1.2.0"
+
+        restored = refresh.rollback(cache_path=cache)
+        assert restored["version"] == "1.1.0"
+        assert json.loads(cache.read_text())["catalog_version"] == "1.1.0"
+
+    def test_rollback_without_previous_raises(self, cache):
+        with pytest.raises(CatalogError, match="no previous catalog"):
+            refresh.rollback(cache_path=cache)
+
+
+class TestCheckRemote:
+    def test_check_remote_is_read_only(self, cache, monkeypatch, shipped_doc, tmp_path):
+        new_doc = copy.deepcopy(shipped_doc)
+        new_doc["catalog_version"] = "2.0.0"
+        for entry in new_doc["models"]:
+            if entry["id"] == "gemini-3.1-flash-image":
+                entry["pricing"]["per_resolution"]["1K"] = 0.07
+
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return new_doc
+
+        import requests
+        monkeypatch.setattr(requests, "get", lambda url, timeout: FakeResponse())
+        result = refresh.check_remote(
+            url="https://example.test/catalog.json",
+            cache_path=cache,
+            local_config_path=tmp_path / "none.json",
+        )
+        assert result["diff"]["version"]["new"] == "2.0.0"
+        assert any(
+            c["component"] == "per_resolution.1K" and c["new"] == 0.07
+            for c in result["diff"]["price_changes"]
+        )
+        assert not cache.exists()  # nothing written
+
+
+class TestStaleness:
+    def test_staleness_on_shipped_baseline(self, cache, tmp_path):
+        report = refresh.staleness_report(
+            cache_path=cache, local_config_path=tmp_path / "none.json",
+        )
+        assert report["source"] == "shipped"
+        assert "cache_age_days" not in report
+
+    def test_staleness_reports_cache_age(self, cache, shipped_doc, tmp_path):
+        v1 = copy.deepcopy(shipped_doc)
+        v1["catalog_version"] = "1.1.0"
+        refresh.apply_refresh(v1, cache_path=cache)
+        report = refresh.staleness_report(
+            cache_path=cache, local_config_path=tmp_path / "none.json",
+        )
+        assert report["version"] == "1.1.0"
+        assert report["cache_age_days"] >= 0.0

--- a/plugins/jack-tar-cloud/tests/test_model_probe.py
+++ b/plugins/jack-tar-cloud/tests/test_model_probe.py
@@ -1,0 +1,144 @@
+"""Tests for live provider discovery (EPIC #125, issue #129).
+
+Classification and candidate logic are pure functions over injected probe
+results — no network. The probe functions themselves are tested only for
+their graceful-skip paths (no credentials / SDK missing); live listing is
+exercised manually via /verify.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from src.model_catalog import load_catalog  # noqa: E402
+from src import model_probe  # noqa: E402
+
+SHIPPED = PLUGIN_ROOT / "src" / "model-catalog.json"
+
+
+@pytest.fixture
+def catalog(tmp_path):
+    return load_catalog(
+        shipped_path=SHIPPED,
+        cache_path=tmp_path / "no-cache.json",
+        local_config_path=tmp_path / "no-local.json",
+    )
+
+
+def _verdict(entries, model_id):
+    return next(e for e in entries if e["model"] == model_id)
+
+
+class TestClassification:
+    def test_upstream_listed_model_is_verified(self, catalog):
+        probes = {"google": {"status": "ok", "models": {
+            "gemini-3.1-flash-image", "gemini-3-pro-image", "gemini-3.5-flash",
+        }}}
+        entries = model_probe.classify_entries(catalog, probes)
+        assert _verdict(entries, "gemini-3.1-flash-image")["verdict"] == "verified"
+
+    def test_unlisted_active_model_is_suspect_retired(self, catalog):
+        """The issue #123 failure mode, caught before a deck build 404s."""
+        probes = {"google": {"status": "ok", "models": {"gemini-3.5-flash"}}}
+        entries = model_probe.classify_entries(catalog, probes)
+        flash = _verdict(entries, "gemini-3.1-flash-image")
+        assert flash["verdict"] == "suspect_retired"
+        assert "refresh-models" in flash["note"]
+
+    def test_retired_and_unlisted_is_confirmed(self, catalog):
+        probes = {"google": {"status": "ok", "models": {"gemini-3.5-flash"}}}
+        entries = model_probe.classify_entries(catalog, probes)
+        assert _verdict(entries, "gemini-2.0-flash")["verdict"] == "confirmed_retired"
+
+    def test_retired_but_still_listed_flags_unretire(self, catalog):
+        probes = {"google": {"status": "ok", "models": {"gemini-2.0-flash"}}}
+        entries = model_probe.classify_entries(catalog, probes)
+        verdict = _verdict(entries, "gemini-2.0-flash")
+        assert verdict["verdict"] == "verified"
+        assert "un-retiring" in verdict["note"]
+
+    def test_alias_match_counts_as_verified(self, catalog):
+        """An API still listing only the old '-preview' alias verifies the entry."""
+        probes = {"google": {"status": "ok",
+                             "models": {"gemini-3.1-flash-image-preview"}}}
+        entries = model_probe.classify_entries(catalog, probes)
+        assert _verdict(entries, "gemini-3.1-flash-image")["verdict"] == "verified"
+
+    def test_ollama_tag_prefix_matches(self, catalog):
+        probes = {"ollama": {"status": "ok", "models": {"x/flux2-klein:9b"}}}
+        entries = model_probe.classify_entries(catalog, probes)
+        assert _verdict(entries, "x/flux2-klein")["verdict"] == "verified"
+        assert _verdict(entries, "x/z-image-turbo")["verdict"] == "suspect_retired"
+
+    def test_fal_recraft_always_unprobed(self, catalog):
+        entries = model_probe.classify_entries(catalog, {})
+        assert _verdict(entries, "fal-ai/flux-2-pro")["verdict"] == "unprobed"
+        assert _verdict(entries, "recraft-v4-svg")["verdict"] == "unprobed"
+
+    def test_skipped_probe_yields_unprobed_with_reason(self, catalog):
+        probes = {"google": {"status": "skipped", "reason": "no key"}}
+        entries = model_probe.classify_entries(catalog, probes)
+        verdict = _verdict(entries, "gemini-3-pro-image")
+        assert verdict["verdict"] == "unprobed"
+        assert verdict["note"] == "no key"
+
+
+class TestCandidates:
+    def test_unknown_relevant_model_is_candidate(self, catalog):
+        probes = {"google": {"status": "ok", "models": {
+            "gemini-3.1-flash-image",       # known
+            "gemini-4.0-flash-image",       # NEW — candidate
+            "text-embedding-004",           # irrelevant — filtered out
+        }}}
+        candidates = model_probe.find_new_candidates(catalog, probes)
+        assert candidates == {"google": ["gemini-4.0-flash-image"]}
+
+    def test_alias_covered_model_is_not_candidate(self, catalog):
+        probes = {"google": {"status": "ok",
+                             "models": {"gemini-3-pro-image-preview"}}}
+        assert model_probe.find_new_candidates(catalog, probes) == {}
+
+    def test_installed_tag_of_known_prefix_is_not_candidate(self, catalog):
+        probes = {"ollama": {"status": "ok",
+                             "models": {"x/flux2-klein:4b", "x/new-model:7b"}}}
+        candidates = model_probe.find_new_candidates(catalog, probes)
+        assert candidates == {"ollama": ["x/new-model:7b"]}
+
+    def test_skipped_probes_contribute_nothing(self, catalog):
+        probes = {"openai": {"status": "skipped", "reason": "no key"}}
+        assert model_probe.find_new_candidates(catalog, probes) == {}
+
+
+class TestGracefulSkips:
+    def test_google_skips_without_credentials(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+        result = model_probe.probe_google_models()
+        assert result["status"] == "skipped"
+        assert "credentials" in result["reason"]
+
+    def test_openai_skips_without_key(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        result = model_probe.probe_openai_models()
+        assert result["status"] == "skipped"
+
+    def test_ollama_skips_when_unreachable(self):
+        result = model_probe.probe_ollama_models(endpoint="http://localhost:1")
+        assert result["status"] == "skipped"
+
+
+class TestReport:
+    def test_report_shape_with_injected_probes(self, catalog):
+        probes = {
+            "google": {"status": "ok", "models": {"gemini-3.5-flash"}},
+            "openai": {"status": "skipped", "reason": "no key"},
+        }
+        report = model_probe.probe_report(catalog=catalog, probes=probes)
+        assert report["catalog_version"] == catalog.version
+        # probe summaries never leak the full model sets into the report
+        assert "models" not in report["probes"]["google"]
+        assert report["probes"]["openai"]["reason"] == "no key"
+        assert any(e["verdict"] == "suspect_retired" for e in report["entries"])

--- a/plugins/jack-tar-deckhand/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-deckhand/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-deckhand",
   "description": "Full presentation pipeline — brand, style, narrative, images, SmartArt, assembly, QA + academic-figure rendering (optional paperbanana CLI) + /iterate-slide single-slide critique-driven refinement + full_bleed image-is-the-slide strategy + creative vision renderer (#105) + creative_vision GA: per-slide cost surface, Creative Sprint phase, per-iteration operator gate, deck-level creative anchors (#113)",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-deckhand/skills/imagegen-bridge/SKILL.md
+++ b/plugins/jack-tar-deckhand/skills/imagegen-bridge/SKILL.md
@@ -384,14 +384,21 @@ OUTPUT_DIR=$(echo "$DISPATCH_JSON" | jq -r '.output_dir')
 # CLI-side budget guard ($0.25 cap per slide; jack-tar's own accounting
 # is the authoritative gate since paperbanana's pricing table is
 # incomplete — upstream #213).
+#
+# Model ids below come from the model catalog (EPIC #125,
+# docs/model-catalog.md): the VLM must hold the catalog's vlm_json role
+# (a NON-thinking model — thinking models break paperbanana's JSON
+# retriever, issues #122/#123), and the image model is the catalog's
+# image_gen default. If these ever fail with 404/timeout, run the
+# refresh-models skill and re-read the catalog rather than guessing ids.
 PB_OUTPUT=$(paperbanana generate \
   --input "$SRC_TMP" \
   --caption "$CAPTION" \
   --aspect-ratio "$ASPECT" \
   --iterations "$ITERS" \
-  --vlm-provider gemini --vlm-model gemini-2.5-flash \
+  --vlm-provider gemini --vlm-model gemini-3.5-flash \
   --image-provider google_imagen \
-  --image-model gemini-3.1-flash-image-preview \
+  --image-model gemini-3.1-flash-image \
   --output "$OUTPUT_DIR" \
   --budget 0.25 2>&1)
 
@@ -570,10 +577,10 @@ Pick the render skill based on the cascade tier:
 
 - `ollama` tier → dispatch `/jack-tar-ollama:image` with the approved prompt.
 - `flash_1k` / `flash_2k` / `flash_4k` tiers → dispatch `/jack-tar-cloud:image`
-  with `--provider google --model gemini-3.1-flash-image-preview` and the
+  with `--provider google --model gemini-3.1-flash-image` and the
   matching `--resolution` flag.
 - `pro_1k` / `pro_2k` / `pro_4k` tiers → dispatch `/jack-tar-cloud:image` with
-  `--provider google --model gemini-3-pro-image-preview` at the matching
+  `--provider google --model gemini-3-pro-image` at the matching
   `--resolution`.
 - `recraft_*` tiers → dispatch `/jack-tar-cloud:recraft-image` with the matching
   `--tier` and `--resolution` flags.
@@ -852,8 +859,8 @@ For `pragmatic_composition` slides, calculate the target aspect ratio from the s
 
 When provider is `google`, the `--model` parameter selects the tier:
 - Draft/budget: `--model imagen-4.0-fast-generate-001` ($0.02)
-- Standard production: `--model gemini-3.1-flash-image-preview` ($0.067)
-- Premium (text-heavy, complex): `--model gemini-3-pro-image-preview` ($0.134)
+- Standard production: `--model gemini-3.1-flash-image` ($0.067)
+- Premium (text-heavy, complex): `--model gemini-3-pro-image` ($0.134)
 
 The routing matrix and production-upgrade-plan already specify the correct model. Use the model from the plan entry directly — do NOT hardcode model names in the bridge.
 
@@ -950,9 +957,9 @@ For all other `raster_upscale` entries, execute the cross-tier refinement loop:
 
 **Phase 1 — Flash draft and refinement (up to 3 iterations)**
 
-1. Generate a Flash draft using `gemini-3.1-flash-image-preview` with the plan's `draft_prompt`:
+1. Generate a Flash draft using `gemini-3.1-flash-image` with the plan's `draft_prompt`:
    ```
-   /jack-tar-cloud:image "DRAFT_PROMPT" --provider google --model gemini-3.1-flash-image-preview --width WIDTH --height HEIGHT --output ./tmp/deck/images/slide-NN-hero-flash-v1.png
+   /jack-tar-cloud:image "DRAFT_PROMPT" --provider google --model gemini-3.1-flash-image --width WIDTH --height HEIGHT --output ./tmp/deck/images/slide-NN-hero-flash-v1.png
    ```
 
 2. Dispatch the `image-reviewer` agent on the Flash output. If verdict is `pass`, skip Phase 2 entirely — Flash quality is sufficient and no Pro spend is needed. Store the Flash image as the final output.
@@ -988,13 +995,13 @@ For all other `raster_upscale` entries, execute the cross-tier refinement loop:
 
 8. **Optional Flash 4K pre-test** (only when `slide.resolution == "4K"`) — before paying for Pro 4K ($0.240), do a Flash 4K validation render at $0.151:
    ```
-   /jack-tar-cloud:google-image "REFINED_PROMPT" --model gemini-3.1-flash-image-preview --resolution 4K --output ./tmp/deck/images/slide-NN-hero-flash4k.png
+   /jack-tar-cloud:google-image "REFINED_PROMPT" --model gemini-3.1-flash-image --resolution 4K --output ./tmp/deck/images/slide-NN-hero-flash4k.png
    ```
    Dispatch `image-reviewer`. If pass: stop, use Flash 4K as final. If refine: proceed to Pro 4K. (This pattern was validated by the resolution smoke test in #59 — Flash 4K caught prompt issues that 1K Flash missed because text rendering scales differently at 4K.)
 
 9. If Flash passes (on any iteration in Phase 1) and the slide opted into `"2K"` or `"4K"`, take the prompt that produced the passing Flash result and generate once with Pro at the requested tier:
    ```
-   /jack-tar-cloud:google-image "REFINED_PROMPT" --model gemini-3-pro-image-preview --resolution {slide.resolution} --output ./tmp/deck/images/slide-NN-hero.png
+   /jack-tar-cloud:google-image "REFINED_PROMPT" --model gemini-3-pro-image --resolution {slide.resolution} --output ./tmp/deck/images/slide-NN-hero.png
    ```
    For 1K slides (the default), keep the existing single-shot Pro 1K behaviour with `--resolution 1K`.
 

--- a/plugins/jack-tar-deckhand/skills/narrative-architect/SKILL.md
+++ b/plugins/jack-tar-deckhand/skills/narrative-architect/SKILL.md
@@ -208,7 +208,7 @@ For those slides, the `strategy_classifier.py` heuristic (paperbanana E1)
 will set `strategy: "academic_figure"` automatically in the StrategyMap,
 and the imagegen-bridge will dispatch to the **paperbanana** CLI via
 subprocess (`paperbanana generate --input ... --caption ... --image-model
-gemini-3.1-flash-image-preview ...`) for publication-grade rendering
+gemini-3.1-flash-image ...`) for publication-grade rendering
 when paperbanana is installed (falls back to cloud Flash 1K otherwise —
 see `/jack-tar-deckhand:verify` for live availability and install hints).
 

--- a/plugins/jack-tar-deckhand/src/budget_tracker.py
+++ b/plugins/jack-tar-deckhand/src/budget_tracker.py
@@ -12,23 +12,33 @@ Budget state is persisted to pipeline-state.json via deckcontext.
 
 from datetime import datetime, timezone
 
-# Cost constants per model and quality tier (USD)
+try:
+    from .model_catalog import get_catalog as _get_model_catalog
+except ImportError:  # pragma: no cover - direct-script execution path
+    from model_catalog import get_catalog as _get_model_catalog
+
+_catalog = _get_model_catalog()
+
+# Cost per router-facing model key (USD), derived from the model catalog
+# (EPIC #125). This table previously drifted from the cloud plugin's
+# pricing — it carried a fourth divergent FLUX-2-Pro figure ($0.050 flat)
+# and retired gpt-image-1-mini ids. Deriving from the catalog makes that
+# drift structurally impossible; the short keys stay because the router
+# and manifests use them.
 MODEL_COSTS = {
-    # OpenAI
-    'gpt-image-1-mini-low': 0.005,
-    'gpt-image-1-mini-medium': 0.007,
-    'gpt-image-1.5-low': 0.009,
-    'gpt-image-1.5-medium': 0.040,
-    'gpt-image-1.5-high': 0.133,
-    # Google
-    'imagen-4-fast': 0.020,
-    'imagen-4-standard': 0.040,
-    # FAL.ai
-    'flux-2-pro': 0.050,
-    'ideogram-3': 0.080,
-    # Recraft
-    'recraft-v4-svg': 0.040,
-    'recraft-v4-png': 0.080,
+    # OpenAI (1024x1024 reference size per quality tier)
+    'gpt-image-1.5-low': _catalog.cost('gpt-image-1.5', size='1024x1024', quality='low'),
+    'gpt-image-1.5-medium': _catalog.cost('gpt-image-1.5', size='1024x1024', quality='medium'),
+    'gpt-image-1.5-high': _catalog.cost('gpt-image-1.5', size='1024x1024', quality='high'),
+    # Google Imagen (1K; Developer-API backend as the conservative rate)
+    'imagen-4-fast': _catalog.cost('imagen-4-fast', resolution='1K', backend='developer'),
+    'imagen-4-standard': _catalog.cost('imagen-4-standard', resolution='1K', backend='developer'),
+    # FAL.ai — typical deck slide is 1920x1080 (~2.07 MP) on tiered pricing
+    'flux-2-pro': round(_catalog.cost('flux-2-pro', megapixels=2.0736), 3),
+    'ideogram-3': _catalog.cost('ideogram-3'),
+    # Recraft: svg = icon tier rate; png = raster standard 1K
+    'recraft-v4-svg': _catalog.cost('recraft-v4-svg', tier='standard'),
+    'recraft-v4-png': _catalog.cost('recraft-v4-standard', resolution='1K'),
 }
 
 # State thresholds

--- a/plugins/jack-tar-deckhand/src/creative_vision/cascade.py
+++ b/plugins/jack-tar-deckhand/src/creative_vision/cascade.py
@@ -2,17 +2,22 @@
 
 Implements §5 of the spec. Issue #105.
 
-Cost-table reconciliation (issue #113 AC6): the canonical pricing source is
-``plugins/jack-tar-cloud/src/generate_cloud_image.py``'s ``estimate_google_cost``
-and ``estimate_recraft_cost``. ``TIER_COSTS`` below is the cascade-tier-keyed
-projection of that pricing, and ``TIER_TO_PROVIDER_MODEL_RESOLUTION`` maps each
-cascade tier to the (provider, model, resolution) tuple that the cloud module
-uses. The cross-plugin reconciliation test in
-``plugins/integration_tests/test_cost_reconciliation.py`` asserts the two stay
-in sync — if the cloud table moves (Google drops pricing, Recraft changes a
-tier), the integration test fails and ``TIER_COSTS`` here is updated to match.
+Cost-table reconciliation (issue #113 AC6, superseded by EPIC #125): pricing
+comes from the shipped model catalog (``model-catalog.json`` via
+``model_catalog.py``) — the same source the cloud plugin's estimators read.
+``TIER_TO_PROVIDER_MODEL_RESOLUTION`` maps each cascade tier to the
+(provider, model, resolution) tuple, and ``TIER_COSTS`` is DERIVED from that
+mapping at import time, so the cascade can no longer disagree with the cloud
+module (the $0.193-vs-$0.134 Pro 2K drift that motivated AC6 is structurally
+impossible). ``plugins/integration_tests/test_cost_reconciliation.py`` remains
+as a regression net across the plugin boundary.
 """
 from __future__ import annotations
+
+try:
+    from ..model_catalog import get_catalog as _get_model_catalog
+except ImportError:  # pragma: no cover - direct-script execution path
+    from src.model_catalog import get_catalog as _get_model_catalog
 
 LADDER_DEFAULT: list[str] = [
     "ollama", "flash_1k", "flash_2k", "flash_4k",
@@ -30,35 +35,28 @@ LADDER_RECRAFT: list[str] = [
 # the two namespaces without coupling the modules at import time.
 TIER_TO_PROVIDER_MODEL_RESOLUTION: dict[str, tuple[str | None, str | None, str | None]] = {
     "ollama": (None, None, None),
-    "flash_1k": ("google", "gemini-3.1-flash-image-preview", "1K"),
-    "flash_2k": ("google", "gemini-3.1-flash-image-preview", "2K"),
-    "flash_4k": ("google", "gemini-3.1-flash-image-preview", "4K"),
-    "pro_1k": ("google", "gemini-3-pro-image-preview", "1K"),
-    "pro_2k": ("google", "gemini-3-pro-image-preview", "2K"),
-    "pro_4k": ("google", "gemini-3-pro-image-preview", "4K"),
+    "flash_1k": ("google", "gemini-3.1-flash-image", "1K"),
+    "flash_2k": ("google", "gemini-3.1-flash-image", "2K"),
+    "flash_4k": ("google", "gemini-3.1-flash-image", "4K"),
+    "pro_1k": ("google", "gemini-3-pro-image", "1K"),
+    "pro_2k": ("google", "gemini-3-pro-image", "2K"),
+    "pro_4k": ("google", "gemini-3-pro-image", "4K"),
     "recraft_standard_1k": ("recraft", "recraft-v4-standard", "1K"),
     "recraft_pro_2k": ("recraft", "recraft-v4-pro", "2K"),
     "recraft_pro_4k": ("recraft", "recraft-v4-pro", "4K"),
 }
 
-# Per-tier cost in USD. Mirrors the cloud module's pricing tables; the
-# reconciliation test pins them together. When updating, also update the
-# integration test's expected values OR update the cloud module if that is the
-# moved source of truth.
+# Per-tier cost in USD, derived from the model catalog through the tier
+# mapping above (EPIC #125). The recraft_pro_4k figure includes the
+# Creative-Upscale chain component, honouring RECRAFT_UPSCALE_COST_USD
+# at import time.
 TIER_COSTS: dict[str, float] = {
-    "ollama": 0.0,
-    "flash_1k": 0.067,
-    "flash_2k": 0.101,
-    "flash_4k": 0.151,
-    "pro_1k": 0.134,
-    # Issue #113 AC6: reconciled 2026-05-24. Google Nano Banana Pro 2K is
-    # priced identically to Pro 1K ($0.134); cascade previously had $0.193
-    # which produced inflated cost estimates at strategy approval.
-    "pro_2k": 0.134,
-    "pro_4k": 0.240,
-    "recraft_standard_1k": 0.04,
-    "recraft_pro_2k": 0.25,
-    "recraft_pro_4k": 0.50,
+    tier: (
+        0.0 if provider is None
+        else _get_model_catalog().cost(model, resolution=resolution)
+    )
+    for tier, (provider, model, resolution)
+    in TIER_TO_PROVIDER_MODEL_RESOLUTION.items()
 }
 
 DEFAULT_ITERATION_CAPS: dict[str, int] = {

--- a/plugins/jack-tar-deckhand/src/image_router.py
+++ b/plugins/jack-tar-deckhand/src/image_router.py
@@ -60,6 +60,64 @@ UpgradeDecision = namedtuple(
 )
 
 
+# --- Model catalog (EPIC #125) ---
+# Model facts (pricing, capability) come from the shipped model catalog;
+# the matrices below keep only the routing PREFERENCES (which model to try
+# first for which visual type) while every cost figure is derived.
+try:
+    from .model_catalog import get_catalog as _get_model_catalog
+except ImportError:  # pragma: no cover - direct-script execution path
+    from model_catalog import get_catalog as _get_model_catalog
+
+_MODEL_CATALOG = _get_model_catalog()
+
+# Approximate megapixels per resolution tier for FAL tiered pricing
+# (1K -> ~1MP preset; 2K -> 2048x2048).
+_RESOLUTION_MEGAPIXELS = {'1K': 1.0, '2K': 4.194304}
+
+# Router quality-tier suffixes on the OpenAI model alias -> API quality.
+_OPENAI_QUALITY_SUFFIXES = {'low': 'low', 'med': 'medium', 'high': 'high'}
+
+
+def _route_cost(skill, provider, model, resolution):
+    """Estimated USD cost for one generation by this routing target.
+
+    Derived from the model catalog so the matrices carry no price
+    literals. Local providers are free; icon-skill targets price at the
+    icon model's standard tier; OpenAI router aliases carry a quality
+    suffix; FAL tiered pricing converts the resolution tier to megapixels.
+    """
+    if provider in ('ollama', 'local'):
+        return 0.0
+    if skill == 'cloud-generate-icon':
+        return _MODEL_CATALOG.cost(
+            _MODEL_CATALOG.default_model('icon')['id'], tier='standard'
+        )
+    if provider == 'openai':
+        base, _, suffix = model.rpartition('-')
+        quality = _OPENAI_QUALITY_SUFFIXES.get(suffix)
+        if quality is None:
+            base, quality = model, 'medium'
+        return _MODEL_CATALOG.cost(base, size='1024x1024', quality=quality)
+    if provider == 'fal':
+        return round(
+            _MODEL_CATALOG.cost(
+                model, megapixels=_RESOLUTION_MEGAPIXELS.get(resolution, 1.0)
+            ),
+            3,
+        )
+    return _MODEL_CATALOG.cost(model, resolution=resolution)
+
+
+def _T(skill, provider, model, resolution='1K'):
+    """RoutingTarget with its cost derived from the model catalog."""
+    return RoutingTarget(
+        skill, provider, model,
+        _route_cost(skill, provider, model, resolution),
+        resolution,
+    )
+
+
 # --- Routing Matrix ---
 # Maps (visual_type, mode) -> list of RoutingTargets in priority order.
 # The first target whose provider is available is selected.
@@ -72,24 +130,24 @@ UpgradeDecision = namedtuple(
 # then Imagen Standard (budget fallback).
 ROUTING_MATRIX = {
     ('hero_image', 'draft'): [
-        RoutingTarget('ollama-image', 'ollama', 'x/z-image-turbo', 0.00),
-        RoutingTarget('cloud-generate-image', 'fal', 'flux-2-pro', 0.03),
-        RoutingTarget('cloud-generate-image', 'openai', 'gpt-image-1.5-low', 0.009),
+        _T('ollama-image', 'ollama', 'x/z-image-turbo'),
+        _T('cloud-generate-image', 'fal', 'flux-2-pro'),
+        _T('cloud-generate-image', 'openai', 'gpt-image-1.5-low'),
     ],
     ('hero_image', 'production'): [
-        RoutingTarget('cloud-generate-image', 'fal', 'flux-2-pro', 0.03),
-        RoutingTarget('cloud-generate-image', 'openai', 'gpt-image-1.5-med', 0.034),
-        RoutingTarget('cloud-generate-image', 'google', 'imagen-4-standard', 0.04),
-        RoutingTarget('ollama-image', 'ollama', 'x/z-image-turbo', 0.00),
+        _T('cloud-generate-image', 'fal', 'flux-2-pro'),
+        _T('cloud-generate-image', 'openai', 'gpt-image-1.5-med'),
+        _T('cloud-generate-image', 'google', 'imagen-4-standard'),
+        _T('ollama-image', 'ollama', 'x/z-image-turbo'),
     ],
     ('hero_image', 'production_2k'): [
-        RoutingTarget('cloud-generate-image', 'google', 'gemini-3.1-flash-image-preview', 0.101, '2K'),
-        RoutingTarget('cloud-generate-image', 'fal', 'fal-ai/flux-2-pro', 0.075, '2K'),
-        RoutingTarget('cloud-generate-image', 'google', 'imagen-4.0-generate-001', 0.04, '2K'),
+        _T('cloud-generate-image', 'google', 'gemini-3.1-flash-image', '2K'),
+        _T('cloud-generate-image', 'fal', 'fal-ai/flux-2-pro', '2K'),
+        _T('cloud-generate-image', 'google', 'imagen-4.0-generate-001', '2K'),
     ],
     ('hero_image', 'production_4k'): [
-        RoutingTarget('cloud-generate-image', 'google', 'gemini-3-pro-image-preview', 0.24, '4K'),
-        RoutingTarget('cloud-generate-image', 'google', 'gemini-3.1-flash-image-preview', 0.151, '4K'),
+        _T('cloud-generate-image', 'google', 'gemini-3-pro-image', '4K'),
+        _T('cloud-generate-image', 'google', 'gemini-3.1-flash-image', '4K'),
     ],
     # Brand-fidelity-exact rows — added by issue #61. The router upgrades
     # mode to 'production_brand_exact' / 'production_brand_exact_4k' when
@@ -97,43 +155,43 @@ ROUTING_MATRIX = {
     # compliance); fallbacks preserve existing photorealistic providers
     # when Recraft is unavailable.
     ('hero_image', 'production_brand_exact'): [
-        RoutingTarget('cloud-generate-image', 'recraft', 'recraft-v4-pro', 0.25, '2K'),
-        RoutingTarget('cloud-generate-image', 'fal', 'fal-ai/flux-2-pro', 0.075, '2K'),
+        _T('cloud-generate-image', 'recraft', 'recraft-v4-pro', '2K'),
+        _T('cloud-generate-image', 'fal', 'fal-ai/flux-2-pro', '2K'),
     ],
     ('hero_image', 'production_brand_exact_4k'): [
-        RoutingTarget('cloud-generate-image', 'recraft', 'recraft-v4-pro', 0.50, '4K'),
-        RoutingTarget('cloud-generate-image', 'google', 'gemini-3-pro-image-preview', 0.24, '4K'),
+        _T('cloud-generate-image', 'recraft', 'recraft-v4-pro', '4K'),
+        _T('cloud-generate-image', 'google', 'gemini-3-pro-image', '4K'),
     ],
     ('icon_set', 'draft'): [
-        RoutingTarget('cloud-generate-icon', 'recraft', 'recraft-v4-svg', 0.08),
-        RoutingTarget('cloud-generate-icon', 'fal', 'recraft-v4', 0.08),
+        _T('cloud-generate-icon', 'recraft', 'recraft-v4-svg'),
+        _T('cloud-generate-icon', 'fal', 'recraft-v4'),
     ],
     ('icon_set', 'production'): [
-        RoutingTarget('cloud-generate-icon', 'recraft', 'recraft-v4-svg', 0.08),
-        RoutingTarget('cloud-generate-icon', 'fal', 'recraft-v4', 0.08),
+        _T('cloud-generate-icon', 'recraft', 'recraft-v4-svg'),
+        _T('cloud-generate-icon', 'fal', 'recraft-v4'),
     ],
     ('pattern_background', 'draft'): [
-        RoutingTarget('ollama-pattern', 'ollama', 'x/z-image-turbo', 0.00),
-        RoutingTarget('cloud-generate-image', 'google', 'imagen-4-fast', 0.02),
-        RoutingTarget('cloud-generate-image', 'fal', 'flux-2-pro', 0.03),
+        _T('ollama-pattern', 'ollama', 'x/z-image-turbo'),
+        _T('cloud-generate-image', 'google', 'imagen-4-fast'),
+        _T('cloud-generate-image', 'fal', 'flux-2-pro'),
     ],
     ('pattern_background', 'production'): [
-        RoutingTarget('cloud-generate-image', 'google', 'imagen-4-fast', 0.02),
-        RoutingTarget('cloud-generate-image', 'fal', 'flux-2-pro', 0.03),
-        RoutingTarget('ollama-pattern', 'ollama', 'x/z-image-turbo', 0.00),
+        _T('cloud-generate-image', 'google', 'imagen-4-fast'),
+        _T('cloud-generate-image', 'fal', 'flux-2-pro'),
+        _T('ollama-pattern', 'ollama', 'x/z-image-turbo'),
     ],
     ('diagram', 'draft'): [
-        RoutingTarget('ollama-diagram', 'ollama', 'x/flux2-klein', 0.00),
+        _T('ollama-diagram', 'ollama', 'x/flux2-klein'),
     ],
     ('diagram', 'production'): [
-        RoutingTarget('cloud-generate-icon', 'recraft', 'recraft-v4-svg', 0.08),
-        RoutingTarget('ollama-diagram', 'ollama', 'x/flux2-klein', 0.00),
+        _T('cloud-generate-icon', 'recraft', 'recraft-v4-svg'),
+        _T('ollama-diagram', 'ollama', 'x/flux2-klein'),
     ],
     ('chart', 'draft'): [
-        RoutingTarget('render_chart', 'local', 'matplotlib', 0.00),
+        _T('render_chart', 'local', 'matplotlib'),
     ],
     ('chart', 'production'): [
-        RoutingTarget('render_chart', 'local', 'matplotlib', 0.00),
+        _T('render_chart', 'local', 'matplotlib'),
     ],
     ('none', 'draft'): [],
     ('none', 'production'): [],
@@ -142,28 +200,28 @@ ROUTING_MATRIX = {
 # Budget-degraded routing overrides
 BUDGET_DEGRADED_MATRIX = {
     ('hero_image', 'allow_with_caps'): [
-        RoutingTarget('cloud-generate-image', 'google', 'imagen-4-fast', 0.02),
-        RoutingTarget('cloud-generate-image', 'fal', 'flux-2-pro', 0.03),
-        RoutingTarget('ollama-image', 'ollama', 'x/z-image-turbo', 0.00),
+        _T('cloud-generate-image', 'google', 'imagen-4-fast'),
+        _T('cloud-generate-image', 'fal', 'flux-2-pro'),
+        _T('ollama-image', 'ollama', 'x/z-image-turbo'),
     ],
     ('hero_image', 'degrade'): [
-        RoutingTarget('ollama-image', 'ollama', 'x/z-image-turbo', 0.00),
+        _T('ollama-image', 'ollama', 'x/z-image-turbo'),
     ],
     ('icon_set', 'allow_with_caps'): [
-        RoutingTarget('cloud-generate-icon', 'recraft', 'recraft-v4-svg', 0.08),
+        _T('cloud-generate-icon', 'recraft', 'recraft-v4-svg'),
     ],
     ('icon_set', 'degrade'): [],  # No local alternative for SVG icons
     ('pattern_background', 'allow_with_caps'): [
-        RoutingTarget('ollama-pattern', 'ollama', 'x/z-image-turbo', 0.00),
+        _T('ollama-pattern', 'ollama', 'x/z-image-turbo'),
     ],
     ('pattern_background', 'degrade'): [
-        RoutingTarget('ollama-pattern', 'ollama', 'x/z-image-turbo', 0.00),
+        _T('ollama-pattern', 'ollama', 'x/z-image-turbo'),
     ],
     ('diagram', 'allow_with_caps'): [
-        RoutingTarget('ollama-diagram', 'ollama', 'x/flux2-klein', 0.00),
+        _T('ollama-diagram', 'ollama', 'x/flux2-klein'),
     ],
     ('diagram', 'degrade'): [
-        RoutingTarget('ollama-diagram', 'ollama', 'x/flux2-klein', 0.00),
+        _T('ollama-diagram', 'ollama', 'x/flux2-klein'),
     ],
 }
 
@@ -196,42 +254,25 @@ OPENAI_SUPPORTED_SIZES = {'1024x1024', '1536x1024', '1024x1536'}
 
 # Per-provider/model resolution capability for in-process pre-validation.
 #
-# Two kinds of entries:
-#   1. Canonical model IDs — must stay byte-identical to the cloud plugin's
-#      authoritative source. Cross-plugin drift detection in
-#      plugins/integration_tests/test_router_capability_drift.py asserts
-#      these match plugins/jack-tar-cloud/src/provider_discovery.py's
-#      _PROVIDER_MODEL_RESOLUTIONS for every model that appears in both.
-#   2. Router-internal aliases (gpt-image-1.5-low, imagen-4-fast,
-#      imagen-4-standard, flux-2-pro) used in ROUTING_MATRIX rows for
-#      readability. These translate to canonical IDs at dispatch time
-#      (see imagegen-bridge SKILL.md). Aliases have no cloud-plugin
-#      counterpart and are not subject to drift checking.
-#
-# Single source of truth at runtime is provider_discovery.discover_providers(),
-# which exposes the canonical capability via available_providers[provider]
-# ['models'][model]['supported_resolutions']. This static table is for
-# router-time decisions where reaching across plugin boundaries would
-# require a live cloud-plugin import.
-_PROVIDER_MODEL_RESOLUTIONS = {
-    ('openai', 'gpt-image-1.5'): ['1K'],
-    ('openai', 'gpt-image-1.5-low'): ['1K'],
-    ('openai', 'gpt-image-1.5-med'): ['1K'],
-    ('google', 'imagen-4-fast'): ['1K'],
-    ('google', 'imagen-4.0-fast-generate-001'): ['1K'],
-    ('google', 'imagen-4-standard'): ['1K', '2K'],
-    ('google', 'imagen-4.0-generate-001'): ['1K', '2K'],
-    ('google', 'imagen-4.0-ultra-generate-001'): ['1K', '2K'],
-    ('google', 'gemini-3.1-flash-image-preview'): ['512', '1K', '2K', '4K'],
-    ('google', 'gemini-3-pro-image-preview'): ['1K', '2K', '4K'],
-    ('fal', 'fal-ai/flux-2-pro'): ['1K', '2K'],
-    ('fal', 'flux-2-pro'): ['1K', '2K'],
-    ('fal', 'fal-ai/flux-2-klein'): ['1K'],
-    ('fal', 'fal-ai/ideogram/v3'): ['1K'],
-    # Recraft V4 raster (issue #61)
-    ('recraft', 'recraft-v4-standard'): ['1K'],
-    ('recraft', 'recraft-v4-pro'): ['2K', '4K'],
-}
+# Single source of truth is the model catalog (EPIC #125): canonical ids
+# AND aliases (retired '-preview' Gemini ids, router short names) key the
+# same capability, so this table can no longer drift from the cloud
+# plugin's — both derive from the same shipped model-catalog.json.
+_PROVIDER_MODEL_RESOLUTIONS = {}
+for _entry in _MODEL_CATALOG.entries(role='image_gen'):
+    _resolutions = list((_entry.get('capabilities') or {}).get('resolutions', []))
+    if not _resolutions or _entry['provider'] == 'ollama':
+        continue
+    for _name in [_entry['id'], *_entry.get('aliases', [])]:
+        _PROVIDER_MODEL_RESOLUTIONS[(_entry['provider'], _name)] = _resolutions
+
+# Router-internal quality-tier aliases (gpt-image-1.5-low/-med) have no
+# catalog counterpart — they translate to the canonical OpenAI id at
+# dispatch time (see imagegen-bridge SKILL.md) and share its capability.
+for _alias in ('gpt-image-1.5-low', 'gpt-image-1.5-med'):
+    _PROVIDER_MODEL_RESOLUTIONS[('openai', _alias)] = (
+        _PROVIDER_MODEL_RESOLUTIONS[('openai', 'gpt-image-1.5')]
+    )
 
 
 def _check_resolution_compatibility(provider, model, resolution):

--- a/plugins/jack-tar-deckhand/src/iterate_slide_dispatch.py
+++ b/plugins/jack-tar-deckhand/src/iterate_slide_dispatch.py
@@ -47,11 +47,19 @@ _RUN_DIR_PATTERN = re.compile(r"^run_\d{8}_\d{6}_[a-f0-9]+$")
 # the end of a successful run. We grep stdout for that.
 _OUTPUT_PATH_PATTERN = re.compile(r"Output(?:\s+saved)?(?:\s+to)?:\s+(\S+)")
 
-# Defaults tuned from the 2026-05-18 dogfood. Reviewable in one place.
+try:
+    from .model_catalog import get_catalog as _get_model_catalog
+except ImportError:  # pragma: no cover - direct-script execution path
+    from src.model_catalog import get_catalog as _get_model_catalog
+
+# Model defaults come from the catalog (EPIC #125). The vlm_json role
+# default is a NON-thinking model — gemini-2.5-flash's reasoning tokens
+# broke paperbanana's strict-JSON retriever with a ~17-minute timeout
+# (issues #122/#123); the catalog's role eligibility encodes that.
 _DEFAULT_VLM_PROVIDER = "gemini"
-_DEFAULT_VLM_MODEL = "gemini-2.5-flash"
+_DEFAULT_VLM_MODEL = _get_model_catalog().default_model("vlm_json")["id"]
 _DEFAULT_IMAGE_PROVIDER = "google_imagen"
-_DEFAULT_IMAGE_MODEL = "gemini-3.1-flash-image-preview"
+_DEFAULT_IMAGE_MODEL = _get_model_catalog().default_model("image_gen")["id"]
 _DEFAULT_BUDGET_USD = 0.25
 _DEFAULT_AUTO_MAX_ITERATIONS = 4
 _DEFAULT_ENUMERATE_ITERATIONS = 2

--- a/plugins/jack-tar-deckhand/src/model-catalog.json
+++ b/plugins/jack-tar-deckhand/src/model-catalog.json
@@ -26,7 +26,8 @@
         "verified": "2026-05-24",
         "estimate": false,
         "per_resolution": {"512": 0.045, "1K": 0.067, "2K": 0.101, "4K": 0.151},
-        "notes": "EPIC #58 pricing table; reconciled issue #113 AC6."
+        "token_rates": {"text_input_per_mtok": 0.5, "image_output_per_mtok": 60.0},
+        "notes": "EPIC #58 pricing table; reconciled issue #113 AC6. Token rates from ai.google.dev/gemini-api/docs/pricing (captured 2026-05-21)."
       },
       "sdk": {"api": "generate_content", "config_field": "image_size"},
       "notes": "Nano Banana Flash. The '-preview' suffixed id was deprecated upstream (issue #123, verified 2026-07-15); alias retained so existing manifests and callers resolve."
@@ -48,7 +49,8 @@
         "verified": "2026-05-24",
         "estimate": false,
         "per_resolution": {"1K": 0.134, "2K": 0.134, "4K": 0.24},
-        "notes": "Pro 2K priced identically to Pro 1K (issue #113 AC6 reconciliation)."
+        "token_rates": {"text_input_per_mtok": 2.0, "image_output_per_mtok": 120.0},
+        "notes": "Pro 2K priced identically to Pro 1K (issue #113 AC6 reconciliation). Token rates from ai.google.dev/gemini-api/docs/pricing (captured 2026-05-21)."
       },
       "sdk": {"api": "generate_content", "config_field": "image_size"},
       "notes": "Nano Banana Pro — best in-image text rendering. '-preview' id deprecated upstream (issue #123)."
@@ -149,7 +151,9 @@
           "1024x1536|low": 0.013,
           "1024x1536|medium": 0.051,
           "1024x1536|high": 0.2
-        }
+        },
+        "token_rates": {"input_per_mtok": 5.0, "output_per_mtok": 40.0},
+        "notes": "token_rates are UNVERIFIED_ESTIMATE — all OpenAI pricing URLs 403/404'd during the 2026-05-21 spike; community-cited placeholders pending dashboard verification (see docs/spikes/2026-05-21-actual-token-pricing/)."
       },
       "sdk": {"api": "openai_images"}
     },

--- a/plugins/jack-tar-deckhand/src/model-catalog.json
+++ b/plugins/jack-tar-deckhand/src/model-catalog.json
@@ -1,0 +1,366 @@
+{
+  "catalog_version": "1.0.0",
+  "min_loader_version": 1,
+  "updated": "2026-07-15",
+  "role_defaults": {
+    "image_gen": "gemini-3.1-flash-image",
+    "vlm_json": "gemini-3.5-flash",
+    "icon": "recraft-v4-svg",
+    "local_draft": ["x/flux2-klein", "x/z-image-turbo"]
+  },
+  "models": [
+    {
+      "id": "gemini-3.1-flash-image",
+      "provider": "google",
+      "aliases": ["gemini-3.1-flash-image-preview"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["512", "1K", "2K", "4K"],
+        "text_rendering": "good"
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-24",
+        "estimate": false,
+        "per_resolution": {"512": 0.045, "1K": 0.067, "2K": 0.101, "4K": 0.151},
+        "notes": "EPIC #58 pricing table; reconciled issue #113 AC6."
+      },
+      "sdk": {"api": "generate_content", "config_field": "image_size"},
+      "notes": "Nano Banana Flash. The '-preview' suffixed id was deprecated upstream (issue #123, verified 2026-07-15); alias retained so existing manifests and callers resolve."
+    },
+    {
+      "id": "gemini-3-pro-image",
+      "provider": "google",
+      "aliases": ["gemini-3-pro-image-preview"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K", "2K", "4K"],
+        "text_rendering": "excellent"
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-24",
+        "estimate": false,
+        "per_resolution": {"1K": 0.134, "2K": 0.134, "4K": 0.24},
+        "notes": "Pro 2K priced identically to Pro 1K (issue #113 AC6 reconciliation)."
+      },
+      "sdk": {"api": "generate_content", "config_field": "image_size"},
+      "notes": "Nano Banana Pro — best in-image text rendering. '-preview' id deprecated upstream (issue #123)."
+    },
+    {
+      "id": "imagen-4.0-fast-generate-001",
+      "provider": "google",
+      "aliases": ["imagen-4-fast"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["fixed_resolution", "no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K"]
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "backends": {
+          "vertex": {"1K": 0.02},
+          "developer": {"1K": 0.02}
+        }
+      },
+      "sdk": {"api": "generate_images"},
+      "notes": "Fixed native resolution — rejects image_size/sampleImageSize with 400 INVALID_ARGUMENT (issue #74). 'imagen-4-fast' is the router-side alias."
+    },
+    {
+      "id": "imagen-4.0-generate-001",
+      "provider": "google",
+      "aliases": ["imagen-4", "imagen-4-standard"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K", "2K"],
+        "prompt_budget": {"max_words": 40, "style": "concise"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "backends": {
+          "vertex": {"1K": 0.04, "2K": 0.04},
+          "developer": {"1K": 0.04, "2K": 0.101}
+        },
+        "notes": "Dual pricing: Vertex (GOOGLE_APPLICATION_CREDENTIALS) flat per-image; Gemini Developer API (GOOGLE_API_KEY only) token-based, 2K dearer."
+      },
+      "sdk": {"api": "generate_images", "config_field": "image_size"}
+    },
+    {
+      "id": "imagen-4.0-ultra-generate-001",
+      "provider": "google",
+      "aliases": ["imagen-4-ultra"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K", "2K"]
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "backends": {
+          "vertex": {"1K": 0.06, "2K": 0.06},
+          "developer": {"1K": 0.06, "2K": 0.101}
+        },
+        "notes": "Developer-API 2K treated as token-based like Standard."
+      },
+      "sdk": {"api": "generate_images", "config_field": "image_size"}
+    },
+    {
+      "id": "gpt-image-1.5",
+      "provider": "openai",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["no_negative_prompt"],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "prompt_budget": {"max_words": 500, "style": "natural_language"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "per_size_quality": {
+          "1024x1024|low": 0.009,
+          "1024x1024|medium": 0.034,
+          "1024x1024|high": 0.133,
+          "1536x1024|low": 0.013,
+          "1536x1024|medium": 0.051,
+          "1536x1024|high": 0.2,
+          "1024x1536|low": 0.013,
+          "1024x1536|medium": 0.051,
+          "1024x1536|high": 0.2
+        }
+      },
+      "sdk": {"api": "openai_images"}
+    },
+    {
+      "id": "fal-ai/flux-2-pro",
+      "provider": "fal",
+      "aliases": ["flux-2-pro"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K", "2K"],
+        "prompt_budget": {"max_words": 60, "style": "photography"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "tiered_megapixel": {"first_mp": 0.03, "per_extra_mp": 0.015},
+        "notes": "~$0.045 for 1920x1080. budget_tracker previously carried a divergent $0.050 flat figure — the tiered rate here is canonical (EPIC #125)."
+      },
+      "sdk": {"api": "fal_subscribe"},
+      "notes": "Caps at 2048x2048."
+    },
+    {
+      "id": "fal-ai/flux-2-klein",
+      "provider": "fal",
+      "aliases": ["flux-2-klein"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"]
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "flat": 0.014
+      },
+      "sdk": {"api": "fal_subscribe"}
+    },
+    {
+      "id": "fal-ai/ideogram/v3",
+      "provider": "fal",
+      "aliases": ["ideogram-3"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "text_rendering": "excellent",
+        "prompt_budget": {"max_words": 80, "style": "typography"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": true,
+        "flat": 0.06,
+        "notes": "Published range $0.030-$0.090; midpoint used."
+      },
+      "sdk": {"api": "fal_subscribe"}
+    },
+    {
+      "id": "recraft-v4-standard",
+      "provider": "recraft",
+      "aliases": ["recraft-v4"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "brand_hex_fidelity": true,
+        "prompt_budget": {"max_words": 100, "style": "design_centric"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-07",
+        "estimate": false,
+        "per_resolution": {"1K": 0.04},
+        "notes": "Verified via fal.ai/models/fal-ai/recraft/v4/*."
+      },
+      "sdk": {"api": "recraft_rest", "endpoint": "external.api.recraft.ai/v1"},
+      "notes": "Router-side id; dispatch picks the actual endpoint by tier+resolution (issue #61)."
+    },
+    {
+      "id": "recraft-v4-pro",
+      "provider": "recraft",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen"],
+      "quirks": ["upscale_chain_4k"],
+      "capabilities": {
+        "resolutions": ["2K", "4K"],
+        "brand_hex_fidelity": true
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-07",
+        "estimate": true,
+        "per_resolution": {"2K": 0.25, "4K": 0.5},
+        "env_override": {"upscale": "RECRAFT_UPSCALE_COST_USD"},
+        "notes": "4K = 2K generation ($0.25) + Creative Upscale ($0.25 FAL-parity assumption — direct-API upscale price not published; env override honoured when positive)."
+      },
+      "sdk": {"api": "recraft_rest", "endpoint": "external.api.recraft.ai/v1"}
+    },
+    {
+      "id": "recraft-v4-svg",
+      "provider": "recraft",
+      "aliases": ["recraftv4"],
+      "status": "active",
+      "replacement": null,
+      "roles": ["icon"],
+      "quirks": [],
+      "capabilities": {
+        "vector": true,
+        "brand_hex_fidelity": true
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-05-03",
+        "estimate": false,
+        "per_tier": {"standard": 0.08, "pro": 0.3},
+        "notes": "Same rates via direct API and the FAL route (fal-ai/recraft/v4/text-to-vector). budget_tracker previously carried divergent $0.04/$0.08 svg/png figures — per_tier here is canonical (EPIC #125)."
+      },
+      "sdk": {"api": "recraft_rest", "endpoint": "fal-ai/recraft/v4/text-to-vector"}
+    },
+    {
+      "id": "x/flux2-klein",
+      "provider": "ollama",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen", "local_draft"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "timeout_seconds": 600,
+        "prompt_budget": {"max_words": 200, "style": "detailed_spatial"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-07-10",
+        "estimate": false,
+        "flat": 0.0
+      },
+      "sdk": {"api": "ollama_generate"},
+      "notes": "Tag-prefix entry: exact installed tag (e.g. x/flux2-klein:9b) resolves at runtime via /api/tags — never hardcode tags. Preferred local model for academic figures (F16 audit: Klein 9b at 8/9 on the deck-schema brief)."
+    },
+    {
+      "id": "x/z-image-turbo",
+      "provider": "ollama",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["image_gen", "local_draft"],
+      "quirks": [],
+      "capabilities": {
+        "resolutions": ["1K"],
+        "timeout_seconds": 120,
+        "prompt_budget": {"max_words": 50, "style": "concise_camera"}
+      },
+      "pricing": {
+        "currency": "USD",
+        "verified": "2026-07-10",
+        "estimate": false,
+        "flat": 0.0
+      },
+      "sdk": {"api": "ollama_generate"},
+      "notes": "Fast local draft fallback when flux2-klein is not pulled."
+    },
+    {
+      "id": "gemini-3.5-flash",
+      "provider": "google",
+      "aliases": [],
+      "status": "active",
+      "replacement": null,
+      "roles": ["vlm", "vlm_json"],
+      "quirks": [],
+      "capabilities": {},
+      "sdk": {"api": "generate_content"},
+      "notes": "Verified 2026-07-15 (issue #123): non-thinking for retriever/planning steps, clean JSON output for paperbanana's parser, publication-quality academic figures in 2-3 iterations at ~$0.02/diagram."
+    },
+    {
+      "id": "gemini-2.5-flash",
+      "provider": "google",
+      "aliases": [],
+      "status": "deprecated",
+      "replacement": "gemini-3.5-flash",
+      "roles": ["vlm"],
+      "quirks": ["thinking"],
+      "capabilities": {},
+      "sdk": {"api": "generate_content"},
+      "notes": "Thinking model — reasoning tokens break strict-JSON parsers (paperbanana retriever loops to ~17min timeout, issues #122/#123). NOT eligible for the vlm_json role. Deprecated as a jack-tar default in favour of gemini-3.5-flash."
+    },
+    {
+      "id": "gemini-2.0-flash",
+      "provider": "google",
+      "aliases": [],
+      "status": "retired",
+      "replacement": "gemini-3.5-flash",
+      "roles": ["vlm", "vlm_json"],
+      "quirks": [],
+      "capabilities": {},
+      "sdk": {"api": "generate_content"},
+      "notes": "Retired upstream — 404 NOT_FOUND 'This model is no longer available' (verified 2026-07-15, issue #123)."
+    }
+  ]
+}

--- a/plugins/jack-tar-deckhand/src/model_catalog.py
+++ b/plugins/jack-tar-deckhand/src/model_catalog.py
@@ -1,0 +1,501 @@
+"""Model catalog loader — single source of truth for AI model identity,
+capability, and pricing (EPIC #125).
+
+Model IDs, aliases, retirement pointers, resolution capability, and cost
+tables live in ``model-catalog.json``, NOT in code. This loader merges three
+layers, lowest precedence first:
+
+1. **Shipped baseline** — the ``model-catalog.json`` vendored next to this
+   module (or the repo-level ``model-catalog/`` directory in development).
+2. **Cached remote** — ``~/.jack-tar/model-catalog.json``, written by the
+   refresh-models skill (issue #128). Replaces the baseline wholesale when
+   present, valid, and loader-compatible; a bad cache falls back to shipped.
+3. **Local overrides** — the ``model_catalog`` key in the project's
+   ``local-config.json`` (gitignored). Entries merge per-model by id;
+   ``role_defaults`` merge per-key.
+
+Stdlib-only. Schema-level validation lives in
+``model-catalog/model-catalog.schema.json`` (enforced by tests/CI); this
+module performs structural validation sufficient to reject a broken cache
+at runtime without a jsonschema dependency.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Bump when the loader's expectations of the catalog shape change.
+#: A catalog whose ``min_loader_version`` exceeds this is rejected.
+LOADER_VERSION = 1
+
+CATALOG_FILENAME = "model-catalog.json"
+
+#: Env var pointing at an explicit catalog file (highest-priority baseline).
+CATALOG_PATH_ENV = "JACK_TAR_MODEL_CATALOG"
+
+#: Env var overriding the cached-remote location.
+CATALOG_CACHE_ENV = "JACK_TAR_CATALOG_CACHE"
+
+_DEFAULT_CACHE_PATH = Path.home() / ".jack-tar" / CATALOG_FILENAME
+
+_ENTRY_REQUIRED_FIELDS = ("id", "provider", "status", "roles")
+_VALID_STATUSES = frozenset({"active", "deprecated", "retired"})
+_RESOLUTION_ALIASES = {"512": "512", "1K": "1K", "2K": "2K", "4K": "4K"}
+
+
+class CatalogError(Exception):
+    """Catalog missing, unparseable, or structurally invalid."""
+
+
+class UnknownModelError(KeyError):
+    """No catalog entry (id or alias) matches the requested model."""
+
+
+class PricingError(ValueError):
+    """The entry has no price for the requested parameters."""
+
+
+def _normalise_resolution(resolution):
+    key = str(resolution).strip().upper()
+    if key in _RESOLUTION_ALIASES:
+        return _RESOLUTION_ALIASES[key]
+    raise PricingError(
+        f"resolution={resolution!r} not recognised. "
+        f"Valid values: {sorted(_RESOLUTION_ALIASES)}"
+    )
+
+
+def validate_catalog(doc):
+    """Structurally validate a catalog document. Raises CatalogError.
+
+    This is the runtime gate (cheap, stdlib-only). Full JSON-Schema
+    validation runs in the test suite against model-catalog.schema.json.
+    """
+    if not isinstance(doc, dict):
+        raise CatalogError("catalog root must be an object")
+    for key in ("catalog_version", "min_loader_version", "updated", "models"):
+        if key not in doc:
+            raise CatalogError(f"catalog missing required key: {key}")
+    min_loader = doc["min_loader_version"]
+    if not isinstance(min_loader, int) or min_loader < 1:
+        raise CatalogError("min_loader_version must be a positive integer")
+    if min_loader > LOADER_VERSION:
+        raise CatalogError(
+            f"catalog requires loader version >= {min_loader}; "
+            f"this loader is version {LOADER_VERSION} — update the plugin"
+        )
+    models = doc["models"]
+    if not isinstance(models, list) or not models:
+        raise CatalogError("models must be a non-empty list")
+
+    seen = {}
+    for entry in models:
+        if not isinstance(entry, dict):
+            raise CatalogError("every model entry must be an object")
+        for field in _ENTRY_REQUIRED_FIELDS:
+            if field not in entry:
+                raise CatalogError(
+                    f"model entry {entry.get('id', '<no id>')!r} missing "
+                    f"required field: {field}"
+                )
+        status = entry["status"]
+        if status not in _VALID_STATUSES:
+            raise CatalogError(
+                f"model {entry['id']!r} has invalid status {status!r}"
+            )
+        if status == "retired" and not entry.get("replacement"):
+            raise CatalogError(
+                f"retired model {entry['id']!r} must name a replacement"
+            )
+        for name in [entry["id"], *entry.get("aliases", [])]:
+            if name in seen:
+                raise CatalogError(
+                    f"duplicate model id/alias {name!r} "
+                    f"(in {entry['id']!r} and {seen[name]!r})"
+                )
+            seen[name] = entry["id"]
+
+    # Replacements and role defaults must resolve to real ids/aliases.
+    for entry in models:
+        replacement = entry.get("replacement")
+        if replacement and replacement not in seen:
+            raise CatalogError(
+                f"model {entry['id']!r} names unknown replacement "
+                f"{replacement!r}"
+            )
+    for role, value in (doc.get("role_defaults") or {}).items():
+        ids = [value] if isinstance(value, str) else list(value)
+        for model_id in ids:
+            if model_id not in seen:
+                raise CatalogError(
+                    f"role_defaults[{role!r}] names unknown model {model_id!r}"
+                )
+
+
+def _read_json(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _find_shipped_catalog(shipped_path=None):
+    """Locate the shipped baseline catalog.
+
+    Search order: explicit arg -> JACK_TAR_MODEL_CATALOG env var -> file
+    next to this module (vendored plugin layout) -> repo-level
+    model-catalog/ directory walking up from this module (dev layout).
+    """
+    if shipped_path:
+        return Path(shipped_path)
+    env_path = os.environ.get(CATALOG_PATH_ENV)
+    if env_path:
+        return Path(env_path)
+    module_dir = Path(__file__).resolve().parent
+    candidate = module_dir / CATALOG_FILENAME
+    if candidate.exists():
+        return candidate
+    for ancestor in module_dir.parents[:3]:
+        candidate = ancestor / "model-catalog" / CATALOG_FILENAME
+        if candidate.exists():
+            return candidate
+    raise CatalogError(
+        f"shipped {CATALOG_FILENAME} not found next to {module_dir} "
+        f"or in an ancestor model-catalog/ directory"
+    )
+
+
+def _load_cached_remote(cache_path=None):
+    """Return (doc, path) for a valid cached remote catalog, else None.
+
+    A missing cache is normal (install has never refreshed). An invalid
+    or loader-incompatible cache logs a warning and is ignored — the
+    shipped baseline always keeps the pipeline running.
+    """
+    path = Path(
+        cache_path
+        or os.environ.get(CATALOG_CACHE_ENV)
+        or _DEFAULT_CACHE_PATH
+    )
+    if not path.exists():
+        return None
+    try:
+        doc = _read_json(path)
+        validate_catalog(doc)
+        return doc, path
+    except (OSError, json.JSONDecodeError, CatalogError) as exc:
+        logger.warning(
+            "ignoring invalid cached model catalog at %s: %s "
+            "(falling back to shipped baseline)", path, exc,
+        )
+        return None
+
+
+def _apply_local_overrides(doc, local_config_path):
+    """Merge local-config.json's ``model_catalog`` key into the catalog.
+
+    ``models`` entries merge per-model by id (shallow field update; unknown
+    ids append as new entries). ``role_defaults`` merge per-key. The merged
+    document is re-validated so a broken override fails loudly — local
+    overrides are operator-authored and should not degrade silently.
+    """
+    path = Path(local_config_path) if local_config_path else Path("local-config.json")
+    if not path.exists():
+        return doc, False
+    try:
+        local = _read_json(path)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("ignoring unreadable local-config.json: %s", exc)
+        return doc, False
+    overrides = local.get("model_catalog")
+    if not isinstance(overrides, dict):
+        return doc, False
+
+    merged = copy.deepcopy(doc)
+    by_id = {entry["id"]: entry for entry in merged["models"]}
+    for patch in overrides.get("models", []):
+        target = by_id.get(patch.get("id"))
+        if target is not None:
+            target.update(copy.deepcopy(patch))
+        else:
+            merged["models"].append(copy.deepcopy(patch))
+    if "role_defaults" in overrides:
+        merged.setdefault("role_defaults", {}).update(overrides["role_defaults"])
+    validate_catalog(merged)
+    return merged, True
+
+
+class ModelCatalog:
+    """Immutable view over a validated catalog document."""
+
+    def __init__(self, doc, source="shipped"):
+        self._doc = doc
+        self.source = source
+        self._by_name = {}
+        for entry in doc["models"]:
+            self._by_name[entry["id"]] = entry
+            for alias in entry.get("aliases", []):
+                self._by_name[alias] = entry
+
+    @property
+    def version(self):
+        return self._doc["catalog_version"]
+
+    @property
+    def updated(self):
+        return self._doc["updated"]
+
+    def ids(self):
+        return [entry["id"] for entry in self._doc["models"]]
+
+    def get(self, id_or_alias, follow_replacement=True):
+        """Return a copy of the entry for a model id or alias.
+
+        Retired entries resolve to their replacement when
+        ``follow_replacement`` (the substitution is logged and recorded in
+        the returned dict's ``resolved_from``). Deprecated entries return
+        themselves with a warning. Unknown names raise UnknownModelError.
+        """
+        entry = self._by_name.get(id_or_alias)
+        if entry is None:
+            raise UnknownModelError(
+                f"model {id_or_alias!r} not in catalog "
+                f"(version {self.version}); known ids: {self.ids()}"
+            )
+        resolved_from = None
+        if id_or_alias != entry["id"]:
+            resolved_from = id_or_alias
+        hops = 0
+        while follow_replacement and entry["status"] == "retired":
+            replacement = entry["replacement"]
+            logger.info(
+                "model %s is retired — substituting %s (catalog %s)",
+                entry["id"], replacement, self.version,
+            )
+            resolved_from = resolved_from or entry["id"]
+            entry = self._by_name[replacement]
+            hops += 1
+            if hops > len(self._doc["models"]):
+                raise CatalogError(
+                    f"replacement cycle detected at {entry['id']!r}"
+                )
+        if entry["status"] == "deprecated":
+            logger.warning(
+                "model %s is deprecated%s", entry["id"],
+                f" — prefer {entry['replacement']}" if entry.get("replacement") else "",
+            )
+        result = copy.deepcopy(entry)
+        if resolved_from:
+            result["resolved_from"] = resolved_from
+        return result
+
+    def entries(self, role=None, provider=None, status="active"):
+        """Return copies of entries filtered by role/provider/status.
+
+        ``status=None`` disables the status filter.
+        """
+        out = []
+        for entry in self._doc["models"]:
+            if status is not None and entry["status"] != status:
+                continue
+            if role is not None and role not in entry["roles"]:
+                continue
+            if provider is not None and entry["provider"] != provider:
+                continue
+            out.append(copy.deepcopy(entry))
+        return out
+
+    def role_default(self, role):
+        """Return the raw role_defaults value: a model id or preference list."""
+        defaults = self._doc.get("role_defaults") or {}
+        if role not in defaults:
+            raise UnknownModelError(
+                f"no role_default for {role!r}; defined roles: "
+                f"{sorted(defaults)}"
+            )
+        return copy.deepcopy(defaults[role])
+
+    def default_model(self, role):
+        """Return the resolved entry for a role's default.
+
+        For preference-list defaults (e.g. local_draft) the first entry
+        wins — callers that can probe availability should use
+        ``role_default`` and filter the list themselves.
+        """
+        value = self.role_default(role)
+        model_id = value if isinstance(value, str) else value[0]
+        return self.get(model_id)
+
+    def resolutions(self, id_or_alias):
+        entry = self.get(id_or_alias)
+        return list((entry.get("capabilities") or {}).get("resolutions", []))
+
+    def supports(self, id_or_alias, resolution):
+        return _normalise_resolution(resolution) in self.resolutions(id_or_alias)
+
+    def has_quirk(self, id_or_alias, quirk):
+        return quirk in self.get(id_or_alias).get("quirks", [])
+
+    def cost(self, id_or_alias, resolution=None, backend=None, size=None,
+             quality=None, tier=None, megapixels=None):
+        """Return the USD cost for one generation with the given parameters.
+
+        Dispatches across the pricing shapes:
+          flat                     -> no parameters needed
+          per_resolution           -> ``resolution``
+          backends                 -> ``resolution`` + ``backend`` (Google
+                                      Imagen: 'vertex' when
+                                      GOOGLE_APPLICATION_CREDENTIALS is set,
+                                      else 'developer' — auto-detected when
+                                      backend is None)
+          per_size_quality         -> ``size`` + ``quality`` (OpenAI)
+          per_tier                 -> ``tier`` (icons)
+          tiered_megapixel         -> ``megapixels`` (FAL FLUX 2 Pro)
+
+        The upscale_chain_4k quirk (Recraft Pro) applies the documented
+        env override to the upscale component of the 4K chain price.
+        """
+        entry = self.get(id_or_alias)
+        pricing = entry.get("pricing")
+        if pricing is None:
+            raise PricingError(
+                f"model {entry['id']!r} has no pricing data in the catalog"
+            )
+
+        if "flat" in pricing and resolution is None and size is None \
+                and tier is None and megapixels is None:
+            return pricing["flat"]
+
+        if "per_resolution" in pricing and resolution is not None:
+            res = _normalise_resolution(resolution)
+            table = pricing["per_resolution"]
+            if res not in table:
+                raise PricingError(
+                    f"model {entry['id']!r} has no {res} price; "
+                    f"priced resolutions: {sorted(table)}"
+                )
+            if res == "4K" and "upscale_chain_4k" in entry.get("quirks", []):
+                return self._chained_4k_cost(entry, table, pricing)
+            return table[res]
+
+        if "backends" in pricing and resolution is not None:
+            res = _normalise_resolution(resolution)
+            if backend is None:
+                backend = (
+                    "vertex"
+                    if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+                    else "developer"
+                )
+            table = pricing["backends"].get(backend)
+            if table is None:
+                raise PricingError(
+                    f"model {entry['id']!r} has no backend {backend!r}; "
+                    f"priced backends: {sorted(pricing['backends'])}"
+                )
+            if res not in table:
+                raise PricingError(
+                    f"model {entry['id']!r} has no {res} price on "
+                    f"backend {backend!r}; priced: {sorted(table)}"
+                )
+            return table[res]
+
+        if "per_size_quality" in pricing and size is not None:
+            key = f"{size}|{quality}"
+            table = pricing["per_size_quality"]
+            if key not in table:
+                raise PricingError(
+                    f"model {entry['id']!r} has no price for "
+                    f"size/quality {key!r}; priced: {sorted(table)}"
+                )
+            return table[key]
+
+        if "per_tier" in pricing and tier is not None:
+            table = pricing["per_tier"]
+            if tier not in table:
+                raise PricingError(
+                    f"model {entry['id']!r} has no tier {tier!r}; "
+                    f"priced tiers: {sorted(table)}"
+                )
+            return table[tier]
+
+        if "tiered_megapixel" in pricing and megapixels is not None:
+            rates = pricing["tiered_megapixel"]
+            extra = max(0.0, float(megapixels) - 1.0)
+            return rates["first_mp"] + extra * rates["per_extra_mp"]
+
+        if "flat" in pricing:
+            return pricing["flat"]
+
+        raise PricingError(
+            f"model {entry['id']!r}: no pricing shape matches the given "
+            f"parameters (resolution={resolution!r}, size={size!r}, "
+            f"quality={quality!r}, tier={tier!r}, megapixels={megapixels!r}); "
+            f"available shapes: {sorted(set(pricing) - {'currency', 'verified', 'estimate', 'notes', 'env_override'})}"
+        )
+
+    @staticmethod
+    def _chained_4k_cost(entry, table, pricing):
+        """4K = 2K generation + upscale; env override adjusts the upscale part.
+
+        Override is only honoured when it parses to a positive float —
+        guards against accidentally pricing a paid API at $0 or negative
+        (mirrors the historical RECRAFT_UPSCALE_COST_USD behaviour).
+        """
+        base = table.get("2K", 0.0)
+        upscale = table["4K"] - base
+        env_var = (pricing.get("env_override") or {}).get("upscale")
+        if env_var:
+            raw = os.environ.get(env_var)
+            if raw:
+                try:
+                    value = float(raw)
+                    if value > 0:
+                        upscale = value
+                except ValueError:
+                    pass
+        return base + upscale
+
+
+def load_catalog(shipped_path=None, cache_path=None, local_config_path=None):
+    """Load the catalog with full precedence merging. Returns ModelCatalog.
+
+    Precedence (low to high): shipped baseline -> cached remote ->
+    local-config.json ``model_catalog`` overrides. See module docstring.
+    """
+    source = "shipped"
+    cached = _load_cached_remote(cache_path)
+    if cached is not None:
+        doc, path = cached
+        source = f"cached:{path}"
+    else:
+        path = _find_shipped_catalog(shipped_path)
+        try:
+            doc = _read_json(path)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise CatalogError(f"cannot read shipped catalog at {path}: {exc}")
+        validate_catalog(doc)
+
+    doc, overridden = _apply_local_overrides(doc, local_config_path)
+    if overridden:
+        source += "+local"
+    catalog = ModelCatalog(doc, source=source)
+    logger.debug(
+        "model catalog loaded: version=%s source=%s models=%d",
+        catalog.version, source, len(doc["models"]),
+    )
+    return catalog
+
+
+_catalog_singleton = None
+
+
+def get_catalog(reload=False):
+    """Process-wide cached catalog. ``reload=True`` re-reads from disk."""
+    global _catalog_singleton
+    if _catalog_singleton is None or reload:
+        _catalog_singleton = load_catalog()
+    return _catalog_singleton

--- a/plugins/jack-tar-deckhand/src/model_catalog.py
+++ b/plugins/jack-tar-deckhand/src/model_catalog.py
@@ -242,6 +242,11 @@ class ModelCatalog:
                 self._by_name[alias] = entry
 
     @property
+    def doc(self):
+        """The raw validated catalog document (read-only by convention)."""
+        return self._doc
+
+    @property
     def version(self):
         return self._doc["catalog_version"]
 

--- a/plugins/jack-tar-deckhand/src/paperbanana_dispatch.py
+++ b/plugins/jack-tar-deckhand/src/paperbanana_dispatch.py
@@ -63,12 +63,20 @@ _RUN_ID_PATTERN = re.compile(r"/(run_\d{8}_\d{6}_[a-f0-9]+)/")
 OLLAMA_BASE_URL = "http://localhost:11434"
 
 # Image-capable Ollama model families, in quality-priority order for
-# academic figures. flux2-klein (FLUX.2 Klein, 8B) renders labelled
-# diagrams better than z-image-turbo, so it wins when both are pulled.
-# Exact installed tags (e.g. ``x/flux2-klein:4b``) are resolved against
-# this prefix list at detection time — never hardcode a tag here; the
-# operator's tag comes back from Ollama's /api/tags.
-_LOCAL_IMAGE_MODEL_PREFERENCE = ("x/flux2-klein", "x/z-image-turbo")
+# academic figures, from the catalog's local_draft role preference list
+# (EPIC #125). flux2-klein (FLUX.2 Klein) renders labelled diagrams
+# better than z-image-turbo, so it is listed first. Exact installed tags
+# (e.g. ``x/flux2-klein:4b``) are resolved against this prefix list at
+# detection time — never hardcode a tag; the operator's tag comes back
+# from Ollama's /api/tags.
+try:
+    from .model_catalog import get_catalog as _get_model_catalog
+except ImportError:  # pragma: no cover - direct-script execution path
+    from src.model_catalog import get_catalog as _get_model_catalog
+
+_LOCAL_IMAGE_MODEL_PREFERENCE = tuple(
+    _get_model_catalog().role_default("local_draft")
+)
 
 _PAPERBANANA_ABSENT_REASON = (
     "paperbanana CLI not on PATH and paperbanana package not "
@@ -117,7 +125,7 @@ class PaperbananaDispatch:
         fallback_provider: cloud provider to use when paperbanana is
             absent. ``"google"`` by default.
         fallback_model: cloud model to use when paperbanana is absent.
-            ``"gemini-3.1-flash-image-preview"`` (Nano Banana Flash 1K)
+            The catalog's image_gen role default (Nano Banana Flash 1K)
             by default — the cheapest tier that handles complex text.
         fallback_reason: human-readable explanation when ``available``
             is False. Empty when paperbanana was found.
@@ -155,7 +163,7 @@ class PaperbananaDispatch:
     output_dir: str
     args: dict = field(default_factory=dict)
     fallback_provider: str = "google"
-    fallback_model: str = "gemini-3.1-flash-image-preview"
+    fallback_model: str = _get_model_catalog().default_model("image_gen")["id"]
     fallback_reason: str = ""
     backend: str = ""
     local_provider: str = ""

--- a/plugins/jack-tar-deckhand/src/paperbanana_dispatch.py
+++ b/plugins/jack-tar-deckhand/src/paperbanana_dispatch.py
@@ -488,7 +488,10 @@ def build_dispatch_payload(
                 "" if (paperbanana_available or local_only)
                 else _PAPERBANANA_ABSENT_REASON
             ),
-            backend="ollama",
+            # Issue #124: the backend is whatever local provider was
+            # detected ("ollama" today, "mlx" behind the same seam) —
+            # never a hardcoded literal.
+            backend=local_backend.provider,
             local_provider=local_backend.provider,
             local_model=local_backend.model,
             local_args={
@@ -607,12 +610,15 @@ def build_manifest_entry(
         backend_used = dispatch.backend or (
             "paperbanana" if dispatch.available else "cloud_fallback"
         )
-    if backend_used == "ollama":
-        backend_used = "ollama_local"
+    # Issue #124: any local provider family maps to "<provider>_local"
+    # ("ollama" -> "ollama_local", "mlx" -> "mlx_local") — the seam is
+    # provider-shaped, not ollama-shaped.
+    if dispatch.local_provider and backend_used == dispatch.local_provider:
+        backend_used = f"{backend_used}_local"
 
     if backend_used == "paperbanana":
         model_used = "paperbanana"
-    elif backend_used == "ollama_local":
+    elif dispatch.local_provider and backend_used == f"{dispatch.local_provider}_local":
         model_used = dispatch.local_model
     else:
         model_used = dispatch.fallback_model

--- a/plugins/jack-tar-deckhand/src/render_funnel.py
+++ b/plugins/jack-tar-deckhand/src/render_funnel.py
@@ -112,10 +112,11 @@ _CLOUD_STAGE_RESOLUTION = {
 
 # Per-stage default provider+model when the caller doesn't specify.
 # 2K/4K force Google because Nano Banana Pro/Flash are the only models
-# that support those tiers across the matrix.
+# that support those tiers across the matrix. Canonical ids per the
+# model catalog (EPIC #125 — the retired '-preview' ids are aliases).
 _CLOUD_STAGE_DEFAULT_PROVIDER_MODEL = {
-    'cloud_2k': ('google', 'gemini-3.1-flash-image-preview'),
-    'cloud_4k': ('google', 'gemini-3-pro-image-preview'),
+    'cloud_2k': ('google', 'gemini-3.1-flash-image'),
+    'cloud_4k': ('google', 'gemini-3-pro-image'),
 }
 
 

--- a/plugins/jack-tar-deckhand/tests/test_creative_vision_cascade.py
+++ b/plugins/jack-tar-deckhand/tests/test_creative_vision_cascade.py
@@ -70,22 +70,22 @@ def test_tier_to_provider_model_resolution_ollama_is_local():
 def test_tier_to_provider_model_resolution_google_tiers():
     """All flash_* and pro_* tiers route through Google's two image models."""
     assert TIER_TO_PROVIDER_MODEL_RESOLUTION["flash_1k"] == (
-        "google", "gemini-3.1-flash-image-preview", "1K"
+        "google", "gemini-3.1-flash-image", "1K"
     )
     assert TIER_TO_PROVIDER_MODEL_RESOLUTION["flash_2k"] == (
-        "google", "gemini-3.1-flash-image-preview", "2K"
+        "google", "gemini-3.1-flash-image", "2K"
     )
     assert TIER_TO_PROVIDER_MODEL_RESOLUTION["flash_4k"] == (
-        "google", "gemini-3.1-flash-image-preview", "4K"
+        "google", "gemini-3.1-flash-image", "4K"
     )
     assert TIER_TO_PROVIDER_MODEL_RESOLUTION["pro_1k"] == (
-        "google", "gemini-3-pro-image-preview", "1K"
+        "google", "gemini-3-pro-image", "1K"
     )
     assert TIER_TO_PROVIDER_MODEL_RESOLUTION["pro_2k"] == (
-        "google", "gemini-3-pro-image-preview", "2K"
+        "google", "gemini-3-pro-image", "2K"
     )
     assert TIER_TO_PROVIDER_MODEL_RESOLUTION["pro_4k"] == (
-        "google", "gemini-3-pro-image-preview", "4K"
+        "google", "gemini-3-pro-image", "4K"
     )
 
 

--- a/plugins/jack-tar-deckhand/tests/test_image_router_resolution.py
+++ b/plugins/jack-tar-deckhand/tests/test_image_router_resolution.py
@@ -13,7 +13,7 @@ def test_routing_target_has_resolution_field():
     t = image_router.RoutingTarget(
         skill='cloud-generate-image',
         provider='google',
-        model='gemini-3-pro-image-preview',
+        model='gemini-3-pro-image',
         cost_per_image=0.24,
         resolution='4K',
     )
@@ -40,7 +40,7 @@ def test_upgrade_decision_has_target_resolution_field():
         reason='hero benefits from 4K',
         draft_prompt='a lighthouse',
         target_provider='google',
-        target_model='gemini-3-pro-image-preview',
+        target_model='gemini-3-pro-image',
         target_size='4096x4096',
         target_resolution='4K',
         estimated_cost_usd=0.24,
@@ -61,7 +61,7 @@ def test_check_resolution_compatibility_warns_for_unsupported_tier():
 
 def test_check_resolution_compatibility_silent_for_supported_tier():
     warning = image_router._check_resolution_compatibility(
-        provider='google', model='gemini-3-pro-image-preview', resolution='4K',
+        provider='google', model='gemini-3-pro-image', resolution='4K',
     )
     assert warning is None
 
@@ -88,7 +88,7 @@ def test_router_prefers_nano_banana_pro_for_4k_hero():
         budget_state='allow',
     )
     assert decision.provider == 'google'
-    assert decision.model == 'gemini-3-pro-image-preview'
+    assert decision.model == 'gemini-3-pro-image'
     assert decision.resolution == '4K'
 
 

--- a/plugins/jack-tar-deckhand/tests/test_iterate_slide_dispatch.py
+++ b/plugins/jack-tar-deckhand/tests/test_iterate_slide_dispatch.py
@@ -295,8 +295,8 @@ def test_plan_refinement_unknown_mode_raises():
 def test_plan_refinement_includes_explicit_models():
     """F2 finding: must NOT rely on paperbanana's deprecated defaults."""
     plan = plan_refinement("auto", VALID_RUN_ID, IterateSlideRefinementRequest())
-    assert plan.cli_args["--vlm-model"] == "gemini-2.5-flash"
-    assert plan.cli_args["--image-model"] == "gemini-3.1-flash-image-preview"
+    assert plan.cli_args["--vlm-model"] == "gemini-3.5-flash"
+    assert plan.cli_args["--image-model"] == "gemini-3.1-flash-image"
 
 
 # --- cli_args_to_argv ----------------------------------------------------

--- a/plugins/jack-tar-deckhand/tests/test_paperbanana_dispatch.py
+++ b/plugins/jack-tar-deckhand/tests/test_paperbanana_dispatch.py
@@ -344,7 +344,7 @@ def test_dispatch_payload_when_unavailable_populates_fallback():
     assert dispatch.available is False
     assert dispatch.args == {}
     assert dispatch.fallback_provider == "google"
-    assert dispatch.fallback_model == "gemini-3.1-flash-image-preview"
+    assert dispatch.fallback_model == "gemini-3.1-flash-image"
     assert "paperbanana CLI not on PATH" in dispatch.fallback_reason
     assert "pip install" in dispatch.fallback_reason
 
@@ -476,7 +476,7 @@ def test_manifest_entry_for_fallback_cloud_render():
         output_path="/tmp/deck/images/slide-06-academic-figure.png",
     )
     assert entry["backend"] == "cloud_fallback"
-    assert entry["model_used"] == "gemini-3.1-flash-image-preview"
+    assert entry["model_used"] == "gemini-3.1-flash-image"
     assert "fallback_reason" in entry
     assert "paperbanana CLI not on PATH" in entry["fallback_reason"]
     assert "paperbanana_run_id" not in entry
@@ -527,7 +527,7 @@ def test_dispatch_dataclass_default_fallback_values():
         output_dir="./out",
     )
     assert dispatch.fallback_provider == "google"
-    assert dispatch.fallback_model == "gemini-3.1-flash-image-preview"
+    assert dispatch.fallback_model == "gemini-3.1-flash-image"
     assert dispatch.args == {}
     assert dispatch.fallback_reason == ""
 
@@ -714,7 +714,7 @@ def test_dispatch_local_first_without_paperbanana_keeps_cloud_escalation():
     assert dispatch.backend == "ollama"
     assert dispatch.available is False
     assert dispatch.args == {}
-    assert dispatch.fallback_model == "gemini-3.1-flash-image-preview"
+    assert dispatch.fallback_model == "gemini-3.1-flash-image"
     assert "paperbanana CLI not on PATH" in dispatch.fallback_reason
 
 
@@ -913,7 +913,7 @@ def test_manifest_entry_escalated_to_cloud_after_gate():
         backend_used="cloud_fallback",
     )
     assert entry["backend"] == "cloud_fallback"
-    assert entry["model_used"] == "gemini-3.1-flash-image-preview"
+    assert entry["model_used"] == "gemini-3.1-flash-image"
     assert "fallback_reason" in entry
 
 

--- a/plugins/jack-tar-superpower-bridge/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-superpower-bridge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-superpower-bridge",
   "description": "Wraps document-skills:pptx with a narrative pre-brief skill and a post-hoc visual enrichment skill — combine /pptx structural strength with jack-tar visual capabilities (AI backgrounds, element images, editable SmartArt)",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-superpower-bridge/skills/enrich-deck/SKILL.md
+++ b/plugins/jack-tar-superpower-bridge/skills/enrich-deck/SKILL.md
@@ -245,8 +245,8 @@ Repeat until `decision.kind` starts with `terminate_`:
 **(i) Generate the image** based on current `state.phase`:
 
 - `phase_a_ollama` → invoke `/jack-tar-ollama:image "$PROMPT" --output $OUTPUT --width $WIDTH --height $HEIGHT --model $OLLAMA_MODEL` (free; no budget charge)
-- `phase_b_cloud_flash` → invoke `/jack-tar-cloud:image "$PROMPT" --provider google --model gemini-3.1-flash-image-preview --output $OUTPUT --resolution 1K` then charge `kind="generation", provider="nanobanana_flash", cost_usd=0.067`
-- `phase_c_cloud_pro` → invoke `/jack-tar-cloud:image "$PROMPT" --provider google --model gemini-3-pro-image-preview --output $OUTPUT --resolution 1K` then charge `kind="generation", provider="nanobanana_pro", cost_usd=0.134`
+- `phase_b_cloud_flash` → invoke `/jack-tar-cloud:image "$PROMPT" --provider google --model gemini-3.1-flash-image --output $OUTPUT --resolution 1K` then charge `kind="generation", provider="nanobanana_flash", cost_usd=0.067`
+- `phase_c_cloud_pro` → invoke `/jack-tar-cloud:image "$PROMPT" --provider google --model gemini-3-pro-image --output $OUTPUT --resolution 1K` then charge `kind="generation", provider="nanobanana_pro", cost_usd=0.134`
 
 **Note (post-EPIC #58):** bridge routes Phase B/C at `1K` only. Higher tiers (2K/4K) are reachable from the deckhand pipeline via `slide.resolution` + `slide.brand_fidelity` but bridge doesn't yet consume those surfaces — see "Known limitation" in `plugins/jack-tar-superpower-bridge/CLAUDE.md`. v0.3 candidate.
 

--- a/plugins/jack-tar-superpower-bridge/src/image_bridge.py
+++ b/plugins/jack-tar-superpower-bridge/src/image_bridge.py
@@ -230,7 +230,7 @@ def generate_with_review_cycle(
         )
 
     # --- Phase B: Cloud Flash with prompt refinement -------------------
-    flash_model = "gemini-3.1-flash-image-preview"
+    flash_model = "gemini-3.1-flash-image"
     flash_cost = 0.067
     for flash_attempt in range(1, max_cloud_flash_iterations + 1):
         if not budget.can_afford(flash_cost):
@@ -275,7 +275,7 @@ def generate_with_review_cycle(
         last_reviewer_feedback = verdict_payload
         if verdict_payload.get("verdict") == "pass":
             # Optional Phase C — Pro single-shot when Flash converged on a proven prompt
-            pro_model = "gemini-3-pro-image-preview"
+            pro_model = "gemini-3-pro-image"
             pro_cost = 0.134
             if budget.can_afford(pro_cost):
                 gen_payload = cloud_generate(request, pro_model, 1)

--- a/src/model_catalog.py
+++ b/src/model_catalog.py
@@ -1,0 +1,501 @@
+"""Model catalog loader — single source of truth for AI model identity,
+capability, and pricing (EPIC #125).
+
+Model IDs, aliases, retirement pointers, resolution capability, and cost
+tables live in ``model-catalog.json``, NOT in code. This loader merges three
+layers, lowest precedence first:
+
+1. **Shipped baseline** — the ``model-catalog.json`` vendored next to this
+   module (or the repo-level ``model-catalog/`` directory in development).
+2. **Cached remote** — ``~/.jack-tar/model-catalog.json``, written by the
+   refresh-models skill (issue #128). Replaces the baseline wholesale when
+   present, valid, and loader-compatible; a bad cache falls back to shipped.
+3. **Local overrides** — the ``model_catalog`` key in the project's
+   ``local-config.json`` (gitignored). Entries merge per-model by id;
+   ``role_defaults`` merge per-key.
+
+Stdlib-only. Schema-level validation lives in
+``model-catalog/model-catalog.schema.json`` (enforced by tests/CI); this
+module performs structural validation sufficient to reject a broken cache
+at runtime without a jsonschema dependency.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Bump when the loader's expectations of the catalog shape change.
+#: A catalog whose ``min_loader_version`` exceeds this is rejected.
+LOADER_VERSION = 1
+
+CATALOG_FILENAME = "model-catalog.json"
+
+#: Env var pointing at an explicit catalog file (highest-priority baseline).
+CATALOG_PATH_ENV = "JACK_TAR_MODEL_CATALOG"
+
+#: Env var overriding the cached-remote location.
+CATALOG_CACHE_ENV = "JACK_TAR_CATALOG_CACHE"
+
+_DEFAULT_CACHE_PATH = Path.home() / ".jack-tar" / CATALOG_FILENAME
+
+_ENTRY_REQUIRED_FIELDS = ("id", "provider", "status", "roles")
+_VALID_STATUSES = frozenset({"active", "deprecated", "retired"})
+_RESOLUTION_ALIASES = {"512": "512", "1K": "1K", "2K": "2K", "4K": "4K"}
+
+
+class CatalogError(Exception):
+    """Catalog missing, unparseable, or structurally invalid."""
+
+
+class UnknownModelError(KeyError):
+    """No catalog entry (id or alias) matches the requested model."""
+
+
+class PricingError(ValueError):
+    """The entry has no price for the requested parameters."""
+
+
+def _normalise_resolution(resolution):
+    key = str(resolution).strip().upper()
+    if key in _RESOLUTION_ALIASES:
+        return _RESOLUTION_ALIASES[key]
+    raise PricingError(
+        f"resolution={resolution!r} not recognised. "
+        f"Valid values: {sorted(_RESOLUTION_ALIASES)}"
+    )
+
+
+def validate_catalog(doc):
+    """Structurally validate a catalog document. Raises CatalogError.
+
+    This is the runtime gate (cheap, stdlib-only). Full JSON-Schema
+    validation runs in the test suite against model-catalog.schema.json.
+    """
+    if not isinstance(doc, dict):
+        raise CatalogError("catalog root must be an object")
+    for key in ("catalog_version", "min_loader_version", "updated", "models"):
+        if key not in doc:
+            raise CatalogError(f"catalog missing required key: {key}")
+    min_loader = doc["min_loader_version"]
+    if not isinstance(min_loader, int) or min_loader < 1:
+        raise CatalogError("min_loader_version must be a positive integer")
+    if min_loader > LOADER_VERSION:
+        raise CatalogError(
+            f"catalog requires loader version >= {min_loader}; "
+            f"this loader is version {LOADER_VERSION} — update the plugin"
+        )
+    models = doc["models"]
+    if not isinstance(models, list) or not models:
+        raise CatalogError("models must be a non-empty list")
+
+    seen = {}
+    for entry in models:
+        if not isinstance(entry, dict):
+            raise CatalogError("every model entry must be an object")
+        for field in _ENTRY_REQUIRED_FIELDS:
+            if field not in entry:
+                raise CatalogError(
+                    f"model entry {entry.get('id', '<no id>')!r} missing "
+                    f"required field: {field}"
+                )
+        status = entry["status"]
+        if status not in _VALID_STATUSES:
+            raise CatalogError(
+                f"model {entry['id']!r} has invalid status {status!r}"
+            )
+        if status == "retired" and not entry.get("replacement"):
+            raise CatalogError(
+                f"retired model {entry['id']!r} must name a replacement"
+            )
+        for name in [entry["id"], *entry.get("aliases", [])]:
+            if name in seen:
+                raise CatalogError(
+                    f"duplicate model id/alias {name!r} "
+                    f"(in {entry['id']!r} and {seen[name]!r})"
+                )
+            seen[name] = entry["id"]
+
+    # Replacements and role defaults must resolve to real ids/aliases.
+    for entry in models:
+        replacement = entry.get("replacement")
+        if replacement and replacement not in seen:
+            raise CatalogError(
+                f"model {entry['id']!r} names unknown replacement "
+                f"{replacement!r}"
+            )
+    for role, value in (doc.get("role_defaults") or {}).items():
+        ids = [value] if isinstance(value, str) else list(value)
+        for model_id in ids:
+            if model_id not in seen:
+                raise CatalogError(
+                    f"role_defaults[{role!r}] names unknown model {model_id!r}"
+                )
+
+
+def _read_json(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _find_shipped_catalog(shipped_path=None):
+    """Locate the shipped baseline catalog.
+
+    Search order: explicit arg -> JACK_TAR_MODEL_CATALOG env var -> file
+    next to this module (vendored plugin layout) -> repo-level
+    model-catalog/ directory walking up from this module (dev layout).
+    """
+    if shipped_path:
+        return Path(shipped_path)
+    env_path = os.environ.get(CATALOG_PATH_ENV)
+    if env_path:
+        return Path(env_path)
+    module_dir = Path(__file__).resolve().parent
+    candidate = module_dir / CATALOG_FILENAME
+    if candidate.exists():
+        return candidate
+    for ancestor in module_dir.parents[:3]:
+        candidate = ancestor / "model-catalog" / CATALOG_FILENAME
+        if candidate.exists():
+            return candidate
+    raise CatalogError(
+        f"shipped {CATALOG_FILENAME} not found next to {module_dir} "
+        f"or in an ancestor model-catalog/ directory"
+    )
+
+
+def _load_cached_remote(cache_path=None):
+    """Return (doc, path) for a valid cached remote catalog, else None.
+
+    A missing cache is normal (install has never refreshed). An invalid
+    or loader-incompatible cache logs a warning and is ignored — the
+    shipped baseline always keeps the pipeline running.
+    """
+    path = Path(
+        cache_path
+        or os.environ.get(CATALOG_CACHE_ENV)
+        or _DEFAULT_CACHE_PATH
+    )
+    if not path.exists():
+        return None
+    try:
+        doc = _read_json(path)
+        validate_catalog(doc)
+        return doc, path
+    except (OSError, json.JSONDecodeError, CatalogError) as exc:
+        logger.warning(
+            "ignoring invalid cached model catalog at %s: %s "
+            "(falling back to shipped baseline)", path, exc,
+        )
+        return None
+
+
+def _apply_local_overrides(doc, local_config_path):
+    """Merge local-config.json's ``model_catalog`` key into the catalog.
+
+    ``models`` entries merge per-model by id (shallow field update; unknown
+    ids append as new entries). ``role_defaults`` merge per-key. The merged
+    document is re-validated so a broken override fails loudly — local
+    overrides are operator-authored and should not degrade silently.
+    """
+    path = Path(local_config_path) if local_config_path else Path("local-config.json")
+    if not path.exists():
+        return doc, False
+    try:
+        local = _read_json(path)
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("ignoring unreadable local-config.json: %s", exc)
+        return doc, False
+    overrides = local.get("model_catalog")
+    if not isinstance(overrides, dict):
+        return doc, False
+
+    merged = copy.deepcopy(doc)
+    by_id = {entry["id"]: entry for entry in merged["models"]}
+    for patch in overrides.get("models", []):
+        target = by_id.get(patch.get("id"))
+        if target is not None:
+            target.update(copy.deepcopy(patch))
+        else:
+            merged["models"].append(copy.deepcopy(patch))
+    if "role_defaults" in overrides:
+        merged.setdefault("role_defaults", {}).update(overrides["role_defaults"])
+    validate_catalog(merged)
+    return merged, True
+
+
+class ModelCatalog:
+    """Immutable view over a validated catalog document."""
+
+    def __init__(self, doc, source="shipped"):
+        self._doc = doc
+        self.source = source
+        self._by_name = {}
+        for entry in doc["models"]:
+            self._by_name[entry["id"]] = entry
+            for alias in entry.get("aliases", []):
+                self._by_name[alias] = entry
+
+    @property
+    def version(self):
+        return self._doc["catalog_version"]
+
+    @property
+    def updated(self):
+        return self._doc["updated"]
+
+    def ids(self):
+        return [entry["id"] for entry in self._doc["models"]]
+
+    def get(self, id_or_alias, follow_replacement=True):
+        """Return a copy of the entry for a model id or alias.
+
+        Retired entries resolve to their replacement when
+        ``follow_replacement`` (the substitution is logged and recorded in
+        the returned dict's ``resolved_from``). Deprecated entries return
+        themselves with a warning. Unknown names raise UnknownModelError.
+        """
+        entry = self._by_name.get(id_or_alias)
+        if entry is None:
+            raise UnknownModelError(
+                f"model {id_or_alias!r} not in catalog "
+                f"(version {self.version}); known ids: {self.ids()}"
+            )
+        resolved_from = None
+        if id_or_alias != entry["id"]:
+            resolved_from = id_or_alias
+        hops = 0
+        while follow_replacement and entry["status"] == "retired":
+            replacement = entry["replacement"]
+            logger.info(
+                "model %s is retired — substituting %s (catalog %s)",
+                entry["id"], replacement, self.version,
+            )
+            resolved_from = resolved_from or entry["id"]
+            entry = self._by_name[replacement]
+            hops += 1
+            if hops > len(self._doc["models"]):
+                raise CatalogError(
+                    f"replacement cycle detected at {entry['id']!r}"
+                )
+        if entry["status"] == "deprecated":
+            logger.warning(
+                "model %s is deprecated%s", entry["id"],
+                f" — prefer {entry['replacement']}" if entry.get("replacement") else "",
+            )
+        result = copy.deepcopy(entry)
+        if resolved_from:
+            result["resolved_from"] = resolved_from
+        return result
+
+    def entries(self, role=None, provider=None, status="active"):
+        """Return copies of entries filtered by role/provider/status.
+
+        ``status=None`` disables the status filter.
+        """
+        out = []
+        for entry in self._doc["models"]:
+            if status is not None and entry["status"] != status:
+                continue
+            if role is not None and role not in entry["roles"]:
+                continue
+            if provider is not None and entry["provider"] != provider:
+                continue
+            out.append(copy.deepcopy(entry))
+        return out
+
+    def role_default(self, role):
+        """Return the raw role_defaults value: a model id or preference list."""
+        defaults = self._doc.get("role_defaults") or {}
+        if role not in defaults:
+            raise UnknownModelError(
+                f"no role_default for {role!r}; defined roles: "
+                f"{sorted(defaults)}"
+            )
+        return copy.deepcopy(defaults[role])
+
+    def default_model(self, role):
+        """Return the resolved entry for a role's default.
+
+        For preference-list defaults (e.g. local_draft) the first entry
+        wins — callers that can probe availability should use
+        ``role_default`` and filter the list themselves.
+        """
+        value = self.role_default(role)
+        model_id = value if isinstance(value, str) else value[0]
+        return self.get(model_id)
+
+    def resolutions(self, id_or_alias):
+        entry = self.get(id_or_alias)
+        return list((entry.get("capabilities") or {}).get("resolutions", []))
+
+    def supports(self, id_or_alias, resolution):
+        return _normalise_resolution(resolution) in self.resolutions(id_or_alias)
+
+    def has_quirk(self, id_or_alias, quirk):
+        return quirk in self.get(id_or_alias).get("quirks", [])
+
+    def cost(self, id_or_alias, resolution=None, backend=None, size=None,
+             quality=None, tier=None, megapixels=None):
+        """Return the USD cost for one generation with the given parameters.
+
+        Dispatches across the pricing shapes:
+          flat                     -> no parameters needed
+          per_resolution           -> ``resolution``
+          backends                 -> ``resolution`` + ``backend`` (Google
+                                      Imagen: 'vertex' when
+                                      GOOGLE_APPLICATION_CREDENTIALS is set,
+                                      else 'developer' — auto-detected when
+                                      backend is None)
+          per_size_quality         -> ``size`` + ``quality`` (OpenAI)
+          per_tier                 -> ``tier`` (icons)
+          tiered_megapixel         -> ``megapixels`` (FAL FLUX 2 Pro)
+
+        The upscale_chain_4k quirk (Recraft Pro) applies the documented
+        env override to the upscale component of the 4K chain price.
+        """
+        entry = self.get(id_or_alias)
+        pricing = entry.get("pricing")
+        if pricing is None:
+            raise PricingError(
+                f"model {entry['id']!r} has no pricing data in the catalog"
+            )
+
+        if "flat" in pricing and resolution is None and size is None \
+                and tier is None and megapixels is None:
+            return pricing["flat"]
+
+        if "per_resolution" in pricing and resolution is not None:
+            res = _normalise_resolution(resolution)
+            table = pricing["per_resolution"]
+            if res not in table:
+                raise PricingError(
+                    f"model {entry['id']!r} has no {res} price; "
+                    f"priced resolutions: {sorted(table)}"
+                )
+            if res == "4K" and "upscale_chain_4k" in entry.get("quirks", []):
+                return self._chained_4k_cost(entry, table, pricing)
+            return table[res]
+
+        if "backends" in pricing and resolution is not None:
+            res = _normalise_resolution(resolution)
+            if backend is None:
+                backend = (
+                    "vertex"
+                    if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+                    else "developer"
+                )
+            table = pricing["backends"].get(backend)
+            if table is None:
+                raise PricingError(
+                    f"model {entry['id']!r} has no backend {backend!r}; "
+                    f"priced backends: {sorted(pricing['backends'])}"
+                )
+            if res not in table:
+                raise PricingError(
+                    f"model {entry['id']!r} has no {res} price on "
+                    f"backend {backend!r}; priced: {sorted(table)}"
+                )
+            return table[res]
+
+        if "per_size_quality" in pricing and size is not None:
+            key = f"{size}|{quality}"
+            table = pricing["per_size_quality"]
+            if key not in table:
+                raise PricingError(
+                    f"model {entry['id']!r} has no price for "
+                    f"size/quality {key!r}; priced: {sorted(table)}"
+                )
+            return table[key]
+
+        if "per_tier" in pricing and tier is not None:
+            table = pricing["per_tier"]
+            if tier not in table:
+                raise PricingError(
+                    f"model {entry['id']!r} has no tier {tier!r}; "
+                    f"priced tiers: {sorted(table)}"
+                )
+            return table[tier]
+
+        if "tiered_megapixel" in pricing and megapixels is not None:
+            rates = pricing["tiered_megapixel"]
+            extra = max(0.0, float(megapixels) - 1.0)
+            return rates["first_mp"] + extra * rates["per_extra_mp"]
+
+        if "flat" in pricing:
+            return pricing["flat"]
+
+        raise PricingError(
+            f"model {entry['id']!r}: no pricing shape matches the given "
+            f"parameters (resolution={resolution!r}, size={size!r}, "
+            f"quality={quality!r}, tier={tier!r}, megapixels={megapixels!r}); "
+            f"available shapes: {sorted(set(pricing) - {'currency', 'verified', 'estimate', 'notes', 'env_override'})}"
+        )
+
+    @staticmethod
+    def _chained_4k_cost(entry, table, pricing):
+        """4K = 2K generation + upscale; env override adjusts the upscale part.
+
+        Override is only honoured when it parses to a positive float —
+        guards against accidentally pricing a paid API at $0 or negative
+        (mirrors the historical RECRAFT_UPSCALE_COST_USD behaviour).
+        """
+        base = table.get("2K", 0.0)
+        upscale = table["4K"] - base
+        env_var = (pricing.get("env_override") or {}).get("upscale")
+        if env_var:
+            raw = os.environ.get(env_var)
+            if raw:
+                try:
+                    value = float(raw)
+                    if value > 0:
+                        upscale = value
+                except ValueError:
+                    pass
+        return base + upscale
+
+
+def load_catalog(shipped_path=None, cache_path=None, local_config_path=None):
+    """Load the catalog with full precedence merging. Returns ModelCatalog.
+
+    Precedence (low to high): shipped baseline -> cached remote ->
+    local-config.json ``model_catalog`` overrides. See module docstring.
+    """
+    source = "shipped"
+    cached = _load_cached_remote(cache_path)
+    if cached is not None:
+        doc, path = cached
+        source = f"cached:{path}"
+    else:
+        path = _find_shipped_catalog(shipped_path)
+        try:
+            doc = _read_json(path)
+        except (OSError, json.JSONDecodeError) as exc:
+            raise CatalogError(f"cannot read shipped catalog at {path}: {exc}")
+        validate_catalog(doc)
+
+    doc, overridden = _apply_local_overrides(doc, local_config_path)
+    if overridden:
+        source += "+local"
+    catalog = ModelCatalog(doc, source=source)
+    logger.debug(
+        "model catalog loaded: version=%s source=%s models=%d",
+        catalog.version, source, len(doc["models"]),
+    )
+    return catalog
+
+
+_catalog_singleton = None
+
+
+def get_catalog(reload=False):
+    """Process-wide cached catalog. ``reload=True`` re-reads from disk."""
+    global _catalog_singleton
+    if _catalog_singleton is None or reload:
+        _catalog_singleton = load_catalog()
+    return _catalog_singleton

--- a/src/model_catalog.py
+++ b/src/model_catalog.py
@@ -242,6 +242,11 @@ class ModelCatalog:
                 self._by_name[alias] = entry
 
     @property
+    def doc(self):
+        """The raw validated catalog document (read-only by convention)."""
+        return self._doc
+
+    @property
     def version(self):
         return self._doc["catalog_version"]
 

--- a/src/model_catalog_refresh.py
+++ b/src/model_catalog_refresh.py
@@ -1,0 +1,261 @@
+"""Model catalog refresh — release-decoupled catalog updates (EPIC #125, #128).
+
+Fetches the canonical model catalog from the repository's main branch,
+validates it against the installed loader, surfaces a pricing/model diff
+for the operator gate, and atomically swaps it into the local cache that
+``model_catalog.load_catalog`` prefers over the shipped baseline.
+
+Design constraints:
+
+- **The operator gate is load-bearing** (CLAUDE.md F10): cost figures drive
+  the free→cost cascade gates, so a refresh that changes any price MUST be
+  surfaced to the operator before it takes effect. ``diff_catalogs`` is the
+  gate's evidence; the refresh-models skill presents it and waits for
+  explicit go-ahead. Refresh is on-request, never silent.
+- **A bad remote can never brick an install**: the remote document is
+  validated (structure + min_loader_version) BEFORE it touches the cache;
+  the previous cache is kept alongside for one-command rollback; and the
+  loader independently re-validates the cache on every load, falling back
+  to the shipped baseline if it is somehow corrupt.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+try:
+    from .model_catalog import (
+        CATALOG_CACHE_ENV,
+        CatalogError,
+        load_catalog,
+        validate_catalog,
+    )
+except ImportError:  # pragma: no cover - direct-script execution path
+    from model_catalog import (
+        CATALOG_CACHE_ENV,
+        CatalogError,
+        load_catalog,
+        validate_catalog,
+    )
+
+logger = logging.getLogger(__name__)
+
+#: Canonical published location — the repo's main branch. A catalog-only
+#: commit to main is picked up by every install on next refresh, no plugin
+#: release required.
+DEFAULT_REMOTE_URL = (
+    "https://raw.githubusercontent.com/SteveGJones/jack-tar-deckhand/"
+    "main/model-catalog/model-catalog.json"
+)
+
+REMOTE_URL_ENV = "JACK_TAR_CATALOG_URL"
+
+_DEFAULT_CACHE_PATH = Path.home() / ".jack-tar" / "model-catalog.json"
+_PREV_SUFFIX = ".prev"
+
+
+def _cache_path(cache_path=None):
+    return Path(
+        cache_path
+        or os.environ.get(CATALOG_CACHE_ENV)
+        or _DEFAULT_CACHE_PATH
+    )
+
+
+def fetch_remote_catalog(url=None, timeout=15):
+    """Fetch and parse the remote catalog document. Raises CatalogError.
+
+    The document is structurally validated (including min_loader_version
+    against the installed loader) before being returned — callers never
+    see an unusable catalog.
+    """
+    import requests
+
+    target = url or os.environ.get(REMOTE_URL_ENV) or DEFAULT_REMOTE_URL
+    try:
+        response = requests.get(target, timeout=timeout)
+        response.raise_for_status()
+        doc = response.json()
+    except requests.RequestException as exc:
+        raise CatalogError(f"cannot fetch remote catalog from {target}: {exc}")
+    except ValueError as exc:
+        raise CatalogError(f"remote catalog at {target} is not valid JSON: {exc}")
+    validate_catalog(doc)
+    return doc
+
+
+def diff_catalogs(current_doc, new_doc):
+    """Diff two catalog documents for the operator gate.
+
+    Returns a dict:
+        price_changes: [{model, component, old, new}]  — GATE-RELEVANT
+        added_models: [id]
+        removed_models: [id]
+        status_changes: [{model, old, new, replacement}]
+        version: {old, new}
+    """
+    def _by_id(doc):
+        return {e["id"]: e for e in doc["models"]}
+
+    def _flatten_pricing(entry):
+        flat = {}
+        pricing = entry.get("pricing") or {}
+        for key in ("flat",):
+            if key in pricing:
+                flat[key] = pricing[key]
+        for res, cost in (pricing.get("per_resolution") or {}).items():
+            flat[f"per_resolution.{res}"] = cost
+        for backend, table in (pricing.get("backends") or {}).items():
+            for res, cost in table.items():
+                flat[f"backends.{backend}.{res}"] = cost
+        for key, cost in (pricing.get("per_size_quality") or {}).items():
+            flat[f"per_size_quality.{key}"] = cost
+        for tier, cost in (pricing.get("per_tier") or {}).items():
+            flat[f"per_tier.{tier}"] = cost
+        tiered = pricing.get("tiered_megapixel")
+        if tiered:
+            flat["tiered_megapixel.first_mp"] = tiered["first_mp"]
+            flat["tiered_megapixel.per_extra_mp"] = tiered["per_extra_mp"]
+        for component, rate in (pricing.get("token_rates") or {}).items():
+            flat[f"token_rates.{component}"] = rate
+        return flat
+
+    current = _by_id(current_doc)
+    new = _by_id(new_doc)
+
+    price_changes = []
+    status_changes = []
+    for model_id in sorted(set(current) & set(new)):
+        old_prices = _flatten_pricing(current[model_id])
+        new_prices = _flatten_pricing(new[model_id])
+        for component in sorted(set(old_prices) | set(new_prices)):
+            old_value = old_prices.get(component)
+            new_value = new_prices.get(component)
+            if old_value != new_value:
+                price_changes.append({
+                    "model": model_id,
+                    "component": component,
+                    "old": old_value,
+                    "new": new_value,
+                })
+        if current[model_id]["status"] != new[model_id]["status"]:
+            status_changes.append({
+                "model": model_id,
+                "old": current[model_id]["status"],
+                "new": new[model_id]["status"],
+                "replacement": new[model_id].get("replacement"),
+            })
+
+    return {
+        "price_changes": price_changes,
+        "added_models": sorted(set(new) - set(current)),
+        "removed_models": sorted(set(current) - set(new)),
+        "status_changes": status_changes,
+        "version": {
+            "old": current_doc["catalog_version"],
+            "new": new_doc["catalog_version"],
+        },
+    }
+
+
+def check_remote(url=None, cache_path=None, local_config_path=None):
+    """Fetch the remote catalog and diff it against the effective catalog.
+
+    Read-only: nothing is written. Returns {remote_doc, diff, current_version,
+    current_source} — the refresh-models skill renders the diff for the
+    operator gate and only calls apply_refresh after explicit go-ahead.
+    """
+    current = load_catalog(
+        cache_path=cache_path, local_config_path=local_config_path
+    )
+    remote_doc = fetch_remote_catalog(url=url)
+    return {
+        "remote_doc": remote_doc,
+        "diff": diff_catalogs(current.doc, remote_doc),
+        "current_version": current.version,
+        "current_source": current.source,
+    }
+
+
+def apply_refresh(new_doc, cache_path=None):
+    """Atomically install a validated catalog document into the cache.
+
+    The previous cache (if any) is preserved at ``<cache>.prev`` for
+    rollback. Returns {cache_path, previous_kept, version}.
+    """
+    validate_catalog(new_doc)
+    path = _cache_path(cache_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    previous_kept = False
+    if path.exists():
+        path.with_suffix(path.suffix + _PREV_SUFFIX).write_bytes(path.read_bytes())
+        previous_kept = True
+
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(new_doc, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+    logger.info(
+        "model catalog cache updated: %s (version %s)",
+        path, new_doc["catalog_version"],
+    )
+    return {
+        "cache_path": str(path),
+        "previous_kept": previous_kept,
+        "version": new_doc["catalog_version"],
+    }
+
+
+def rollback(cache_path=None):
+    """Restore the previous cached catalog. Returns the restored version.
+
+    Raises CatalogError when there is no previous copy to restore.
+    """
+    path = _cache_path(cache_path)
+    prev = path.with_suffix(path.suffix + _PREV_SUFFIX)
+    if not prev.exists():
+        raise CatalogError(
+            f"no previous catalog to roll back to at {prev} — "
+            f"delete {path} instead to fall back to the shipped baseline"
+        )
+    doc = json.loads(prev.read_text())
+    validate_catalog(doc)
+    os.replace(prev, path)
+    logger.info("model catalog cache rolled back to version %s", doc["catalog_version"])
+    return {"cache_path": str(path), "version": doc["catalog_version"]}
+
+
+def staleness_report(cache_path=None, local_config_path=None):
+    """Non-blocking staleness hint for /verify: current catalog identity.
+
+    Does NOT hit the network — reports what is loaded and from where, plus
+    the cache file's age in days when a cache is in use.
+    """
+    catalog = load_catalog(
+        cache_path=cache_path, local_config_path=local_config_path
+    )
+    report = {
+        "version": catalog.version,
+        "updated": catalog.updated,
+        "source": catalog.source,
+    }
+    path = _cache_path(cache_path)
+    if path.exists():
+        import time
+        age_days = (time.time() - path.stat().st_mtime) / 86400
+        report["cache_age_days"] = round(age_days, 1)
+    return report

--- a/src/model_probe.py
+++ b/src/model_probe.py
@@ -1,0 +1,229 @@
+"""Live provider discovery — verify catalog entries against provider APIs
+(EPIC #125, issue #129).
+
+Where a provider exposes a list-models API, probe it on request and classify
+every catalog entry:
+
+- ``verified``          — the model id exists upstream right now
+- ``suspect_retired``   — catalog says active/deprecated but the provider no
+                          longer lists it (the gemini-2.0-flash failure mode,
+                          issue #123, caught BEFORE a 404 in a deck build)
+- ``confirmed_retired`` — catalog already says retired and upstream agrees
+- ``unprobed``          — the provider has no list API (FAL, Recraft) or no
+                          credentials are configured; catalog-driven only
+
+Upstream models that no catalog entry covers are reported as
+``new_candidates``. Live discovery attests EXISTENCE, never price — a
+candidate is not routable until a catalog entry prices it (the budget
+tracker cannot cost an uncataloged model), so candidates require explicit
+operator opt-in via a local-config override or a catalog update.
+
+Probes degrade gracefully: a provider with no API key is skipped with a
+reason, never an exception.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+try:
+    from .model_catalog import get_catalog
+except ImportError:  # pragma: no cover - direct-script execution path
+    from model_catalog import get_catalog
+
+logger = logging.getLogger(__name__)
+
+#: Providers with no list-models API — their entries are always unprobed.
+UNPROBEABLE_PROVIDERS = frozenset({"fal", "recraft"})
+
+
+def probe_google_models(timeout=30):
+    """List model ids the Google API serves right now.
+
+    Returns {'status': 'ok', 'models': set[str]} or
+    {'status': 'skipped', 'reason': str}.
+    """
+    if not (os.environ.get("GOOGLE_API_KEY")
+            or os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")):
+        return {"status": "skipped", "reason": "no Google credentials configured"}
+    try:
+        from google import genai
+    except ImportError:
+        return {"status": "skipped", "reason": "google-genai SDK not installed"}
+    try:
+        client_kwargs = {}
+        api_key = os.environ.get("GOOGLE_API_KEY")
+        if api_key:
+            client_kwargs["api_key"] = api_key
+        client = genai.Client(**client_kwargs)
+        names = set()
+        for model in client.models.list():
+            name = getattr(model, "name", "") or ""
+            # API returns "models/gemini-..." — strip the resource prefix.
+            names.add(name.removeprefix("models/"))
+        return {"status": "ok", "models": names}
+    except Exception as exc:  # network/auth errors must not break verify
+        return {"status": "skipped", "reason": f"probe failed: {exc}"}
+
+
+def probe_openai_models(timeout=30):
+    """List model ids the OpenAI API serves right now."""
+    if not os.environ.get("OPENAI_API_KEY"):
+        return {"status": "skipped", "reason": "OPENAI_API_KEY not set"}
+    try:
+        from openai import OpenAI
+    except ImportError:
+        return {"status": "skipped", "reason": "openai SDK not installed"}
+    try:
+        client = OpenAI()
+        return {
+            "status": "ok",
+            "models": {m.id for m in client.models.list()},
+        }
+    except Exception as exc:
+        return {"status": "skipped", "reason": f"probe failed: {exc}"}
+
+
+def probe_ollama_models(endpoint="http://localhost:11434"):
+    """List locally installed Ollama model tags."""
+    import requests
+
+    try:
+        response = requests.get(f"{endpoint}/api/tags", timeout=5)
+        data = response.json()
+        return {
+            "status": "ok",
+            "models": {m["name"] for m in data.get("models", [])},
+        }
+    except Exception as exc:
+        return {"status": "skipped", "reason": f"Ollama not reachable: {exc}"}
+
+
+def _entry_upstream_match(entry, upstream):
+    """True when any name of this entry exists upstream.
+
+    Ollama catalog ids are tag-prefixes (``x/flux2-klein`` matches the
+    installed ``x/flux2-klein:9b``); other providers match exactly.
+    """
+    names = [entry["id"], *entry.get("aliases", [])]
+    if entry["provider"] == "ollama":
+        return any(
+            tag == name or tag.startswith(f"{name}:")
+            for name in names
+            for tag in upstream
+        )
+    return any(name in upstream for name in names)
+
+
+def classify_entries(catalog, probes):
+    """Classify every catalog entry against the probe results.
+
+    Args:
+        catalog: a ModelCatalog.
+        probes: {provider: {'status': 'ok'|'skipped', 'models': set, ...}}
+
+    Returns:
+        list of {model, provider, status, verdict[, note]}.
+    """
+    results = []
+    for entry in catalog.entries(status=None):
+        provider = entry["provider"]
+        probe = probes.get(provider)
+        if provider in UNPROBEABLE_PROVIDERS:
+            verdict = {"verdict": "unprobed",
+                       "note": "provider has no list-models API; catalog-driven"}
+        elif probe is None or probe.get("status") != "ok":
+            reason = (probe or {}).get("reason", "provider not probed")
+            verdict = {"verdict": "unprobed", "note": reason}
+        elif _entry_upstream_match(entry, probe["models"]):
+            if entry["status"] == "retired":
+                verdict = {"verdict": "verified",
+                           "note": "catalog says retired but upstream still "
+                                   "lists it — consider un-retiring"}
+            else:
+                verdict = {"verdict": "verified"}
+        else:
+            if entry["status"] == "retired":
+                verdict = {"verdict": "confirmed_retired"}
+            else:
+                verdict = {"verdict": "suspect_retired",
+                           "note": "not listed upstream — update the catalog "
+                                   "(or run refresh-models) before relying "
+                                   "on this model"}
+        results.append({
+            "model": entry["id"],
+            "provider": provider,
+            "status": entry["status"],
+            **verdict,
+        })
+    return results
+
+
+# Substring filters for candidate relevance per provider — the list APIs
+# return every model family; only image/vision-relevant ones are useful
+# candidates for this pipeline.
+_CANDIDATE_FILTERS = {
+    "google": ("image", "imagen", "flash", "pro"),
+    "openai": ("image", "dall-e"),
+    "ollama": ("x/",),
+}
+
+
+def find_new_candidates(catalog, probes):
+    """Upstream models no catalog entry covers, filtered to relevant kinds.
+
+    Candidates are NOT routable: existence is provable, price is not. They
+    surface for the operator to add to the catalog (or a local-config
+    override) before use.
+    """
+    known = set()
+    for entry in catalog.entries(status=None):
+        known.add(entry["id"])
+        known.update(entry.get("aliases", []))
+
+    candidates = {}
+    for provider, probe in probes.items():
+        if probe.get("status") != "ok":
+            continue
+        filters = _CANDIDATE_FILTERS.get(provider, ())
+        found = []
+        for name in sorted(probe["models"]):
+            if any(name == k or name.startswith(f"{k}:") for k in known):
+                continue
+            if filters and not any(f in name for f in filters):
+                continue
+            found.append(name)
+        if found:
+            candidates[provider] = found
+    return candidates
+
+
+def probe_report(catalog=None, probes=None):
+    """Full live-discovery report for /verify and refresh-models.
+
+    Args:
+        catalog: ModelCatalog (defaults to the effective loaded catalog).
+        probes: pre-computed probe results (tests / callers that already
+            probed); defaults to probing google + openai + ollama live.
+
+    Returns:
+        {catalog_version, probes: {provider: status/reason},
+         entries: [classification...], new_candidates: {provider: [id...]}}
+    """
+    catalog = catalog or get_catalog()
+    if probes is None:
+        probes = {
+            "google": probe_google_models(),
+            "openai": probe_openai_models(),
+            "ollama": probe_ollama_models(),
+        }
+    return {
+        "catalog_version": catalog.version,
+        "probes": {
+            provider: {k: v for k, v in probe.items() if k != "models"}
+            for provider, probe in probes.items()
+        },
+        "entries": classify_entries(catalog, probes),
+        "new_candidates": find_new_candidates(catalog, probes),
+    }


### PR DESCRIPTION
## Summary

Implements EPIC #125 end-to-end across its four phases (#126, #127, #128, #129): a single schema-validated **model catalog** replaces the six independently-drifting hardcoded model/cost/capability tables, catalog updates become **release-decoupled** (a data commit to main, picked up by `refresh-models`), and **live provider probes** verify entries and surface new-model candidates.

Closes #126, closes #127, closes #128, closes #129. Fixes #121, fixes #122, fixes #123. Unblocks #124 (the `LocalBackend` seam fixes noted there are included; the MLX backend itself remains open).

## Phase 1 — catalog + loader (#126)

- `model-catalog/model-catalog.json` + `model-catalog.schema.json` (Draft-07) — canonical, vendored byte-identically into jack-tar-cloud and jack-tar-deckhand with copy-identity tests.
- `model_catalog.py` loader: three-layer precedence (shipped → cached remote at `~/.jack-tar/` → `local-config.json` `model_catalog` overrides), alias resolution, retired→replacement substitution, role selection (`image_gen`, `vlm_json`, `icon`, `local_draft`), all pricing shapes (flat / per-resolution / dual-backend / size×quality / per-tier / tiered-megapixel / token rates), env-overridable Recraft 4K upscale chain.
- The standing bugs land as **data**: #123's retired `-preview` ids are aliases with `status: retired` + `replacement`; #122's thinking-model failure is a `thinking` quirk excluding `gemini-2.5-flash` from the `vlm_json` role (default: `gemini-3.5-flash`, verified 2026-07-15).
- **#121 does not reproduce**: `ImageConfig(image_size='1K')` works on google-genai 2.11.0 (`image_size` and `aspect_ratio` are distinct, coexisting fields — verified in a clean venv). The deck-build failure was almost certainly the retired model names. The catalog records `sdk.config_field: image_size` as ground truth; evidence comment to follow on #121.

## Phase 2 — readers derive from the catalog (#127)

Every table in `generate_cloud_image.py`, `generate_cloud_icon.py`, `provider_discovery.py`, `image_router.py` (capability mirror AND `ROUTING_MATRIX` costs), `cascade.py` `TIER_COSTS`, `budget_tracker.py`, `prompt_translator.py`, `actual_cost_calculator.py` (token rates moved into the catalog), plus the `paperbanana_dispatch` / `iterate_slide_dispatch` / `render_funnel` model defaults, now derives from the catalog at import time. Consequences:

- The `test_cost_reconciliation` / `test_router_capability_drift` drift class is structurally impossible — both sides derive from one file (tests retained as regression nets).
- `generate_google` canonicalises aliases, so callers holding `-preview` ids reach the id the live API accepts today.
- budget_tracker's four-way FLUX price divergence and stale `gpt-image-1-mini` ids are gone.
- All SKILL.md / agent / CLAUDE.md docs updated; `docs/model-catalog.md` is generated by `model-catalog/catalog_markdown.py` with a CI drift check (SmartArt-catalog pattern); a stale-id guard walks every plugin's src+skills tree.

## Phase 3 — release-decoupled refresh (#128)

`model_catalog_refresh.py` + `/jack-tar-cloud:refresh-models`: fetch from raw main (env-overridable URL) → validate structure + `min_loader_version` **before** touching the cache → **operator price-diff gate** (F10 economics — any price change requires explicit go-ahead; never silent/auto) → atomic swap with `.prev` rollback. `/verify` gains a non-blocking staleness hint. A bad remote can never brick an install: the loader independently re-validates the cache and falls back to shipped.

## Phase 4 — live discovery (#129)

`model_probe.py`: Google/OpenAI list-models + Ollama tags probes (graceful skip without credentials), classification (`verified` / `suspect_retired` / `confirmed_retired` / `unprobed`), and `new_candidates` — reported but **not routable** until priced in the catalog (explicit operator opt-in). Wired into `/verify` as an on-request step. Includes the #124-noted seam fixes (`backend=local_backend.provider`, `<provider>_local` manifest mapping).

## Tests

| Suite | Result |
|---|---|
| jack-tar-cloud | 188 passed (73 new: loader 43, refresh 14, probe 16) |
| jack-tar-deckhand | 441 passed |
| integration | 84 passed (17 new: copy-identity, schema, doc drift, stale-id guard, price agreement) |
| superpower-bridge | 397 passed |
| ollama | 27 passed |

Test expectation updates: assertions pinning the retired `-preview` ids and the old `gemini-2.5-flash` VLM default were updated to the canonical/current ids — that is the fix under test, not a behavioural regression.

## Notes / deviations

- **Root `src/` cloud modules** remain a generation behind the plugin copies (pre-existing; CI does not exercise root `tests/`). The canonical catalog artifacts live at top level; wholesale root-module sync is proposed as follow-up housekeeping rather than churned here.
- **Live refresh URL** becomes functional the moment this merges (the canonical file must exist on `main`); the mechanism is fully covered by faked-transport tests meanwhile.
- Matrix cost hints for FAL 2K and Imagen-Developer 2K now compute from the catalog and are slightly more accurate than the old rounded literals ($0.078 vs $0.075; backend-aware Imagen pricing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
