### PR TITLE
feat(deckhand): /annotate-figure — perfect-text labels over generated or external images (#142)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -45,7 +45,7 @@
       "name": "jack-tar-deckhand",
       "description": "Full presentation pipeline \u2014 brand, style, narrative, images, SmartArt, assembly, QA + academic-figure rendering (optional paperbanana CLI; local-first Ollama tier + local_only zero-spend mode, #119) + /iterate-slide single-slide critique-driven refinement + full_bleed image-is-the-slide strategy + creative vision renderer (#105) + creative_vision GA: per-slide cost surface, Creative Sprint phase, per-iteration operator gate, deck-level creative anchors (#113)",
       "source": "./plugins/jack-tar-deckhand",
-      "version": "1.8.0"
+      "version": "1.9.0"
     },
     {
       "name": "jack-tar-superpower-bridge",

--- a/docs/feature-proposals/142-annotate-figure.md
+++ b/docs/feature-proposals/142-annotate-figure.md
@@ -1,0 +1,111 @@
+# Feature Proposal: Programmatic figure annotation — perfect labels over generated or external images
+
+**Proposal Number:** 142 ([issue #142](https://github.com/SteveGJones/jack-tar-deckhand/issues/142))
+**Status:** In Progress
+**Author:** Claude (AI Agent), directed by operator
+**Created:** 2026-07-17
+**Target Branch:** `feat/annotate-figure`
+
+---
+
+## Executive Summary
+
+Add an annotation-overlay capability: render a diagram-class image WITHOUT
+labels (or accept an operator-supplied EXTERNAL image), obtain anchor
+coordinates for the parts to label via a vision pass, then draw leader
+lines and typeset labels programmatically. Text is perfect by
+construction; pointer correctness becomes a vision-coordinate problem
+instead of a diffusion problem. PoC (2026-07-17): blind 10/10 on the
+benchmark's B5 rubric at $0, vs a cloud TECH ceiling of 8.7 (PR #138).
+
+## Motivation
+
+The 2026-07-17 benchmark's central finding: exact labels + correct
+structure is where every model — local and cloud — is weakest. Diffusion
+models draw scenes well and text/pointers badly. Splitting the work
+(model draws, code writes) dissolves the weakness. Accepting external
+images extends the pipeline to imagery we did not generate (photos,
+screenshots, product shots, existing diagrams).
+
+### User Stories
+
+- As an operator, I want labeled technical figures whose text is always
+  perfectly spelled, at local-draft cost.
+- As an operator, I want to hand the pipeline an existing image and get
+  it labeled the same way.
+- As a developer, I want the overlay engine testable without any model
+  call (pure function of image + anchors + labels).
+
+## Design (v1)
+
+1. **Module** `plugins/jack-tar-deckhand/src/annotate_figure.py`:
+   - `validate_anchors(payload) -> dict` — validates the vision pass's
+     JSON contract `{"anchors": {label: [x, y]}, ...}` (normalized 0-1
+     floats; labels non-empty unique strings); raises with actionable
+     messages.
+   - `place_labels(anchors, image_size, *, margin_band=0.12) -> dict` —
+     automatic occlusion-avoiding placement: each label is pushed outward
+     from its anchor into the nearest margin band (top/bottom/left/right
+     by anchor proximity), with collision resolution by vertical/
+     horizontal stacking within a band. Deterministic.
+   - `annotate(image_path, labels, out_path, *, font_size=26, style
+     opts) -> Path` — PIL: leader line anchor→label, terminus dot, white
+     label box with border, typeset text. `labels` is either
+     `{name: [x,y]}` (auto placement) or `{name: {"anchor": [x,y],
+     "label_pos": [x,y]}}` (explicit override).
+   - No model calls in the module — pure imaging. Font fallback chain
+     (Helvetica → DejaVu → PIL default).
+2. **Skill** `/jack-tar-deckhand:annotate-figure` orchestrates:
+   - Source: `--image <path>` (external, F10-free) OR a prompt → local
+     draft render with a LABEL-STRIPPED prompt transform (drop quoted
+     label directives; append "No text, no labels, no annotations of any
+     kind."), via the standard local-draft ladder (klein/z-image).
+   - Anchor pass: dispatch image-reviewer/general-purpose with the
+     structured JSON contract from the PoC (normalized coords + bow-side
+     style sanity fields where applicable); validate via the module.
+   - Overlay via the module; then a review pass that verifies ANCHOR
+     CORRECTNESS ONLY (text is axiomatic) — one refine loop re-querying
+     coordinates for any mispointed label.
+   - Output: annotated PNG path + manifest-style summary (source,
+     anchors, review verdict).
+3. **Out of scope for v1** (tracked in #142): PPTX-native text-box
+   variant, strategy-map auto-routing, blank-zone generation variant.
+
+### Acceptance Criteria
+
+Given a prompt describing a labeled diagram
+When `/annotate-figure` runs with local rendering
+Then the output image contains every requested label spelled exactly
+(by construction) with leader lines the reviewer verifies as anchored
+correctly, at $0 cloud spend.
+
+Given an external image path and a label list
+When `/annotate-figure` runs
+Then the same overlay flow applies with no generation step.
+
+## Success Criteria
+
+- [ ] Module unit tests green (validation, placement determinism +
+      collision handling, drawing, external-source path)
+- [ ] E2E: ship PoC reproduced through the skill flow
+- [ ] deckhand 1.8.0 → 1.9.0; marketplace lockstep; CI green
+- [ ] PR merged referencing #142
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Vision anchor errors (wrong part) | Mislabeled figure | Anchor-verification review + one refine loop; operator gate remains final |
+| Label placement occludes content | Cluttered figure | Margin-band placement + collision stacking; explicit label_pos override |
+| Label-stripped prompts still render stray text | Double text | "No text" negative in transform + reviewer flags stray text |
+| Process note | — | Compressed pipeline (no separate Opus design/adversarial review) — PoC validated the core; recorded here as a deliberate deviation |
+
+## Changes Made
+
+| Action | File |
+|--------|------|
+| Create | `plugins/jack-tar-deckhand/src/annotate_figure.py` |
+| Create | `plugins/jack-tar-deckhand/tests/test_annotate_figure.py` |
+| Create | `plugins/jack-tar-deckhand/skills/annotate-figure/SKILL.md` |
+| Modify | plugin.json + marketplace (1.9.0), plugin CLAUDE.md, root CLAUDE.md |
+| Create | this proposal + `retrospectives/142-annotate-figure.md` |

--- a/plugins/jack-tar-deckhand/.claude-plugin/plugin.json
+++ b/plugins/jack-tar-deckhand/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "jack-tar-deckhand",
   "description": "Full presentation pipeline — brand, style, narrative, images, SmartArt, assembly, QA + academic-figure rendering (optional paperbanana CLI) + /iterate-slide single-slide critique-driven refinement + full_bleed image-is-the-slide strategy + creative vision renderer (#105) + creative_vision GA: per-slide cost surface, Creative Sprint phase, per-iteration operator gate, deck-level creative anchors (#113)",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "author": {
     "name": "Steve Jones"
   },

--- a/plugins/jack-tar-deckhand/CLAUDE.md
+++ b/plugins/jack-tar-deckhand/CLAUDE.md
@@ -31,6 +31,7 @@ Without engine plugins, the pipeline produces text-only slides with placeholder 
 | `/deck-assembler` | Assemble .pptx — routes to PptxGenJS (standard) or python-pptx (template mode) |
 | `/deck-qa` | Run 25 automated anti-pattern checks |
 | `/iterate-slide` | Single-slide critique-driven refinement via paperbanana `--continue-run` (three modes: auto / enumerate / draft) |
+| `/annotate-figure` | Perfect-text labeled figures: label-free render (or external image) + vision anchors + programmatic overlay |
 | `/verify` | Check pipeline readiness and engine plugin availability |
 
 ## Quick Start

--- a/plugins/jack-tar-deckhand/skills/annotate-figure/SKILL.md
+++ b/plugins/jack-tar-deckhand/skills/annotate-figure/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: annotate-figure
+description: Produce a labeled figure with PERFECT text — render a label-free image locally (or take an external image) then overlay leader lines and typeset labels programmatically from vision-derived anchor coordinates. Text is correct by construction; only pointer placement is reviewed.
+allowed-tools: Read, Bash(python3 *), Bash(ls *), Task
+---
+
+# Annotate Figure
+
+Split the work between what image models do well (drawing scenes and objects) and what code does perfectly (text and lines). Never ask a diffusion model to render the labels.
+
+Do not `Read` PNG/JPG/image files directly — all image inspection goes through the `jack-tar-deckhand:image-reviewer` or `general-purpose` subagent (issue #76 discipline).
+
+## Inputs
+
+- **Either** `--image <path>` — an external image supplied by the operator (photo, screenshot, existing diagram; no generation, no spend), **or** a scene description to render locally.
+- A **label list**: the exact strings to place (e.g., `Mast, Sail, Hull, Rudder, Bow, Stern`) and, per label, what it should point at.
+
+## Procedure
+
+### 1. Source the base image
+
+- **External image**: use the given path as-is. Record `source: external`.
+- **Generate**: transform the prompt to be LABEL-FREE — remove every quoted label directive and any "labelled/labeled X" phrasing, describe the parts that must be *visible* instead ("rudder visible at the rear below the waterline"), and append: `No text, no labels, no leader lines, no annotations of any kind.` Render via the standard local draft ladder (`local-config.json` model preferences; klein/z-image per the catalog `local_draft` role) at 1024×576 unless told otherwise. $0; the F10 gate is untouched (no paid tier is involved unless the operator later escalates the BASE image).
+
+### 2. Anchor pass (vision → structured JSON)
+
+Dispatch `jack-tar-deckhand:image-reviewer` (or `general-purpose` for complex scenes) with the image path and this contract — labels filled in from the request:
+
+> Return NORMALIZED coordinates (x, y as fractions of width/height, 0–1, origin top-left) for the exact point a leader line should TOUCH for each of: <label>: <what it points at>, … Also give a one-line description of the depicted subject and any orientation facts needed to sanity-check (e.g. which side is the front). Output ONLY JSON: `{"description": "...", "anchors": {"<Label>": [x, y], ...}}`
+
+Validate the response with `annotate_figure.validate_anchors` (module below); on validation failure, re-dispatch once with the error message included.
+
+### 3. Overlay (perfect text, deterministic)
+
+```bash
+python3 - <<'PY'
+import sys; sys.path.insert(0, '<PLUGIN_ROOT>/src')
+from annotate_figure import annotate
+annotate('<base image>', {<label>: [x, y], ...}, '<out path>')
+PY
+```
+
+Automatic occlusion-avoiding placement puts each label in the nearest margin band; pass explicit `{"anchor": [...], "label_pos": [...]}` per label only when the reviewer flags a placement problem.
+
+### 4. Anchor-verification review (pointers only — text is axiomatic)
+
+Dispatch the reviewer on the ANNOTATED image: "For each labeled leader line, does it touch the anatomically/semantically correct part? Leader lines are dark with a white casing halo — over dark image regions look for the casing, and zoom before declaring a leader absent. Do not review spelling (programmatic). Flag any label box occluding important content and any stray text baked into the base image." One refine loop allowed: re-query coordinates for mispointed labels (include the reviewer's correction hints), re-run the overlay. More than one failed loop → surface to the operator with the best attempt (F12 stance: reviewer verdicts advisory; the operator certifies).
+
+### 5. Deliver
+
+Report: output path, source (external | generated + model + seed), anchor JSON used, review verdict. In deck context, hand the annotated PNG to the assembler like any figure asset.
+
+## Why this exists (evidence)
+
+The 2026-07-17 benchmark (docs/spikes/2026-07-17-mlx-model-benchmark/) showed exact labels + pointer placement is the universal weakness — best local 5.8/10, cloud ceiling 8.7/10 on technical figures. This flow's PoC scored a blind 10/10 on the same rubric at $0: spelling cannot fail, and pointer accuracy became a vision-coordinate problem with a verification loop. External-image support extends the pipeline to imagery it did not generate.

--- a/plugins/jack-tar-deckhand/src/annotate_figure.py
+++ b/plugins/jack-tar-deckhand/src/annotate_figure.py
@@ -1,0 +1,522 @@
+"""Programmatic annotation overlay for diagram-class images (feature #142).
+
+Draws leader lines, terminus dots, and typeset labels over an image whose
+anchor coordinates were supplied by a vision pass (or by the caller
+directly). Text is perfect by construction — labels come from a Python
+string, never from a diffusion model — so this module only has to get the
+POINTING right, not the spelling.
+
+No model calls, no network access. Pure PIL imaging. This keeps the
+overlay engine testable as a pure function of (image, anchors, labels).
+
+See docs/feature-proposals/142-annotate-figure.md for the design.
+"""
+
+import os
+
+from PIL import Image, ImageDraw, ImageFont
+
+# ---------------------------------------------------------------------------
+# Drawing style constants
+# ---------------------------------------------------------------------------
+
+LEADER_LINE_WIDTH = 3
+LEADER_LINE_COLOR = (20, 20, 20)
+LEADER_CASING_EXTRA = 4   # casing line width = line_width + this
+TERMINUS_DOT_RADIUS = 4
+TERMINUS_DOT_COLOR = (20, 20, 20)
+DOT_CASING_EXTRA = 3      # casing ring radius = dot_radius + this
+LABEL_BOX_FILL = (255, 255, 255)
+LABEL_BOX_BORDER = (20, 20, 20)
+LABEL_BOX_BORDER_WIDTH = 2
+LABEL_BOX_PADDING = 8
+LABEL_TEXT_COLOR = (20, 20, 20)
+DEFAULT_FONT_SIZE = 26
+
+# Font fallback chain: Helvetica (macOS) -> DejaVu Sans (Linux/most systems) -> PIL default
+_FONT_CANDIDATES = [
+    '/System/Library/Fonts/Helvetica.ttc',
+    '/System/Library/Fonts/Supplemental/Helvetica.ttc',
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
+]
+
+DEFAULT_MARGIN_BAND = 0.12
+
+_BANDS = ('top', 'bottom', 'left', 'right')
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _load_font(font_size):
+    """Load a font via the fallback chain: Helvetica -> DejaVu -> PIL default.
+
+    Returns a PIL ImageFont instance. Never raises — falls all the way
+    back to ImageFont.load_default() if no TrueType font is found.
+    """
+    for candidate in _FONT_CANDIDATES:
+        if os.path.exists(candidate):
+            try:
+                return ImageFont.truetype(candidate, font_size)
+            except Exception:
+                continue
+    try:
+        # Pillow >= 9.2 supports a size arg on the default bitmap font
+        return ImageFont.load_default(size=font_size)
+    except TypeError:
+        return ImageFont.load_default()
+
+
+def _nearest_band(x, y):
+    """Determine which margin band (top/bottom/left/right) an anchor is closest to.
+
+    Distance to each of the four image edges is compared; the nearest edge
+    wins. x, y are normalized 0-1 floats.
+    """
+    distances = {
+        'top': y,
+        'bottom': 1.0 - y,
+        'left': x,
+        'right': 1.0 - x,
+    }
+    return min(distances, key=distances.get)
+
+
+def _segment_box_entry(p0, p1, box):
+    """Point where the segment p0 -> p1 first enters an axis-aligned box.
+
+    Used to terminate a leader line at the edge of its own label box
+    nearest the anchor, instead of drawing into the box interior.
+    Slab-method clip: p1 is expected to be inside the box (the label
+    centre); if the segment never reaches the box (degenerate input),
+    p1 is returned unchanged as a safe fallback.
+
+    Args:
+        p0: (x, y) segment start in pixels (the anchor).
+        p1: (x, y) segment end in pixels (the label box centre).
+        box: (left, top, right, bottom) rect in pixels.
+
+    Returns:
+        (x, y) tuple: the entry point on the box perimeter (or p0 if the
+        anchor is already inside the box).
+    """
+    x0, y0 = p0
+    x1, y1 = p1
+    dx, dy = x1 - x0, y1 - y0
+    t_min, t_max = 0.0, 1.0
+
+    for delta, lo, hi, origin in ((dx, box[0], box[2], x0),
+                                  (dy, box[1], box[3], y0)):
+        if delta == 0:
+            if origin < lo or origin > hi:
+                return p1  # parallel and outside the slab — degenerate
+        else:
+            t_a = (lo - origin) / delta
+            t_b = (hi - origin) / delta
+            if t_a > t_b:
+                t_a, t_b = t_b, t_a
+            t_min = max(t_min, t_a)
+            t_max = min(t_max, t_b)
+
+    if t_min > t_max:
+        return p1  # segment never enters the box — degenerate
+
+    t = max(0.0, t_min)  # anchor inside box -> zero-length leader
+    return (x0 + t * dx, y0 + t * dy)
+
+
+def _draw_leader(draw, p0, p1, color, width):
+    """Draw a leader line twice with a 1px offset to mitigate aliasing.
+
+    Near-horizontal (and near-vertical) lines render visually fainter in
+    PIL's non-anti-aliased line rasteriser; the second pass, offset 1px
+    along the line's minor axis, thickens the perceived stroke evenly.
+    """
+    draw.line([p0, p1], fill=color, width=width)
+    if abs(p1[0] - p0[0]) >= abs(p1[1] - p0[1]):
+        off_x, off_y = 0, 1  # near-horizontal: offset vertically
+    else:
+        off_x, off_y = 1, 0  # near-vertical: offset horizontally
+    draw.line(
+        [(p0[0] + off_x, p0[1] + off_y), (p1[0] + off_x, p1[1] + off_y)],
+        fill=color, width=width,
+    )
+
+
+def _band_target_point(band, x, y, margin_band):
+    """Project an anchor's (x, y) onto its band's placement line.
+
+    The label is pushed to the middle of the outer margin_band fraction on
+    the chosen side, preserving the anchor's position along the
+    perpendicular axis (e.g. for the top band, x is preserved and y is
+    pushed to the vertical midpoint of the top margin strip).
+    """
+    half_band = margin_band / 2.0
+    if band == 'top':
+        return x, half_band
+    if band == 'bottom':
+        return x, 1.0 - half_band
+    if band == 'left':
+        return half_band, y
+    # band == 'right'
+    return 1.0 - half_band, y
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def validate_anchors(payload):
+    """Validate the vision pass's anchor JSON contract.
+
+    Expected shape: {"anchors": {label_name: [x, y], ...}, ...extra keys
+    are passed through untouched}. Coordinates must be normalized floats
+    in [0, 1]. Labels must be non-empty, unique strings.
+
+    Args:
+        payload: dict from the vision pass (or hand-authored).
+
+    Returns:
+        dict: the validated payload (same object, not a copy).
+
+    Raises:
+        ValueError: with an actionable message identifying exactly what
+            is wrong (missing key, wrong type, out-of-range coordinate,
+            duplicate/empty label name).
+    """
+    if not isinstance(payload, dict):
+        raise ValueError(
+            f"Anchor payload must be a dict, got {type(payload).__name__}"
+        )
+
+    if 'anchors' not in payload:
+        raise ValueError(
+            "Anchor payload missing required 'anchors' key. "
+            "Expected shape: {\"anchors\": {label: [x, y], ...}}"
+        )
+
+    anchors = payload['anchors']
+    if not isinstance(anchors, dict):
+        raise ValueError(
+            f"'anchors' must be a dict of {{label: [x, y]}}, got {type(anchors).__name__}"
+        )
+
+    if not anchors:
+        raise ValueError("'anchors' dict is empty — at least one anchor is required")
+
+    seen_labels = set()
+    for label, coord in anchors.items():
+        if not isinstance(label, str) or not label.strip():
+            raise ValueError(
+                f"Anchor label must be a non-empty string, got {label!r}"
+            )
+        # Case-sensitive exact-match duplicate check: dict keys are already
+        # unique by construction, but guard against caller-constructed
+        # payloads built by hand (e.g. list-of-tuples coerced to dict) where
+        # whitespace-only variants could otherwise slip through as distinct.
+        normalized = label.strip()
+        if normalized in seen_labels:
+            raise ValueError(f"Duplicate anchor label: '{label}'")
+        seen_labels.add(normalized)
+
+        if not isinstance(coord, (list, tuple)) or len(coord) != 2:
+            raise ValueError(
+                f"Anchor '{label}' coordinate must be a 2-element [x, y] list, got {coord!r}"
+            )
+
+        x, y = coord
+        for axis_name, axis_val in (('x', x), ('y', y)):
+            if not isinstance(axis_val, (int, float)) or isinstance(axis_val, bool):
+                raise ValueError(
+                    f"Anchor '{label}' {axis_name} coordinate must be a number, got {axis_val!r}"
+                )
+            if not (0.0 <= axis_val <= 1.0):
+                raise ValueError(
+                    f"Anchor '{label}' {axis_name} coordinate must be normalized in [0, 1], "
+                    f"got {axis_val}. Coordinates must be fractions of image width/height, "
+                    f"not pixels."
+                )
+
+    return payload
+
+
+def place_labels(anchors, image_size, *, margin_band=DEFAULT_MARGIN_BAND):
+    """Automatically place labels in the nearest margin band, avoiding collisions.
+
+    Each anchor is assigned to the margin band (top/bottom/left/right) it
+    is nearest to, then pushed outward to that band at the anchor's
+    projected position. Labels landing in the same band are stacked along
+    the band (vertically for left/right bands, horizontally for top/bottom
+    bands) to avoid overlapping label boxes, AND staggered along the
+    perpendicular axis (alternating offsets within the band strip) so that
+    leader lines from stacked labels do not overlap each other's boxes.
+    Stacking order follows the anchors' positions along the band's run
+    axis, tie-broken by label name — deterministic: the same input always
+    produces the same output.
+
+    Args:
+        anchors: dict of {label: [x, y]} normalized coordinates (already
+            validated by validate_anchors).
+        image_size: (width, height) in pixels — used to convert the
+            normalized stacking offsets into a genuinely non-overlapping
+            spread regardless of aspect ratio.
+        margin_band: fraction of image extent reserved as the outer margin
+            strip on each side (default 0.12 — matches the proposal).
+
+    Returns:
+        dict: {label: {"anchor": [x, y], "label_pos": [x, y]}} — both
+        normalized 0-1 floats, ready for annotate(). Deterministic: the
+        same anchors + image_size always produce the same label_pos.
+    """
+    width, height = image_size
+    if width <= 0 or height <= 0:
+        raise ValueError(f"image_size must be positive, got {image_size}")
+
+    # Assign each label to its nearest band.
+    by_band = {band: [] for band in _BANDS}
+    for label, (x, y) in anchors.items():
+        band = _nearest_band(x, y)
+        by_band[band].append(label)
+
+    placements = {}
+    for band, labels in by_band.items():
+        # Deterministic stacking order: by anchor position along the band's
+        # run axis (x for top/bottom, y for left/right), tie-broken by
+        # label name. Spatial ordering keeps each leader short and stops
+        # leaders crossing sibling slots; the name tie-break keeps the
+        # result independent of dict insertion order.
+        run_axis = 0 if band in ('top', 'bottom') else 1
+        labels_sorted = sorted(labels, key=lambda lbl: (anchors[lbl][run_axis], lbl))
+        n = len(labels_sorted)
+        for i, label in enumerate(labels_sorted):
+            x, y = anchors[label]
+            target_x, target_y = _band_target_point(band, x, y, margin_band)
+
+            # Stack labels sharing a band along the band's run direction so
+            # their boxes don't collide, AND stagger them along the
+            # perpendicular axis (alternating a near-edge offset with the
+            # band's inner boundary) so leaders from stacked labels do not
+            # overlap each other's boxes.
+            #
+            # Top/bottom bands spread across the central run span (boxes
+            # are wide, so generous horizontal separation is needed);
+            # left/right bands instead stack in a narrow window centred on
+            # the anchors' centroid, spaced by an estimated box height —
+            # this keeps each leader short so it cannot travel past a
+            # sibling's (horizontally wide) box.
+            if n > 1:
+                if band in ('top', 'bottom'):
+                    span_lo, span_hi = margin_band, 1.0 - margin_band
+                    step = (span_hi - span_lo) / (n + 1)
+                    slot = span_lo + step * (i + 1)
+                else:
+                    est_step = 60.0 / height  # est. box height + gap, normalized
+                    centroid = sum(anchors[lbl][1] for lbl in labels_sorted) / n
+                    half_window = (n - 1) / 2.0 * est_step
+                    win_lo = margin_band + half_window
+                    win_hi = 1.0 - margin_band - half_window
+                    if win_lo <= win_hi:
+                        centroid = min(max(centroid, win_lo), win_hi)
+                        slot = centroid + (i - (n - 1) / 2.0) * est_step
+                    else:
+                        # Too many labels for a centred window — fall back
+                        # to an even spread across the run span.
+                        step = (1.0 - 2 * margin_band) / (n + 1)
+                        slot = margin_band + step * (i + 1)
+
+                # Perpendicular stagger: even slots near the edge, odd
+                # slots at the band's inner boundary.
+                perp = margin_band / 4.0 if i % 2 == 0 else margin_band
+                if band == 'top':
+                    target_x, target_y = slot, perp
+                elif band == 'bottom':
+                    target_x, target_y = slot, 1.0 - perp
+                elif band == 'left':
+                    target_x, target_y = perp, slot
+                else:  # right
+                    target_x, target_y = 1.0 - perp, slot
+
+            placements[label] = {
+                'anchor': [x, y],
+                'label_pos': [target_x, target_y],
+            }
+
+    return placements
+
+
+def annotate(image_path, labels, out_path, *, font_size=DEFAULT_FONT_SIZE,
+             line_width=LEADER_LINE_WIDTH, line_color=LEADER_LINE_COLOR,
+             dot_radius=TERMINUS_DOT_RADIUS, box_fill=LABEL_BOX_FILL,
+             box_border=LABEL_BOX_BORDER, box_border_width=LABEL_BOX_BORDER_WIDTH,
+             box_padding=LABEL_BOX_PADDING, text_color=LABEL_TEXT_COLOR,
+             casing_color=None, casing_width=None):
+    """Draw leader lines, terminus dots, and boxed labels onto an image.
+
+    For each label, draws: a small filled dot at the anchor point, a
+    straight leader line from the anchor towards the label position —
+    terminating at the edge of its OWN label box nearest the anchor
+    (never drawn into the box interior) — and a white box with a dark
+    border containing the typeset label text centred at the label
+    position. All leader lines are drawn BEFORE any label boxes/text, so
+    boxes always sit on top of any leader that passes beneath them.
+
+    Leaders and dots are drawn with cartographic CASING: a light underlay
+    line (line_width + 4 wide) beneath each dark leader, and a light ring
+    (dot_radius + 3) beneath each terminus dot, so lines and dots stay
+    readable against dark image regions. All casing underlays are drawn
+    before any dark cores, so one leader's casing never cuts another's
+    core line.
+
+    Args:
+        image_path: Path to the source image (diagram, generated or
+            external). Must exist.
+        labels: dict, either
+            {name: [x, y]} — auto placement (fed through place_labels()
+                using the image's own dimensions), or
+            {name: {"anchor": [x, y], "label_pos": [x, y]}} — explicit
+                override, e.g. from a prior place_labels() call or a
+                caller-specified position.
+            Both forms use normalized 0-1 coordinates. Mixing forms
+            within a single dict is allowed per-key.
+        out_path: Where to save the annotated PNG.
+        font_size: Point size for label text (default 26, per the PoC).
+        line_width: Leader line stroke width in pixels (default 3).
+        line_color: RGB tuple for the leader line and terminus dot.
+        dot_radius: Terminus dot radius in pixels (default 4).
+        box_fill: RGB tuple for the label box background (default white).
+        box_border: RGB tuple for the label box border (default dark).
+        box_border_width: Label box border stroke width in pixels.
+        box_padding: Padding in pixels between label text and its box edge.
+        text_color: RGB tuple for the label text.
+        casing_color: RGB tuple for the leader/dot casing underlay.
+            Default None -> uses box_fill (white), matching the label
+            boxes so all overlay furniture reads as one system.
+        casing_width: Casing line width in pixels. Default None ->
+            line_width + 4. Pass 0 to disable casing entirely (dots then
+            also lose their rings).
+
+    Returns:
+        str: out_path, the path to the annotated PNG.
+
+    Raises:
+        FileNotFoundError: If image_path does not exist.
+        ValueError: If labels is empty or malformed.
+    """
+    if not os.path.exists(image_path):
+        raise FileNotFoundError(f'Image not found: {image_path}')
+
+    if not labels:
+        raise ValueError("'labels' must be a non-empty dict")
+
+    with Image.open(image_path) as src:
+        img = src.convert('RGB')
+
+    width, height = img.size
+
+    # Split labels into those needing auto-placement vs. explicit override.
+    explicit = {}
+    auto_anchors = {}
+    for name, spec in labels.items():
+        if isinstance(spec, dict):
+            if 'anchor' not in spec or 'label_pos' not in spec:
+                raise ValueError(
+                    f"Label '{name}' explicit spec must have both 'anchor' and "
+                    f"'label_pos' keys, got {list(spec.keys())}"
+                )
+            explicit[name] = spec
+        elif isinstance(spec, (list, tuple)) and len(spec) == 2:
+            auto_anchors[name] = spec
+        else:
+            raise ValueError(
+                f"Label '{name}' must be either [x, y] (auto placement) or "
+                f"{{'anchor': [x, y], 'label_pos': [x, y]}} (explicit override), "
+                f"got {spec!r}"
+            )
+
+    resolved = dict(explicit)
+    if auto_anchors:
+        resolved.update(place_labels(auto_anchors, (width, height)))
+
+    font = _load_font(font_size)
+    draw = ImageDraw.Draw(img)
+
+    # Precompute all geometry first: box rects, text metrics, and the
+    # leader's termination point on its own box edge nearest the anchor.
+    geometry = []
+    for name in sorted(resolved):
+        spec = resolved[name]
+        ax, ay = spec['anchor']
+        lx, ly = spec['label_pos']
+
+        anchor_px = (ax * width, ay * height)
+        label_px = (lx * width, ly * height)
+
+        text_bbox = draw.textbbox((0, 0), name, font=font)
+        text_w = text_bbox[2] - text_bbox[0]
+        text_h = text_bbox[3] - text_bbox[1]
+
+        lx_px, ly_px = label_px
+        box_rect = (
+            lx_px - text_w / 2 - box_padding,
+            ly_px - text_h / 2 - box_padding,
+            lx_px + text_w / 2 + box_padding,
+            ly_px + text_h / 2 + box_padding,
+        )
+        leader_end = _segment_box_entry(anchor_px, label_px, box_rect)
+        geometry.append((name, anchor_px, label_px, box_rect, text_bbox, leader_end))
+
+    resolved_casing_color = casing_color if casing_color is not None else box_fill
+    resolved_casing_width = (casing_width if casing_width is not None
+                             else line_width + LEADER_CASING_EXTRA)
+
+    # Pass 1a: ALL casing underlays (light lines + dot rings) first, so
+    # one leader's casing never cuts another leader's dark core.
+    if resolved_casing_width > 0:
+        ring_radius = dot_radius + DOT_CASING_EXTRA
+        for name, anchor_px, label_px, box_rect, text_bbox, leader_end in geometry:
+            _draw_leader(draw, anchor_px, leader_end,
+                         resolved_casing_color, resolved_casing_width)
+
+            ax_px, ay_px = anchor_px
+            draw.ellipse(
+                [ax_px - ring_radius, ay_px - ring_radius,
+                 ax_px + ring_radius, ay_px + ring_radius],
+                fill=resolved_casing_color,
+            )
+
+    # Pass 1b: ALL dark leader cores + terminus dots, over the casing
+    # layer but still before every label box drawn in pass 2, so boxes
+    # sit on top of any leader that passes beneath them.
+    for name, anchor_px, label_px, box_rect, text_bbox, leader_end in geometry:
+        _draw_leader(draw, anchor_px, leader_end, line_color, line_width)
+
+        ax_px, ay_px = anchor_px
+        draw.ellipse(
+            [ax_px - dot_radius, ay_px - dot_radius,
+             ax_px + dot_radius, ay_px + dot_radius],
+            fill=TERMINUS_DOT_COLOR,
+        )
+
+    # Pass 2: ALL label boxes + text, painted over the leader layer.
+    for name, anchor_px, label_px, box_rect, text_bbox, leader_end in geometry:
+        draw.rectangle(
+            list(box_rect),
+            fill=box_fill,
+            outline=box_border,
+            width=box_border_width,
+        )
+
+        # Centre text within the box, accounting for textbbox's own offset.
+        lx_px, ly_px = label_px
+        text_w = text_bbox[2] - text_bbox[0]
+        text_h = text_bbox[3] - text_bbox[1]
+        text_x = lx_px - text_w / 2 - text_bbox[0]
+        text_y = ly_px - text_h / 2 - text_bbox[1]
+        draw.text((text_x, text_y), name, font=font, fill=text_color)
+
+    os.makedirs(os.path.dirname(out_path) or '.', exist_ok=True)
+    img.save(out_path, format='PNG')
+
+    return out_path

--- a/plugins/jack-tar-deckhand/tests/test_annotate_figure.py
+++ b/plugins/jack-tar-deckhand/tests/test_annotate_figure.py
@@ -1,0 +1,614 @@
+"""Tests for the annotation-overlay module (feature #142).
+
+Covers: anchor payload validation, deterministic auto-placement,
+collision resolution, band selection, end-to-end drawing, explicit
+label_pos override, and missing-file handling. All images are
+synthesized in tmp_path — none are committed to the repo.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from PIL import Image, ImageDraw
+
+PLUGIN_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+from src.annotate_figure import (  # noqa: E402
+    DEFAULT_MARGIN_BAND,
+    LABEL_BOX_PADDING,
+    LEADER_LINE_WIDTH,
+    annotate,
+    place_labels,
+    validate_anchors,
+    _load_font,
+    _segment_box_entry,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_image(tmp_path, size=(800, 600), color=(30, 30, 30)):
+    """Create a synthetic solid-colour PIL image on disk and return its path."""
+    img = Image.new('RGB', size, color)
+    path = tmp_path / 'source.png'
+    img.save(path)
+    return str(path)
+
+
+def _box_for(label_pos_norm, image_size, text, font_size=26, padding=LABEL_BOX_PADDING):
+    """Independently recompute a label's box rect the same way annotate() does.
+
+    Used by tests to assert non-overlap without reaching into annotate()'s
+    internals — this mirrors the textbbox-based sizing logic in the module.
+    """
+    width, height = image_size
+    draw = ImageDraw.Draw(Image.new('RGB', image_size))
+    font = _load_font(font_size)
+    bbox = draw.textbbox((0, 0), text, font=font)
+    text_w = bbox[2] - bbox[0]
+    text_h = bbox[3] - bbox[1]
+
+    lx = label_pos_norm[0] * width
+    ly = label_pos_norm[1] * height
+    return (
+        lx - text_w / 2 - padding,
+        ly - text_h / 2 - padding,
+        lx + text_w / 2 + padding,
+        ly + text_h / 2 + padding,
+    )
+
+
+def _boxes_intersect(a, b):
+    return not (a[2] <= b[0] or b[2] <= a[0] or a[3] <= b[1] or b[3] <= a[1])
+
+
+def _segment_intersects_rect(p0, p1, rect):
+    """Liang-Barsky clip: does the segment p0->p1 pass through the rect?"""
+    x0, y0 = p0
+    x1, y1 = p1
+    dx, dy = x1 - x0, y1 - y0
+    t_min, t_max = 0.0, 1.0
+    for p, q in ((-dx, x0 - rect[0]), (dx, rect[2] - x0),
+                 (-dy, y0 - rect[1]), (dy, rect[3] - y0)):
+        if p == 0:
+            if q < 0:
+                return False  # parallel and outside this boundary
+        else:
+            r = q / p
+            if p < 0:
+                t_min = max(t_min, r)
+            else:
+                t_max = min(t_max, r)
+    return t_min <= t_max
+
+
+def _leader_segments_and_boxes(anchors, image_size):
+    """Mirror annotate()'s geometry: placements, box rects, leader segments."""
+    placements = place_labels(anchors, image_size)
+    width, height = image_size
+    boxes = {}
+    leaders = {}
+    for name, spec in placements.items():
+        anchor_px = (spec['anchor'][0] * width, spec['anchor'][1] * height)
+        label_px = (spec['label_pos'][0] * width, spec['label_pos'][1] * height)
+        box = _box_for(spec['label_pos'], image_size, name)
+        boxes[name] = box
+        leaders[name] = (anchor_px, _segment_box_entry(anchor_px, label_px, box))
+    return leaders, boxes
+
+
+def _assert_no_leader_crosses_other_box(anchors, image_size):
+    leaders, boxes = _leader_segments_and_boxes(anchors, image_size)
+    for leader_name, (p0, p1) in leaders.items():
+        for box_name, rect in boxes.items():
+            if box_name == leader_name:
+                continue
+            assert not _segment_intersects_rect(p0, p1, rect), (
+                f"Leader for '{leader_name}' passes through '{box_name}' label box"
+            )
+
+
+# ---------------------------------------------------------------------------
+# validate_anchors — valid payloads
+# ---------------------------------------------------------------------------
+
+def test_validate_anchors_valid_payload_passes():
+    payload = {"anchors": {"Bow": [0.1, 0.2], "Stern": [0.9, 0.8]}}
+    result = validate_anchors(payload)
+    assert result == payload
+
+
+def test_validate_anchors_valid_payload_with_extra_keys_passthrough():
+    payload = {"anchors": {"Bow": [0.1, 0.2]}, "model": "vision-check"}
+    result = validate_anchors(payload)
+    assert result["model"] == "vision-check"
+
+
+def test_validate_anchors_accepts_integer_coordinates():
+    # 0 and 1 are valid boundary values, and int is a valid numeric type.
+    payload = {"anchors": {"Corner": [0, 1]}}
+    result = validate_anchors(payload)
+    assert result["anchors"]["Corner"] == [0, 1]
+
+
+# ---------------------------------------------------------------------------
+# validate_anchors — invalid payloads
+# ---------------------------------------------------------------------------
+
+def test_validate_anchors_rejects_non_dict_payload():
+    with pytest.raises(ValueError, match='must be a dict'):
+        validate_anchors(['not', 'a', 'dict'])
+
+
+def test_validate_anchors_rejects_missing_anchors_key():
+    with pytest.raises(ValueError, match="missing required 'anchors' key"):
+        validate_anchors({"other": {}})
+
+
+def test_validate_anchors_rejects_non_dict_anchors_value():
+    with pytest.raises(ValueError, match="'anchors' must be a dict"):
+        validate_anchors({"anchors": [["Bow", 0.1, 0.2]]})
+
+
+def test_validate_anchors_rejects_empty_anchors_dict():
+    with pytest.raises(ValueError, match="'anchors' dict is empty"):
+        validate_anchors({"anchors": {}})
+
+
+def test_validate_anchors_rejects_empty_label_name():
+    with pytest.raises(ValueError, match='non-empty string'):
+        validate_anchors({"anchors": {"": [0.1, 0.2]}})
+
+
+def test_validate_anchors_rejects_whitespace_only_label_name():
+    with pytest.raises(ValueError, match='non-empty string'):
+        validate_anchors({"anchors": {"   ": [0.1, 0.2]}})
+
+
+def test_validate_anchors_rejects_duplicate_label_after_normalization():
+    # Distinct dict keys that normalize (strip) to the same label name.
+    payload = {"anchors": {"Bow": [0.1, 0.2], " Bow ": [0.3, 0.4]}}
+    with pytest.raises(ValueError, match='Duplicate anchor label'):
+        validate_anchors(payload)
+
+
+def test_validate_anchors_rejects_coordinate_not_two_elements():
+    with pytest.raises(ValueError, match='2-element'):
+        validate_anchors({"anchors": {"Bow": [0.1, 0.2, 0.3]}})
+
+
+def test_validate_anchors_rejects_non_numeric_coordinate():
+    with pytest.raises(ValueError, match='must be a number'):
+        validate_anchors({"anchors": {"Bow": ["x", 0.2]}})
+
+
+def test_validate_anchors_rejects_boolean_coordinate():
+    # bool is a numbers.Number subclass in Python; explicitly rejected.
+    with pytest.raises(ValueError, match='must be a number'):
+        validate_anchors({"anchors": {"Bow": [True, 0.2]}})
+
+
+def test_validate_anchors_rejects_out_of_range_low():
+    with pytest.raises(ValueError, match='normalized in \\[0, 1\\]'):
+        validate_anchors({"anchors": {"Bow": [-0.1, 0.2]}})
+
+
+def test_validate_anchors_rejects_out_of_range_high():
+    with pytest.raises(ValueError, match='normalized in \\[0, 1\\]'):
+        validate_anchors({"anchors": {"Bow": [0.1, 1.5]}})
+
+
+def test_validate_anchors_error_message_names_the_offending_label():
+    with pytest.raises(ValueError, match="'Mast'"):
+        validate_anchors({"anchors": {"Mast": [2.0, 0.2]}})
+
+
+# ---------------------------------------------------------------------------
+# place_labels — determinism
+# ---------------------------------------------------------------------------
+
+def test_place_labels_deterministic_same_input_same_output():
+    anchors = {"Bow": [0.05, 0.5], "Stern": [0.95, 0.5], "Mast": [0.5, 0.05]}
+    result1 = place_labels(anchors, (800, 600))
+    result2 = place_labels(anchors, (800, 600))
+    assert result1 == result2
+
+
+def test_place_labels_deterministic_across_dict_ordering():
+    # Same anchors, different insertion order -> same placement result.
+    anchors_a = {"Bow": [0.05, 0.5], "Stern": [0.95, 0.5]}
+    anchors_b = {"Stern": [0.95, 0.5], "Bow": [0.05, 0.5]}
+    assert place_labels(anchors_a, (800, 600)) == place_labels(anchors_b, (800, 600))
+
+
+def test_place_labels_rejects_non_positive_image_size():
+    with pytest.raises(ValueError):
+        place_labels({"Bow": [0.1, 0.1]}, (0, 600))
+
+
+# ---------------------------------------------------------------------------
+# place_labels — band selection
+# ---------------------------------------------------------------------------
+
+def test_place_labels_anchor_near_top_edge_goes_to_top_band():
+    anchors = {"Mast": [0.5, 0.02]}
+    result = place_labels(anchors, (800, 600))
+    label_pos = result["Mast"]["label_pos"]
+    # Top band: label pushed to the vertical midpoint of the top margin strip.
+    assert label_pos[1] == pytest.approx(DEFAULT_MARGIN_BAND / 2)
+    assert label_pos[0] == pytest.approx(0.5)
+
+
+def test_place_labels_anchor_near_bottom_edge_goes_to_bottom_band():
+    anchors = {"Keel": [0.5, 0.98]}
+    result = place_labels(anchors, (800, 600))
+    label_pos = result["Keel"]["label_pos"]
+    assert label_pos[1] == pytest.approx(1.0 - DEFAULT_MARGIN_BAND / 2)
+
+
+def test_place_labels_anchor_near_left_edge_goes_to_left_band():
+    anchors = {"Bow": [0.02, 0.5]}
+    result = place_labels(anchors, (800, 600))
+    label_pos = result["Bow"]["label_pos"]
+    assert label_pos[0] == pytest.approx(DEFAULT_MARGIN_BAND / 2)
+
+
+def test_place_labels_anchor_near_right_edge_goes_to_right_band():
+    anchors = {"Stern": [0.98, 0.5]}
+    result = place_labels(anchors, (800, 600))
+    label_pos = result["Stern"]["label_pos"]
+    assert label_pos[0] == pytest.approx(1.0 - DEFAULT_MARGIN_BAND / 2)
+
+
+def test_place_labels_anchor_at_dead_centre_picks_a_single_band():
+    # Equidistant from all four edges — nearest_band must resolve to exactly
+    # one band deterministically (min() with a dict picks the first tie).
+    anchors = {"Middle": [0.5, 0.5]}
+    result = place_labels(anchors, (800, 600))
+    assert "label_pos" in result["Middle"]
+
+
+# ---------------------------------------------------------------------------
+# place_labels — collision handling
+# ---------------------------------------------------------------------------
+
+def test_place_labels_close_anchors_get_non_overlapping_boxes():
+    # Two anchors close together on the left edge -> same band -> must stack.
+    anchors = {"Bow": [0.02, 0.40], "BowLine": [0.02, 0.42]}
+    image_size = (800, 600)
+    result = place_labels(anchors, image_size)
+
+    box_bow = _box_for(result["Bow"]["label_pos"], image_size, "Bow")
+    box_bowline = _box_for(result["BowLine"]["label_pos"], image_size, "BowLine")
+
+    assert not _boxes_intersect(box_bow, box_bowline)
+    # And they must actually be different positions (proof stacking happened).
+    assert result["Bow"]["label_pos"] != result["BowLine"]["label_pos"]
+
+
+def test_place_labels_three_close_anchors_all_pairwise_non_overlapping():
+    anchors = {
+        "Mast1": [0.30, 0.02],
+        "Mast2": [0.50, 0.02],
+        "Mast3": [0.70, 0.02],
+    }
+    image_size = (1000, 700)
+    result = place_labels(anchors, image_size)
+
+    boxes = {
+        name: _box_for(result[name]["label_pos"], image_size, name)
+        for name in anchors
+    }
+    names = list(boxes)
+    for i in range(len(names)):
+        for j in range(i + 1, len(names)):
+            assert not _boxes_intersect(boxes[names[i]], boxes[names[j]]), (
+                f'{names[i]} and {names[j]} label boxes overlap'
+            )
+
+
+# ---------------------------------------------------------------------------
+# place_labels — perpendicular stagger + leader/box geometry
+# ---------------------------------------------------------------------------
+
+def test_place_labels_stacked_labels_stagger_along_perpendicular_axis():
+    # Three labels in the top band: stacked along x AND staggered along y
+    # (alternating offsets) so their y positions are not all identical.
+    anchors = {
+        "Mast1": [0.30, 0.02],
+        "Mast2": [0.50, 0.02],
+        "Mast3": [0.70, 0.02],
+    }
+    result = place_labels(anchors, (1000, 700))
+    ys = {result[name]["label_pos"][1] for name in anchors}
+    assert len(ys) >= 2, 'Stacked labels must alternate perpendicular offsets'
+    # All staggered positions must remain inside the top band strip.
+    assert all(0.0 <= y <= DEFAULT_MARGIN_BAND for y in ys)
+
+
+def test_segment_box_entry_terminates_on_box_edge():
+    # Horizontal approach from the left: entry is on the box's left edge.
+    entry = _segment_box_entry((0, 50), (50, 50), (40, 40, 60, 60))
+    assert entry == (40, 50)
+
+
+def test_segment_box_entry_anchor_inside_box_is_zero_length():
+    # Anchor already inside the box -> leader collapses to the anchor.
+    entry = _segment_box_entry((45, 50), (50, 50), (40, 40, 60, 60))
+    assert entry == (45, 50)
+
+
+def test_no_leader_intersects_other_label_box_top_band():
+    # Clustered anchors near the top edge fan out to spread slots — no
+    # leader may pass through a sibling label's box.
+    anchors = {
+        "Foremast": [0.45, 0.03],
+        "Mainmast": [0.50, 0.03],
+        "Mizzenmast": [0.55, 0.03],
+    }
+    _assert_no_leader_crosses_other_box(anchors, (1000, 700))
+
+
+def test_no_leader_intersects_other_label_box_left_band():
+    anchors = {
+        "Bow": [0.02, 0.40],
+        "BowLine": [0.02, 0.42],
+        "Keel": [0.02, 0.44],
+    }
+    _assert_no_leader_crosses_other_box(anchors, (800, 600))
+
+
+def test_default_leader_line_width_is_3():
+    assert LEADER_LINE_WIDTH == 3
+
+
+# ---------------------------------------------------------------------------
+# annotate — end to end
+# ---------------------------------------------------------------------------
+
+def test_annotate_end_to_end_creates_output_file(tmp_path):
+    src = _make_image(tmp_path)
+    out = tmp_path / 'annotated.png'
+
+    result_path = annotate(src, {"Bow": [0.1, 0.5]}, str(out))
+
+    assert result_path == str(out)
+    assert out.exists()
+
+
+def test_annotate_output_differs_from_input(tmp_path):
+    src = _make_image(tmp_path, color=(30, 30, 30))
+    out = tmp_path / 'annotated.png'
+    annotate(src, {"Bow": [0.1, 0.5]}, str(out))
+
+    with Image.open(src) as src_img, Image.open(out) as out_img:
+        assert src_img.tobytes() != out_img.convert('RGB').tobytes()
+
+
+def test_annotate_label_box_location_is_white_ish(tmp_path):
+    src = _make_image(tmp_path, size=(800, 600), color=(30, 30, 30))
+    out = tmp_path / 'annotated.png'
+
+    # Explicit override so the label box position is exactly known.
+    labels = {"Bow": {"anchor": [0.1, 0.5], "label_pos": [0.5, 0.5]}}
+    annotate(src, labels, str(out))
+
+    with Image.open(out) as img:
+        img = img.convert('RGB')
+        width, height = img.size
+        # Sample near the top-left corner of the label box (inside the
+        # padding, away from the glyph strokes and the border line).
+        box = _box_for([0.5, 0.5], (width, height), 'Bow')
+        sample_x = int(box[0] + 3)
+        sample_y = int(box[1] + 3)
+        pixel = img.getpixel((sample_x, sample_y))
+
+    assert all(channel > 230 for channel in pixel), f'Expected white-ish pixel, got {pixel}'
+
+
+def test_annotate_explicit_label_pos_override_respected(tmp_path):
+    src = _make_image(tmp_path, size=(800, 600), color=(30, 30, 30))
+    out = tmp_path / 'annotated.png'
+
+    # An explicit label_pos far from where auto-placement (nearest margin
+    # band) would ever put it -- if the override is honoured, the box shows
+    # up dead centre; if auto-placement ran instead, it would be pushed to
+    # a margin band near the anchor at (0.1, 0.5), i.e. the left edge.
+    explicit_pos = [0.5, 0.5]
+    labels = {"Bow": {"anchor": [0.1, 0.5], "label_pos": explicit_pos}}
+    annotate(src, labels, str(out))
+
+    with Image.open(out) as img:
+        img = img.convert('RGB')
+        width, height = img.size
+        box = _box_for(explicit_pos, (width, height), 'Bow')
+        centre_pixel = img.getpixel((int((box[0] + box[2]) / 2), int(box[1] + 3)))
+        # Left-margin-band placement would leave the image centre untouched
+        # (still the solid source colour); the override must have painted
+        # a white-ish box there instead.
+        assert all(channel > 230 for channel in centre_pixel)
+
+
+def test_annotate_mixed_auto_and_explicit_labels(tmp_path):
+    src = _make_image(tmp_path)
+    out = tmp_path / 'annotated.png'
+
+    labels = {
+        "Bow": [0.05, 0.5],  # auto placement
+        "Stern": {"anchor": [0.95, 0.5], "label_pos": [0.5, 0.5]},  # explicit
+    }
+    result_path = annotate(src, labels, str(out))
+    assert Path(result_path).exists()
+
+
+def test_annotate_raises_on_missing_image(tmp_path):
+    missing = tmp_path / 'does-not-exist.png'
+    out = tmp_path / 'annotated.png'
+    with pytest.raises(FileNotFoundError, match='Image not found'):
+        annotate(str(missing), {"Bow": [0.1, 0.5]}, str(out))
+
+
+def test_annotate_raises_on_empty_labels(tmp_path):
+    src = _make_image(tmp_path)
+    out = tmp_path / 'annotated.png'
+    with pytest.raises(ValueError, match='non-empty dict'):
+        annotate(src, {}, str(out))
+
+
+def test_annotate_raises_on_malformed_label_spec(tmp_path):
+    src = _make_image(tmp_path)
+    out = tmp_path / 'annotated.png'
+    with pytest.raises(ValueError, match='auto placement.*explicit override'):
+        annotate(src, {"Bow": "not a valid spec"}, str(out))
+
+
+def test_annotate_raises_on_incomplete_explicit_spec(tmp_path):
+    src = _make_image(tmp_path)
+    out = tmp_path / 'annotated.png'
+    with pytest.raises(ValueError, match="'anchor' and 'label_pos'"):
+        annotate(src, {"Bow": {"anchor": [0.1, 0.5]}}, str(out))
+
+
+def test_annotate_boxes_drawn_over_leader_lines(tmp_path):
+    # X's leader runs horizontally across the image centre and passes
+    # beneath Y's box. Because all leaders are drawn before any boxes,
+    # Y's box must paint OVER the leader — the sampled pixel inside Y's
+    # box padding (on the leader's path) must be white, not line-dark.
+    src = _make_image(tmp_path, size=(800, 600), color=(30, 30, 30))
+    out = tmp_path / 'annotated.png'
+    labels = {
+        "X": {"anchor": [0.05, 0.5], "label_pos": [0.9, 0.5]},
+        "Y": {"anchor": [0.5, 0.1], "label_pos": [0.5, 0.5]},
+    }
+    annotate(src, labels, str(out))
+
+    with Image.open(out) as img:
+        img = img.convert('RGB')
+        width, height = img.size
+        y_box = _box_for([0.5, 0.5], (width, height), 'Y')
+        # Sample in Y's left padding strip at the leader's row (y = centre).
+        sample = img.getpixel((int(y_box[0]) + 4, height // 2))
+
+    assert all(channel > 230 for channel in sample), (
+        f'Expected white-ish pixel (box over leader), got {sample}'
+    )
+
+
+def test_annotate_leader_stops_at_own_box_edge(tmp_path):
+    # A horizontal leader approaching its own box from the left must stop
+    # at the box's left edge: pixels INSIDE the box on the approach row
+    # (past the border, before the glyph) stay white; a pixel just OUTSIDE
+    # the box on the same row is line-dark.
+    src = _make_image(tmp_path, size=(800, 600), color=(200, 200, 200))
+    out = tmp_path / 'annotated.png'
+    labels = {"Bow": {"anchor": [0.1, 0.5], "label_pos": [0.6, 0.5]}}
+    annotate(src, labels, str(out))
+
+    with Image.open(out) as img:
+        img = img.convert('RGB')
+        width, height = img.size
+        box = _box_for([0.6, 0.5], (width, height), 'Bow')
+        row = height // 2
+        inside = img.getpixel((int(box[0]) + 4, row))
+        outside = img.getpixel((int(box[0]) - 6, row))
+
+    assert all(channel > 230 for channel in inside), (
+        f'Leader drawn into box interior: {inside}'
+    )
+    assert all(channel < 100 for channel in outside), (
+        f'Expected leader line just outside the box, got {outside}'
+    )
+
+
+def test_annotate_leader_casing_visible_on_black_background(tmp_path):
+    # On a solid-black image, the dark leader core must be flanked by
+    # white casing rows so the line reads against the dark region.
+    src = _make_image(tmp_path, size=(800, 600), color=(0, 0, 0))
+    out = tmp_path / 'annotated.png'
+    labels = {"Bow": {"anchor": [0.1, 0.5], "label_pos": [0.7, 0.5]}}
+    annotate(src, labels, str(out))
+
+    with Image.open(out) as img:
+        img = img.convert('RGB')
+        # Horizontal leader along y=300 (rows 299-302 core, 297-304 casing).
+        mid_x = 300  # well inside the leader's run, away from dot and box
+        core = img.getpixel((mid_x, 300))
+        casing_above = img.getpixel((mid_x, 298))
+        casing_below = img.getpixel((mid_x, 303))
+        background = img.getpixel((mid_x, 290))
+
+    assert all(c < 100 for c in core), f'Expected dark leader core, got {core}'
+    assert all(c > 230 for c in casing_above), (
+        f'Expected white casing above the leader, got {casing_above}'
+    )
+    assert all(c > 230 for c in casing_below), (
+        f'Expected white casing below the leader, got {casing_below}'
+    )
+    assert all(c < 50 for c in background), (
+        f'Casing must not flood beyond its width, got {background}'
+    )
+
+
+def test_annotate_terminus_dot_has_casing_ring_on_black(tmp_path):
+    # The terminus dot must sit inside a white ring so it reads on dark
+    # regions: dark at the dot centre, white in the ring annulus, black
+    # background beyond the ring.
+    src = _make_image(tmp_path, size=(800, 600), color=(0, 0, 0))
+    out = tmp_path / 'annotated.png'
+    labels = {"Bow": {"anchor": [0.1, 0.5], "label_pos": [0.7, 0.5]}}
+    annotate(src, labels, str(out))
+
+    with Image.open(out) as img:
+        img = img.convert('RGB')
+        # Anchor at (80, 300): dot r=4 dark, ring r=7 white.
+        dot_centre = img.getpixel((80, 300))
+        ring = img.getpixel((80, 294))        # distance 6: in ring, above line casing
+        beyond = img.getpixel((80, 290))      # distance 10: untouched background
+
+    assert all(c < 100 for c in dot_centre), f'Expected dark dot, got {dot_centre}'
+    assert all(c > 230 for c in ring), f'Expected white casing ring, got {ring}'
+    assert all(c < 50 for c in beyond), f'Expected untouched background, got {beyond}'
+
+
+def test_annotate_casing_can_be_disabled(tmp_path):
+    src = _make_image(tmp_path, size=(800, 600), color=(0, 0, 0))
+    out = tmp_path / 'annotated.png'
+    labels = {"Bow": {"anchor": [0.1, 0.5], "label_pos": [0.7, 0.5]}}
+    annotate(src, labels, str(out), casing_width=0)
+
+    with Image.open(out) as img:
+        img = img.convert('RGB')
+        core = img.getpixel((300, 300))
+        would_be_casing = img.getpixel((300, 298))
+
+    assert all(c < 100 for c in core), f'Expected dark leader core, got {core}'
+    assert all(c < 50 for c in would_be_casing), (
+        f'Casing disabled — expected black background, got {would_be_casing}'
+    )
+
+
+def test_annotate_custom_casing_color_respected(tmp_path):
+    src = _make_image(tmp_path, size=(800, 600), color=(0, 0, 0))
+    out = tmp_path / 'annotated.png'
+    labels = {"Bow": {"anchor": [0.1, 0.5], "label_pos": [0.7, 0.5]}}
+    annotate(src, labels, str(out), casing_color=(255, 255, 0))
+
+    with Image.open(out) as img:
+        img = img.convert('RGB')
+        casing = img.getpixel((300, 298))
+
+    assert casing[0] > 230 and casing[1] > 230 and casing[2] < 50, (
+        f'Expected yellow casing, got {casing}'
+    )
+
+
+def test_annotate_creates_output_directory_if_missing(tmp_path):
+    src = _make_image(tmp_path)
+    out = tmp_path / 'nested' / 'dir' / 'annotated.png'
+    annotate(src, {"Bow": [0.1, 0.5]}, str(out))
+    assert out.exists()

--- a/retrospectives/142-annotate-figure.md
+++ b/retrospectives/142-annotate-figure.md
@@ -1,0 +1,6 @@
+# Retrospective: Feature #142 — annotate-figure
+
+**Branch**: `feat/annotate-figure`
+**Date**: 2026-07-17
+
+_To be completed at feature close._

--- a/retrospectives/142-annotate-figure.md
+++ b/retrospectives/142-annotate-figure.md
@@ -3,4 +3,50 @@
 **Branch**: `feat/annotate-figure`
 **Date**: 2026-07-17
 
-_To be completed at feature close._
+## What Went Well
+
+- **PoC-first de-risking**: a 30-minute proof (unlabeled render + vision
+  anchors + PIL overlay, blind 10/10 on the B5 rubric) justified a
+  compressed pipeline — no separate Opus design or adversarial design
+  review — and the bet held; implementation surprises were all in
+  polish, not architecture.
+- **The E2E iteration loop worked as designed**: v2 caught a broken
+  anchor + leader-through-box (reviewer), v3's residual defect was
+  caught by the OPERATOR — the reviewer misread an invisible
+  dark-on-dark leader as absent. Casing fixed the class, and the skill
+  now tells reviewers about it.
+- Geometric tests (Liang-Barsky no-leader-crosses-sibling-box) caught a
+  second placement defect during development that visual inspection had
+  missed.
+
+## What Could Improve
+
+- The v2 review scored a "correct" Rudder that the operator immediately
+  saw was wrong — anchor verification needs the zoomed-crop discipline
+  the re-query agent used, not whole-image glances. Folded into the
+  skill's review prompt; a stricter contract (evidence clause per
+  anchor) is a v2 candidate.
+- Compressed pipeline means no adversarial pass over the SKILL.md
+  itself; the standard reviewer pass at PR time covers it.
+
+## Lessons Learned
+
+1. **Reviewer verdicts on visibility are contrast-bounded** — "absent"
+   and "invisible against this background" are indistinguishable to a
+   casual pass. Design artifacts for contrast (casing) rather than
+   training reviewers to squint.
+2. Perfect text by construction re-scopes review budget entirely onto
+   spatial correctness — cheaper AND stricter than reviewing both.
+3. Vision anchor accuracy is the new quality bottleneck; evidence-clause
+   contracts and zoomed verification are where future effort pays.
+
+## Changes Made
+
+- `plugins/jack-tar-deckhand/src/annotate_figure.py` (+48 tests)
+- `plugins/jack-tar-deckhand/skills/annotate-figure/SKILL.md`
+- deckhand 1.9.0 + marketplace; proposal doc; this retrospective
+
+## Metrics
+
+- **Files created**: 5 · **Files modified**: 3 · **Tests added**: 48
+- E2E iterations: 4 renders (v1 PoC hand-placed → v4 cased) at $0


### PR DESCRIPTION
Implements #142 v1: render a diagram-class image WITHOUT labels (or take an operator-supplied EXTERNAL image), obtain anchor coordinates via a structured vision pass, then draw leader lines + typeset labels programmatically — **text is perfect by construction**; only pointer placement is reviewed.

Evidence: PoC scored a blind **10/10 on the benchmark's B5 rubric at $0** (cloud TECH ceiling was 8.7, PR #138). The E2E iteration loop hardened the module: geometric no-leader-crossing guarantees, leaders terminating at their own box edge, and white cartographic **casing** after the operator caught dark-on-dark leaders being invisible (which a reviewer had misread as a missing leader — F12 in action).

- `annotate_figure.py` + 48 tests (deterministic placement, collision stagger, Liang-Barsky intersection tests, black-background casing pixel tests)
- `/jack-tar-deckhand:annotate-figure` skill (external-image path, label-stripping prompt transform, anchor contract, pointers-only review loop)
- deckhand 1.9.0; proposal `docs/feature-proposals/142-annotate-figure.md`
- v2 (PPTX-native text boxes, strategy-map auto-routing, blank-zone variant) stays tracked in #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)